### PR TITLE
Guard against multiple fulfilments of a booking

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -21,6 +21,7 @@ class AppointmentForm
   validates :date, presence: true
 
   validate :validate_date
+  validate :validate_not_with_an_existing_booking_request
 
   attr_reader :location_aware_booking_request
 
@@ -61,6 +62,10 @@ class AppointmentForm
   end
 
   private
+
+  def validate_not_with_an_existing_booking_request
+    errors.add(:base, 'has already been fulfilled') if location_aware_booking_request.appointment
+  end
 
   def validate_date
     return unless date

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe AppointmentForm do
       expect(subject).to be_valid
     end
 
+    it 'must not be associated with an existing appointment' do
+      booking_request.appointment = build(:appointment)
+
+      expect(subject).to_not be_valid
+    end
+
     it 'requires a location ID' do
       params[:location_id] = ''
 


### PR DESCRIPTION
There is a chance that given multiple booking managers for the same
location, when they receive the new booking notification they all race
to fulfil the booking request.

Previously, it was possible that a single booking request be fulfilled
multiple times. This change ensures the booking request is not already
associated with an appointment, thus guarding against this outcome.