### PR TITLE
Drop errant RSpec task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,9 +10,3 @@ begin
   RuboCop::RakeTask.new(:default)
 rescue LoadError
 end
-
-begin
-  require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:default)
-rescue LoadError
-end


### PR DESCRIPTION
This was causing RSpec to run twice when running `bundle exex rake`