### PR TITLE
Notify booking manager for new booking requests

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -9,7 +9,7 @@ module Api
         booking_request = BookingRequest.new(booking_request_params)
 
         if booking_request.save
-          CustomerConfirmationJob.perform_later(booking_request)
+          send_notifications(booking_request)
           head :created
         else
           render_errors(booking_request)
@@ -17,6 +17,11 @@ module Api
       end
 
       private
+
+      def send_notifications(booking_request)
+        CustomerConfirmationJob.perform_later(booking_request)
+        BookingManagerConfirmationJob.perform_later(booking_request)
+      end
 
       def render_errors(booking_request)
         render json: { errors: booking_request.errors }, status: :unprocessable_entity

--- a/app/jobs/booking_manager_confirmation_job.rb
+++ b/app/jobs/booking_manager_confirmation_job.rb
@@ -1,0 +1,16 @@
+BookingManagersNotFoundError = StandardError
+
+class BookingManagerConfirmationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(booking_request)
+    booking_location = BookingLocations.find(booking_request.location_id)
+    booking_managers = User.where(organisation_content_id: booking_location.id)
+
+    raise BookingManagersNotFoundError unless booking_managers.present?
+
+    booking_managers.each do |booking_manager|
+      BookingRequests.booking_manager(booking_manager).deliver_later
+    end
+  end
+end

--- a/app/mailers/booking_requests.rb
+++ b/app/mailers/booking_requests.rb
@@ -5,4 +5,8 @@ class BookingRequests < ApplicationMailer
 
     mail to: booking_request.email, subject: 'Your Pension Wise Appointment Request'
   end
+
+  def booking_manager(booking_manager)
+    mail to: booking_manager.email, subject: 'Pension Wise Booking Request'
+  end
 end

--- a/app/views/booking_requests/booking_manager.html.erb
+++ b/app/views/booking_requests/booking_manager.html.erb
@@ -1,0 +1,6 @@
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  There is a new booking request that requires your attention.
+</p>
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  <%= link_to 'Go to the planner', root_url %>
+</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,8 @@ module Planner
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # default options for booking manager confirmation
+    config.action_mailer.default_url_options = { host: ENV['APPLICATION_HOST'] }
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,6 +31,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # default options for booking manager confirmation
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
+
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random
 

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -3,18 +3,20 @@ require 'rails_helper'
 
 RSpec.feature 'Fulfiling Booking Requests' do
   scenario 'Bookings Manager fulfils a Booking Request' do
-    travel_to '2016-06-19' do
-      given_the_user_identifies_as_hackneys_booking_manager do
-        and_there_is_an_unfulfilled_booking_request
-        when_the_booking_manager_attempts_to_fulfil
-        then_they_are_shown_the_fulfilment_page
-        and_they_see_the_customer_details
-        and_they_see_the_requested_slots
-        when_they_choose_a_guider
-        and_the_location
-        and_the_time_and_date_of_the_appointment
-        then_the_appointment_is_created
-        and_the_customer_is_notified
+    perform_enqueued_jobs do
+      travel_to '2016-06-19' do
+        given_the_user_identifies_as_hackneys_booking_manager do
+          and_there_is_an_unfulfilled_booking_request
+          when_the_booking_manager_attempts_to_fulfil
+          then_they_are_shown_the_fulfilment_page
+          and_they_see_the_customer_details
+          and_they_see_the_requested_slots
+          when_they_choose_a_guider
+          and_the_location
+          and_the_time_and_date_of_the_appointment
+          then_the_appointment_is_created
+          and_the_customer_is_notified
+        end
       end
     end
   end

--- a/spec/jobs/booking_manager_confirmation_job_spec.rb
+++ b/spec/jobs/booking_manager_confirmation_job_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe BookingManagerConfirmationJob, '#perform' do
+  let(:booking_request)  { double(location_id: 'whelp') }
+  let(:booking_location) { double(id: 'badbeef') }
+
+  before do
+    allow(BookingLocations).to receive(:find).and_return(booking_location)
+  end
+
+  subject { described_class.new.perform(booking_request) }
+
+  context 'when the booking manager(s) cannot be found' do
+    it 'raises an error thus forcing retries' do
+      expect { subject }.to raise_error(BookingManagersNotFoundError)
+    end
+  end
+
+  context 'when booking manager(s) are found' do
+    before { create(:hackney_booking_manager) }
+
+    let(:booking_location) { double(id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
+
+    it 'fans out a notification job for each booking manager' do
+      assert_enqueued_jobs(1) { subject }
+    end
+  end
+end

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -36,4 +36,24 @@ RSpec.describe BookingRequests do
       end
     end
   end
+
+  describe 'Booking Manager Notification' do
+    let(:booking_manager) { build_stubbed(:hackney_booking_manager) }
+
+    subject(:mail) { BookingRequests.booking_manager(booking_manager) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Pension Wise Booking Request')
+      expect(mail.to).to eq([booking_manager.email])
+      expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+    end
+
+    describe 'rendering the body' do
+      let(:body) { subject.body.encoded }
+
+      it 'includes a link to the service start page' do
+        expect(body).to include('http://localhost:3001')
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
 
   config.include UserHelpers
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include ActiveJob::TestHelper
 
   config.before(:each) { ActionMailer::Base.deliveries.clear }
 end

--- a/spec/requests/create_a_booking_request_spec.rb
+++ b/spec/requests/create_a_booking_request_spec.rb
@@ -2,12 +2,16 @@ require 'rails_helper'
 
 RSpec.describe 'POST /api/v1/booking_requests' do
   scenario 'create a valid booking request' do
-    given_the_client_identifies_as_pension_wise
-    when_a_valid_booking_request_is_made
-    then_the_booking_request_is_created
-    and_the_booking_has_associated_slots
-    and_the_service_responds_with_a_201
-    and_the_customer_receives_a_confirmation_email
+    perform_enqueued_jobs do
+      given_the_client_identifies_as_pension_wise
+      and_the_hackney_booking_manager_exists
+      when_a_valid_booking_request_is_made
+      then_the_booking_request_is_created
+      and_the_booking_has_associated_slots
+      and_the_service_responds_with_a_201
+      and_the_customer_receives_a_confirmation_email
+      and_the_booking_manager_receives_a_notification_email
+    end
   end
 
   scenario 'attempting to create an invalid booking request' do
@@ -93,7 +97,15 @@ RSpec.describe 'POST /api/v1/booking_requests' do
   end
 
   def and_the_customer_receives_a_confirmation_email
-    expect(ActionMailer::Base.deliveries.count).to eq(1)
+    expect(ActionMailer::Base.deliveries.map(&:to)).to include(['morty@example.com'])
+  end
+
+  def and_the_hackney_booking_manager_exists
+    @booking_manager = create(:hackney_booking_manager)
+  end
+
+  def and_the_booking_manager_receives_a_notification_email
+    expect(ActionMailer::Base.deliveries.map(&:to)).to include(['rick@example.com'])
   end
 
   def when_an_invalid_booking_request_is_made


### PR DESCRIPTION
Sends an email notification alerting the booking managers of a new
booking request.

There is a very slight timing issue, whereby a booking manager may not
have yet signed into the application via signon and thus not actually
exist within the `Users` table. In this case we raise
`BookingManagersNotFoundError` and allow the job to retry indefinitely
using the typical sidekiq exponential back-off strategy.

The actual likelihood of this occurring is incredibly slim as at least
one booking manager per-location is likely to have signed into the
production environment before customers have placed booking requests.