### PR TITLE
Provide more descriptive text for accessibility requirements

### DIFF
--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -42,7 +42,11 @@
     <p class="lead"><strong class="t-age-range"><%= @appointment_form.age_range %></strong></p>
 
     <h4>Accessibility requirements:</h4>
-    <p class="lead"><strong class="t-accessibility_requirements"><%= @appointment_form.accessibility_requirements %></strong></p>
+    <p class="lead">
+      <strong class="t-accessibility_requirements">
+        <%= t("booking_request.accessibility_requirements.is_#{@appointment_form.accessibility_requirements}") %>
+      </strong>
+    </p>
   </div>
 
   <div class="col-md-4">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  booking_request:
+    accessibility_requirements:
+      is_true: "Requested, please discuss with customer"
+      is_false: "Not requested"


### PR DESCRIPTION
As some locations may have limited access, even though the
customer has not requested special accessibility requirements,
this should still be kept in mind when fulfilling the booking.

This change clarifies that 'false' only means 'not requested'.

Equally if they have requested this, then more detail should be
seeked out by the booking manager to ensure a suitable location
is selected.