### PR TITLE
Cache booking locations for 2 hours

### DIFF
--- a/config/initializers/booking_locations.rb
+++ b/config/initializers/booking_locations.rb
@@ -1,4 +1,8 @@
-unless Rails.env.production? || Rails.env.staging?
+if Rails.env.production? || Rails.env.staging?
+  require_relative '../../lib/cached_booking_locations_api'
+
+  BookingLocations.api = CachedBookingLocationsApi.new
+else
   require 'booking_locations/stub_api'
 
   BookingLocations.api = BookingLocations::StubApi.new

--- a/lib/cached_booking_locations_api.rb
+++ b/lib/cached_booking_locations_api.rb
@@ -1,0 +1,15 @@
+class CachedBookingLocationsApi < BookingLocations::Api
+  def initialize(cache: Rails.cache)
+    @cache = cache
+  end
+
+  def find(location_id)
+    cache.fetch(location_id, expires_in: 2.hours) do
+      super
+    end
+  end
+
+  private
+
+  attr_reader :cache
+end


### PR DESCRIPTION
Caches booking locations using a read-through cache. This will use
whatever backend Rails caching is configured with - currently
in-memory.