### PR TITLE
Include twilio booking number in confirmation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby IO.read('.ruby-version').strip
 
+gem 'booking_locations'
 gem 'gds-sso'
 gem 'rails', '4.2.6'
 gem 'pg', '~> 0.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
     ast (2.2.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    booking_locations (0.2.1)
+      activesupport (>= 4, < 5.1)
     builder (3.2.2)
     byebug (8.2.4)
     coderay (1.1.1)
@@ -218,6 +220,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  booking_locations
   coffee-rails (~> 4.1.0)
   factory_girl_rails
   gds-sso

--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -9,7 +9,7 @@ module Api
         booking_request = BookingRequest.new(booking_request_params)
 
         if booking_request.save
-          BookingRequests.customer(booking_request).deliver_later
+          CustomerConfirmationJob.perform_later(booking_request)
           head :created
         else
           render_errors(booking_request)

--- a/app/jobs/customer_confirmation_job.rb
+++ b/app/jobs/customer_confirmation_job.rb
@@ -1,0 +1,9 @@
+class CustomerConfirmationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(booking_request)
+    booking_location = BookingLocations.find(booking_request.location_id)
+
+    BookingRequests.customer(booking_request, booking_location).deliver_now
+  end
+end

--- a/app/mailers/booking_requests.rb
+++ b/app/mailers/booking_requests.rb
@@ -1,6 +1,7 @@
 class BookingRequests < ApplicationMailer
-  def customer(booking_request)
-    @booking_request = booking_request
+  def customer(booking_request, booking_location)
+    @booking_request  = booking_request
+    @booking_location = booking_location
 
     mail to: booking_request.email, subject: 'Your Pension Wise Appointment Request'
   end

--- a/app/views/booking_requests/customer.html.erb
+++ b/app/views/booking_requests/customer.html.erb
@@ -35,5 +35,5 @@ class="emphasize" style="font-size: 24px;"><%=
 
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
 0;font-size: 16px;line-height: 1.315789474;">To cancel or change your
-appointment, or if any of the information above isn't correct, call 0800 138
-3944 or reply to this email.</p>
+appointment, or if any of the information above isn't correct, call
+ <%= @booking_location.online_booking_twilio_number %> or reply to this email.</p>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Process jobs inline
+  config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/booking_locations.rb
+++ b/config/initializers/booking_locations.rb
@@ -1,0 +1,5 @@
+unless Rails.env.production?
+  require 'booking_locations/stub_api'
+
+  BookingLocations.api = BookingLocations::StubApi.new
+end

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 
 RSpec.describe BookingRequests do
   describe 'Customer notification' do
+    let(:booking_location) do
+      instance_double(BookingLocations::Location, online_booking_twilio_number: '+441234567890')
+    end
     let(:booking_request) { create(:booking_request) }
 
-    subject(:mail) { BookingRequests.customer(booking_request) }
+    subject(:mail) { BookingRequests.customer(booking_request, booking_location) }
 
     it 'renders the headers' do
       expect(mail.subject).to eq('Your Pension Wise Appointment Request')
@@ -20,6 +23,10 @@ RSpec.describe BookingRequests do
         expect(body).to include(booking_request.phone)
         expect(body).to include(booking_request.reference)
         expect(body).to include(booking_request.memorable_word)
+      end
+
+      it 'includes the booking location particulars' do
+        expect(body).to include(booking_location.online_booking_twilio_number)
       end
 
       it 'includes the three selected slots' do


### PR DESCRIPTION
Includes the booking location specific contact number when emailing the
customer with their booking request confirmation.

I moved this into a background job that runs inline for the time being.
The thinking here was that both the locations API call and email
delivery are better done out-of-band. It felt wrong to make the
locations API call in the mailer itself, too.