### PR TITLE
Prevent long names and email addresses overflowing

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import 'govuk_admin_template';
 
+@import 'helpers/**/*';
 @import 'components/**/*';

--- a/app/assets/stylesheets/helpers/_dont-break-out.scss
+++ b/app/assets/stylesheets/helpers/_dont-break-out.scss
@@ -1,0 +1,18 @@
+// https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+.dont-break-out {
+  /* These are technically the same, but use both */
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  -ms-word-break: break-all;
+  /* This is the dangerous one in WebKit, as it breaks things wherever */
+  word-break: break-all;
+  /* Instead use this non-standard one: */
+  word-break: break-word;
+
+  /* Adds a hyphen where the word breaks, if supported (No Blink) */
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -18,7 +18,7 @@
 </div>
 
 <div class="row">
-  <div class="col-md-4">
+  <div class="col-md-4 dont-break-out">
     <h3>Customer details</h3>
     <p class="lead">
       <%= @appointment_form.name %><br>


### PR DESCRIPTION
Adds helper to ensure long lines wrap cleanly across browsers.
Reference: https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/

tl;dr this change prevents this:

<img width="647" alt="screen shot 2016-07-28 at 15 32 17" src="https://cloud.githubusercontent.com/assets/295469/17216585/3036941c-54d9-11e6-8008-296bba813fea.png">
