### PR TITLE
Ensure fulfilled booking requests are hidden

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -1,7 +1,7 @@
 class BookingRequestsController < ApplicationController
   def index
     @booking_requests = LocationAwareBookingRequests.new(
-      current_user.booking_requests,
+      current_user.unfulfilled_booking_requests,
       booking_location
     ).all
   end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -1,6 +1,8 @@
 class BookingRequest < ActiveRecord::Base
   PERMITTED_AGE_RANGES = %w(50-54 55-plus).freeze
 
+  has_one :appointment
+
   has_many :slots, -> { order(:priority) }
 
   accepts_nested_attributes_for :slots, limit: 3, allow_destroy: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,10 @@ class User < ActiveRecord::Base
            foreign_key: :booking_location_id
 
   alias_attribute :booking_location_id, :organisation_content_id
+
+  def unfulfilled_booking_requests
+    booking_requests
+      .includes(:appointment)
+      .where(appointments: { booking_request_id: nil })
+  end
 end

--- a/spec/features/booking_manager_views_booking_requests_spec.rb
+++ b/spec/features/booking_manager_views_booking_requests_spec.rb
@@ -12,8 +12,11 @@ RSpec.feature 'Viewing Booking Requests' do
   def and_there_are_booking_requests_for_their_location
     create(:hackney_booking_request)
 
-    # this shouldn't be listed
+    # this won't be listed as it's not under Hackney
     create(:booking_request)
+
+    # this won't be listed as it's fulfilled
+    create(:appointment)
   end
 
   def when_they_visit_the_site


### PR DESCRIPTION
Prior to this, when booking requests transitioned into appointments
they were still being displayed on the booking manager's list of
unfulfilled booking requests. Now we hide them once they're fulfilled
so the booking manager can view the list as things that need immediate
attention.