### PR TITLE
Just permit access to any authenticated users

### DIFF
--- a/app/constraints/authenticated_user.rb
+++ b/app/constraints/authenticated_user.rb
@@ -1,0 +1,6 @@
+class AuthenticatedUser
+  def matches?(request)
+    warden = request.tnv['warden']
+    warden&.authenticated? && !warden.user.remotely_signed_out?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   resources :booking_requests, only: :index
 
@@ -9,13 +11,5 @@ Rails.application.routes.draw do
     end
   end
 
-  if Rails.env.production? || Rails.env.staging?
-    require 'sidekiq/web'
-
-    Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-      username == ENV.fetch('SIDEKIQ_WEB_USERNAME') && password == ENV.fetch('SIDEKIQ_WEB_PASSWORD')
-    end
-
-    mount Sidekiq::Web, at: '/sidekiq'
-  end
+  mount Sidekiq::Web, at: '/sidekiq', constraint: AuthenticatedUser.new
 end


### PR DESCRIPTION
We were previously authenticating via HTTP basic, using the existing
authenticated admin account makes more sense.