### PR TITLE
Change confirmation email from address

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'bookings@pensionwise.gov.uk'
+  default from: 'appointments@pensionwise.gov.uk'
   layout 'mailer'
 end

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BookingRequests do
     it 'renders the headers' do
       expect(mail.subject).to eq('Your Pension Wise Appointment Request')
       expect(mail.to).to eq([booking_request.email])
-      expect(mail.from).to eq(['bookings@pensionwise.gov.uk'])
+      expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
     end
 
     describe 'rendering the body' do


### PR DESCRIPTION
It was previously `bookings@` when it should have been `appointments@`
as this address is warmed up and what is configured with our email
  provider.