### PR TITLE
Store booking location ID from API payload

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -24,6 +24,7 @@ module Api
 
       def booking_request_params # rubocop:disable Metrics/MethodLength
         params.require(:booking_request).permit(
+          :booking_location_id,
           :location_id,
           :name,
           :email,

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -6,6 +6,7 @@ class BookingRequest < ActiveRecord::Base
   accepts_nested_attributes_for :slots, limit: 3, allow_destroy: false
 
   validates :name, presence: true
+  validates :booking_location_id, presence: true
   validates :location_id, presence: true
   validates :email, presence: true
   validates :phone, presence: true

--- a/db/migrate/20160714093802_add_booking_location_id_to_booking_requests.rb
+++ b/db/migrate/20160714093802_add_booking_location_id_to_booking_requests.rb
@@ -1,0 +1,5 @@
+class AddBookingLocationIdToBookingRequests < ActiveRecord::Migration
+  def change
+    add_column :booking_requests, :booking_location_id, :string, null: false, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160623172311) do
+ActiveRecord::Schema.define(version: 20160714093802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20160623172311) do
     t.boolean  "defined_contribution_pot",   null: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+    t.string   "booking_location_id",        null: false
   end
 
   create_table "slots", force: :cascade do |t|

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -2,6 +2,7 @@ require 'securerandom'
 
 FactoryGirl.define do
   factory :booking_request do
+    booking_location_id { SecureRandom.uuid }
     location_id { SecureRandom.uuid }
     name 'Morty Sanchez'
     email 'morty@example.com'

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe BookingRequest do
       expect(build(:booking_request)).to be_valid
     end
 
+    it 'requires a booking_location_id' do
+      expect(build(:booking_request, booking_location_id: '')).to_not be_valid
+    end
+
     it 'requires a location_id' do
       expect(build(:booking_request, location_id: '')).to_not be_valid
     end

--- a/spec/requests/create_a_booking_request_spec.rb
+++ b/spec/requests/create_a_booking_request_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
   def when_a_valid_booking_request_is_made
     valid_payload = {
       'booking_request' => {
+        'booking_location_id' => 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
         'location_id' => 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
         'name' => 'Morty Sanchez',
         'email' => 'morty@example.com',
@@ -63,6 +64,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
     @booking = BookingRequest.last
 
     expect(@booking).to have_attributes(
+      booking_location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
       location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
       name: 'Morty Sanchez',
       email: 'morty@example.com',


### PR DESCRIPTION
This means we don't have to perform expensive lookups for the booking
location sub-tree any time we query booking requests for a specific
booking's manager.