### PR TITLE
Remove buildpacks in favour of heroku config

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git
-https://github.com/heroku/heroku-buildpack-ruby.git


### PR DESCRIPTION
It seems the multi-buildpack is deprecated in favour of setting
multiple buildpacks using heroku configuration as below:

```
hurrdurr~/code/planner <bump-locations> # heroku buildpacks:clear --app
staging-planner-pensionwise

Buildpacks cleared.
 ▸    The BUILDPACK_URL config var is still set and will be used for the
      next release
hurrdurr~/code/planner <bump-locations> # heroku buildpacks:add
heroku/nodejs --app staging-planner-pensionwise

Buildpack added. Next release on staging-planner-pensionwise will use heroku/nodejs.
Run git push heroku master to create a new release using this buildpack.
hurrdurr~/code/planner <bump-locations> # heroku buildpacks:add
heroku/ruby --app staging-planner-pensionwise

Buildpack added. Next release on staging-planner-pensionwise will use:
  1. heroku/nodejs
  2. heroku/ruby
```