### PR TITLE
Edit Appointments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby IO.read('.ruby-version').strip
 
+gem 'audited-activerecord'
 gem 'booking_locations'
 gem 'gds-sso'
 gem 'rails', '4.2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
     addressable (2.4.0)
     arel (6.0.3)
     ast (2.2.0)
+    audited (4.2.1)
+      rails-observers (~> 0.1.2)
+    audited-activerecord (4.2.1)
+      activerecord (~> 4.0)
+      audited (= 4.2.1)
     autoprefixer-rails (6.3.6)
       execjs
     binding_of_caller (0.7.2)
@@ -169,6 +174,8 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-observers (0.1.2)
+      activemodel (~> 4.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -257,6 +264,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  audited-activerecord
   booking_locations
   bugsnag
   capybara

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -13,9 +13,11 @@ class AppointmentsController < ApplicationController
   end
 
   def update
-    @appointment.update(edit_appointment_params)
-
-    redirect_to appointments_path
+    if @appointment.update(edit_appointment_params)
+      redirect_to appointments_path
+    else
+      render :edit
+    end
   end
 
   def new

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -14,7 +14,7 @@ class AppointmentsController < ApplicationController
 
   def update
     if @appointment_form.update(edit_appointment_params)
-      Appointments.customer(@appointment_form.entity, booking_location).deliver_later
+      notify_customer(@appointment_form.entity)
 
       redirect_to appointments_path
     else
@@ -28,7 +28,7 @@ class AppointmentsController < ApplicationController
   def create
     if @appointment_form.valid?
       @appointment = Appointment.create(@appointment_form.appointment_params)
-      Appointments.customer(@appointment, booking_location).deliver_later
+      notify_customer(@appointment)
 
       redirect_to booking_requests_path
     else
@@ -37,6 +37,12 @@ class AppointmentsController < ApplicationController
   end
 
   private
+
+  def notify_customer(appointment)
+    return unless appointment.notify?
+
+    Appointments.customer(appointment, booking_location).deliver_later
+  end
 
   def location_aware_appointment
     LocationAwareEntity.new(

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -13,7 +13,7 @@ class AppointmentsController < ApplicationController
   end
 
   def update
-    @appointment.update
+    @appointment.update(edit_appointment_params)
 
     redirect_to appointments_path
   end
@@ -42,10 +42,7 @@ class AppointmentsController < ApplicationController
   end
 
   def populate_edit_appointment_form
-    @appointment = EditAppointmentForm.new(
-      location_aware_appointment,
-      edit_appointment_params
-    )
+    @appointment = EditAppointmentForm.new(location_aware_appointment)
   end
 
   def populate_appointment_form
@@ -63,8 +60,10 @@ class AppointmentsController < ApplicationController
   end
 
   def edit_appointment_params # rubocop:disable Metrics/MethodLength
+    munge_time_params!
+
     params
-      .fetch(:appointment, {})
+      .require(:appointment)
       .permit(
         :name,
         :email,
@@ -74,6 +73,15 @@ class AppointmentsController < ApplicationController
         :proceeded_at,
         :status
       )
+  end
+
+  def munge_time_params!
+    appointment_params = params[:appointment]
+
+    hour   = appointment_params.delete('proceeded_at(4i)')
+    minute = appointment_params.delete('proceeded_at(5i)')
+
+    appointment_params[:proceeded_at] += " #{hour}:#{minute}" if hour && minute
   end
 
   def appointment_params

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,11 +1,15 @@
 class AppointmentsController < ApplicationController
-  before_action :populate_appointment_form, except: :index
+  before_action :populate_appointment_form, only: %i(new create)
 
   def index
     @appointments = LocationAwareEntities.new(
       current_user.appointments,
       booking_location
     ).all
+  end
+
+  def edit
+    head :ok
   end
 
   def new

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -13,7 +13,9 @@ class AppointmentsController < ApplicationController
   end
 
   def update
-    render :edit
+    @appointment.update
+
+    redirect_to appointments_path
   end
 
   def new

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -1,5 +1,6 @@
 class AppointmentsController < ApplicationController
   before_action :populate_appointment_form, only: %i(new create)
+  before_action :populate_edit_appointment_form, only: %i(edit update)
 
   def index
     @appointments = LocationAwareEntities.new(
@@ -9,7 +10,10 @@ class AppointmentsController < ApplicationController
   end
 
   def edit
-    head :ok
+  end
+
+  def update
+    render :edit
   end
 
   def new
@@ -28,6 +32,20 @@ class AppointmentsController < ApplicationController
 
   private
 
+  def location_aware_appointment
+    LocationAwareEntity.new(
+      entity: current_user.appointments.find(params[:id]),
+      booking_location: booking_location
+    )
+  end
+
+  def populate_edit_appointment_form
+    @appointment = EditAppointmentForm.new(
+      location_aware_appointment,
+      edit_appointment_params
+    )
+  end
+
   def populate_appointment_form
     @appointment_form = AppointmentForm.new(
       location_aware_booking_request,
@@ -40,6 +58,20 @@ class AppointmentsController < ApplicationController
       entity: current_user.booking_requests.find(params[:booking_request_id]),
       booking_location: booking_location
     )
+  end
+
+  def edit_appointment_params # rubocop:disable Metrics/MethodLength
+    params
+      .fetch(:appointment, {})
+      .permit(
+        :name,
+        :email,
+        :phone,
+        :guider_id,
+        :location_id,
+        :proceeded_at,
+        :status
+      )
   end
 
   def appointment_params

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -13,7 +13,7 @@ class AppointmentsController < ApplicationController
   end
 
   def update
-    if @appointment.update(edit_appointment_params)
+    if @appointment_form.update(edit_appointment_params)
       redirect_to appointments_path
     else
       render :edit
@@ -44,7 +44,7 @@ class AppointmentsController < ApplicationController
   end
 
   def populate_edit_appointment_form
-    @appointment = EditAppointmentForm.new(location_aware_appointment)
+    @appointment_form = EditAppointmentForm.new(location_aware_appointment)
   end
 
   def populate_appointment_form

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -14,6 +14,8 @@ class AppointmentsController < ApplicationController
 
   def update
     if @appointment_form.update(edit_appointment_params)
+      Appointments.customer(@appointment_form.entity, booking_location).deliver_later
+
       redirect_to appointments_path
     else
       render :edit

--- a/app/forms/edit_appointment_form.rb
+++ b/app/forms/edit_appointment_form.rb
@@ -41,6 +41,17 @@ class EditAppointmentForm
     FlattenedLocationMapper.map(booking_location)
   end
 
+  def update
+    location_aware_appointment.update(
+      name: name,
+      email: email,
+      phone: phone,
+      guider_id: guider_id,
+      location_id: location_id,
+      proceeded_at: proceeded_at
+    )
+  end
+
   # memoized readers to use `params` when present
   EDITABLE_ATTRIBUTES.each do |attribute|
     class_eval <<~EORUBY, __FILE__, __LINE__ + 1

--- a/app/forms/edit_appointment_form.rb
+++ b/app/forms/edit_appointment_form.rb
@@ -1,0 +1,64 @@
+class EditAppointmentForm
+  include ActiveModel::Model
+
+  ATTRIBUTES = %i(
+    id
+    reference
+    booking_location
+    booking_request
+  ).freeze
+
+  EDITABLE_ATTRIBUTES = %i(
+    name
+    email
+    phone
+    location_id
+    guider_id
+  ).freeze
+
+  attr_writer(*EDITABLE_ATTRIBUTES)
+
+  delegate(*ATTRIBUTES, to: :location_aware_appointment)
+
+  delegate :guiders, to: :booking_location
+
+  delegate :primary_slot, :secondary_slot, :tertiary_slot, to: :booking_request
+
+  def initialize(location_aware_appointment, params)
+    @location_aware_appointment = location_aware_appointment
+
+    normalise_time(params)
+    super(params)
+  end
+
+  def proceeded_at
+    @proceeded_at ||= location_aware_appointment.proceeded_at
+
+    Time.zone.parse(@proceeded_at.to_s)
+  end
+
+  def flattened_locations
+    FlattenedLocationMapper.map(booking_location)
+  end
+
+  # memoized readers to use `params` when present
+  EDITABLE_ATTRIBUTES.each do |attribute|
+    class_eval <<~EORUBY, __FILE__, __LINE__ + 1
+      def #{attribute}
+        @#{attribute} ||= location_aware_appointment.#{attribute}
+      end
+    EORUBY
+  end
+
+  private
+
+  def normalise_time(params)
+    date   = params.delete('proceeded_at')
+    hour   = params.delete('proceeded_at(4i)')
+    minute = params.delete('proceeded_at(5i)')
+
+    @proceeded_at = "#{date} #{hour}:#{minute}" if date && hour && minute
+  end
+
+  attr_reader :location_aware_appointment
+end

--- a/app/forms/edit_appointment_form.rb
+++ b/app/forms/edit_appointment_form.rb
@@ -1,75 +1,13 @@
-class EditAppointmentForm
-  include ActiveModel::Model
-
-  ATTRIBUTES = %i(
-    id
-    reference
-    booking_location
-    booking_request
-  ).freeze
-
-  EDITABLE_ATTRIBUTES = %i(
-    name
-    email
-    phone
-    location_id
-    guider_id
-  ).freeze
-
-  attr_writer(*EDITABLE_ATTRIBUTES)
-
-  delegate(*ATTRIBUTES, to: :location_aware_appointment)
-
+class EditAppointmentForm < SimpleDelegator
   delegate :guiders, to: :booking_location
 
   delegate :primary_slot, :secondary_slot, :tertiary_slot, to: :booking_request
 
-  def initialize(location_aware_appointment, params)
-    @location_aware_appointment = location_aware_appointment
-
-    normalise_time(params)
-    super(params)
-  end
-
-  def proceeded_at
-    @proceeded_at ||= location_aware_appointment.proceeded_at
-
-    Time.zone.parse(@proceeded_at.to_s)
+  def initialize(location_aware_appointment)
+    super
   end
 
   def flattened_locations
     FlattenedLocationMapper.map(booking_location)
   end
-
-  def update
-    location_aware_appointment.update(
-      name: name,
-      email: email,
-      phone: phone,
-      guider_id: guider_id,
-      location_id: location_id,
-      proceeded_at: proceeded_at
-    )
-  end
-
-  # memoized readers to use `params` when present
-  EDITABLE_ATTRIBUTES.each do |attribute|
-    class_eval <<~EORUBY, __FILE__, __LINE__ + 1
-      def #{attribute}
-        @#{attribute} ||= location_aware_appointment.#{attribute}
-      end
-    EORUBY
-  end
-
-  private
-
-  def normalise_time(params)
-    date   = params.delete('proceeded_at')
-    hour   = params.delete('proceeded_at(4i)')
-    minute = params.delete('proceeded_at(5i)')
-
-    @proceeded_at = "#{date} #{hour}:#{minute}" if date && hour && minute
-  end
-
-  attr_reader :location_aware_appointment
 end

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -1,0 +1,5 @@
+module AppointmentHelper
+  def friendly_options(statuses)
+    statuses.map { |k, _| [k.titleize, k] }.to_h
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -26,6 +26,10 @@ class Appointment < ActiveRecord::Base
     audits.present?
   end
 
+  def notify?
+    previous_changes.exclude?(:status)
+  end
+
   private
 
   def validate_proceeded_at

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,4 +1,6 @@
 class Appointment < ActiveRecord::Base
+  audited on: [:update]
+
   enum status: %i(
     pending
     completed

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -22,6 +22,10 @@ class Appointment < ActiveRecord::Base
   validates :guider_id, presence: true
   validate  :validate_proceeded_at
 
+  def updated?
+    audits.present?
+  end
+
   private
 
   def validate_proceeded_at

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -14,4 +14,21 @@ class Appointment < ActiveRecord::Base
   belongs_to :booking_request
 
   delegate :reference, to: :booking_request
+
+  validates :name, presence: true
+  validates :email, presence: true
+  validates :phone, presence: true
+  validates :location_id, presence: true
+  validates :guider_id, presence: true
+  validate  :validate_proceeded_at
+
+  private
+
+  def validate_proceeded_at
+    errors.add(:proceeded_at, 'must be present') unless proceeded_at.present?
+
+    Time.zone.parse(proceeded_at.to_s)
+  rescue ArgumentError
+    errors.add(:proceeded_at, 'must be formatted correctly')
+  end
 end

--- a/app/models/location_aware_entity.rb
+++ b/app/models/location_aware_entity.rb
@@ -20,6 +20,8 @@ class LocationAwareEntity < SimpleDelegator
     actual_location.address.split(', ')
   end
 
+  alias entity __getobj__
+
   private
 
   def actual_location

--- a/app/views/appointments/customer.html.erb
+++ b/app/views/appointments/customer.html.erb
@@ -1,6 +1,11 @@
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
 0;font-size: 16px;line-height: 1.315789474;">Dear <%= @appointment.name %>,</p>
 
+<% if @appointment.updated? %>
+  <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin:
+  15px 0;font-size: 16px;line-height: 1.315789474;">Your appointment details were updated.</p>
+<% end %>
+
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
 0;font-size: 16px;line-height: 1.315789474;">Thank you for booking an
 appointment with Pension Wise. We can confirm your appointment will be at <%=

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -16,6 +16,17 @@
     <h3>Change appointment details</h3>
     <p class="lead">Use the form below to change the details of the appointment.</p>
 
+    <% if @appointment.errors.any? %>
+      <div class="alert alert-danger t-errors" role="alert">
+        <h4 class="alert__heading">There's a problem</h4>
+        <ul>
+          <% @appointment.errors.full_messages.each do |msg| %>
+            <li><%= msg %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <%= form_for @appointment, as: :appointment, url: appointment_path(@appointment.id), method: :patch do |f| %>
       <div class="form-group">
         <%= f.label :name %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -70,23 +70,16 @@
     <h3>After the appointment</h3>
     <p class="lead">Appointment finished? Update the status below.</p>
 
-    <form>
+    <%= form_for @appointment, as: :appointment, url: appointment_path(@appointment.id), method: :patch do |f| %>
       <div class="form-group">
-        <label for="location_id">Appointment status:</label>
-        <select name="location_id" id="location_id" class="form-control">
-          <option selected>TODO</option>
-          <option>Completed</option>
-          <option>Ineligible</option>
-          <option>Cancelled – customer request</option>
-          <option>Cancelled – guider request</option>
-          <option>Cancelled – no show</option>
-        </select>
+        <%= f.label :status, 'Appointment status' %>
+        <%= f.select :status, friendly_options(Appointment.statuses), options = {}, { class: 'form-control t-status' } %>
       </div>
 
-      <button type="submit" value="submit" class="btn btn-success btn-block">
+      <%= f.button class: 'btn btn-primary btn-block t-submit-status' do %>
         Update status
-      </button>
-    </form>
+      <% end %>
+    <% end %>
   </div>
 
   <div class="col-md-4">

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,0 +1,128 @@
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= appointments_path %>">Appointments</a></li>
+    <li class="active"><%= @appointment.name %></li>
+  </ol>
+
+  <h1>
+    Modify/cancel appointment for <%= @appointment.name %><br>
+    <small>Booking reference: <%= @appointment.reference %></small>
+  </h1>
+</div>
+
+<div class="row">
+  <div class="col-md-4">
+    <h3>Change appointment details</h3>
+    <p class="lead">Use the form below to change the details of the appointment.</p>
+
+    <%= form_for @appointment, as: :appointment, url: appointment_path(@appointment.id), method: :patch do |f| %>
+      <div class="form-group">
+        <%= f.label :name %>
+        <%= f.text_field :name, class: 'form-control t-name' %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :email %>
+        <%= f.text_field :email, class: 'form-control t-email' %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :phone %>
+        <%= f.text_field :phone, class: 'form-control t-phone' %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :guider_id %>
+        <%= f.select(
+          :guider_id,
+          options_from_collection_for_select(@appointment.guiders, 'id', 'name', selected: @appointment.guider_id),
+          options = {},
+          class: 'form-control t-guider'
+        ) %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :location_id %>
+        <%= f.select(:location_id, @appointment.flattened_locations, options = {}, { class: 'form-control t-location' }
+        ) %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :proceeded_at, 'Date of appointment' %>
+        <%= f.date_field(:proceeded_at, class: 't-date form-control') %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :proceeded_at, 'Time of appointment' %>
+        <div class="form-control">
+          <%= f.time_select(:proceeded_at, ignore_date: true, minute_step: 15) %>
+        </div>
+      </div>
+
+      <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
+        Update appointment and notify<br><%= @appointment.name %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="col-md-4">
+    <h3>After the appointment</h3>
+    <p class="lead">Appointment finished? Update the status below.</p>
+
+    <form>
+      <div class="form-group">
+        <label for="location_id">Appointment status:</label>
+        <select name="location_id" id="location_id" class="form-control">
+          <option selected>TODO</option>
+          <option>Completed</option>
+          <option>Ineligible</option>
+          <option>Cancelled – customer request</option>
+          <option>Cancelled – guider request</option>
+          <option>Cancelled – no show</option>
+        </select>
+      </div>
+
+      <button type="submit" value="submit" class="btn btn-success btn-block">
+        Update status
+      </button>
+    </form>
+  </div>
+
+  <div class="col-md-4">
+    <h3>Original slots requested</h3>
+    <p class="lead">For reference, the slots originally requested by the customer are:</p>
+
+    <div class="SlotPicker-choices is-chosen SlotPicker--selected">
+      <div class="SlotPicker-choice is-chosen">
+        <div class="SlotPicker-choiceInner">
+          <div class="SlotPicker-position"><span>1</span></div>
+          <div class="SlotPicker-choiceContent">
+            <p class="SlotPicker-date t-slot-1-date"><%= @appointment.primary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-1-period"><%= @appointment.primary_slot.period %></p>
+          </div>
+        </div>
+      </div>
+
+      <div class="SlotPicker-choice is-chosen">
+        <div class="SlotPicker-choiceInner">
+          <div class="SlotPicker-position"><span>2</span></div>
+          <div class="SlotPicker-choiceContent">
+            <p class="SlotPicker-date t-slot-2-date"><%= @appointment.secondary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-2-period"><%= @appointment.secondary_slot.period %></p>
+          </div>
+        </div>
+      </div>
+
+      <div class="SlotPicker-choice is-chosen">
+        <div class="SlotPicker-choiceInner">
+          <div class="SlotPicker-position"><span>3</span></div>
+          <div class="SlotPicker-choiceContent">
+            <p class="SlotPicker-date t-slot-3-date"><%= @appointment.tertiary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-3-period"><%= @appointment.tertiary_slot.period %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -2,12 +2,12 @@
   <ol class="breadcrumb">
     <li><a href="<%= root_path %>">Appointment planner</a></li>
     <li><a href="<%= appointments_path %>">Appointments</a></li>
-    <li class="active"><%= @appointment.name %></li>
+    <li class="active"><%= @appointment_form.name %></li>
   </ol>
 
   <h1>
-    Modify/cancel appointment for <%= @appointment.name %><br>
-    <small>Booking reference: <%= @appointment.reference %></small>
+    Modify/cancel appointment for <%= @appointment_form.name %><br>
+    <small>Booking reference: <%= @appointment_form.reference %></small>
   </h1>
 </div>
 
@@ -16,18 +16,18 @@
     <h3>Change appointment details</h3>
     <p class="lead">Use the form below to change the details of the appointment.</p>
 
-    <% if @appointment.errors.any? %>
+    <% if @appointment_form.errors.any? %>
       <div class="alert alert-danger t-errors" role="alert">
         <h4 class="alert__heading">There's a problem</h4>
         <ul>
-          <% @appointment.errors.full_messages.each do |msg| %>
+          <% @appointment_form.errors.full_messages.each do |msg| %>
             <li><%= msg %></li>
           <% end %>
         </ul>
       </div>
     <% end %>
 
-    <%= form_for @appointment, as: :appointment, url: appointment_path(@appointment.id), method: :patch do |f| %>
+    <%= form_for @appointment_form do |f| %>
       <div class="form-group">
         <%= f.label :name %>
         <%= f.text_field :name, class: 'form-control t-name' %>
@@ -47,7 +47,7 @@
         <%= f.label :guider_id %>
         <%= f.select(
           :guider_id,
-          options_from_collection_for_select(@appointment.guiders, 'id', 'name', selected: @appointment.guider_id),
+          options_from_collection_for_select(@appointment_form.guiders, 'id', 'name', selected: @appointment_form.guider_id),
           options = {},
           class: 'form-control t-guider'
         ) %>
@@ -55,7 +55,7 @@
 
       <div class="form-group">
         <%= f.label :location_id %>
-        <%= f.select(:location_id, @appointment.flattened_locations, options = {}, { class: 'form-control t-location' }
+        <%= f.select(:location_id, @appointment_form.flattened_locations, options = {}, { class: 'form-control t-location' }
         ) %>
       </div>
 
@@ -72,7 +72,7 @@
       </div>
 
       <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
-        Update appointment and notify<br><%= @appointment.name %>
+        Update appointment and notify<br><%= @appointment_form.name %>
       <% end %>
     <% end %>
   </div>
@@ -81,7 +81,7 @@
     <h3>After the appointment</h3>
     <p class="lead">Appointment finished? Update the status below.</p>
 
-    <%= form_for @appointment, as: :appointment, url: appointment_path(@appointment.id), method: :patch do |f| %>
+    <%= form_for @appointment_form do |f| %>
       <div class="form-group">
         <%= f.label :status, 'Appointment status' %>
         <%= f.select :status, friendly_options(Appointment.statuses), options = {}, { class: 'form-control t-status' } %>
@@ -102,8 +102,8 @@
         <div class="SlotPicker-choiceInner">
           <div class="SlotPicker-position"><span>1</span></div>
           <div class="SlotPicker-choiceContent">
-            <p class="SlotPicker-date t-slot-1-date"><%= @appointment.primary_slot.formatted_date %></p>
-            <p class="SlotPicker-time t-slot-1-period"><%= @appointment.primary_slot.period %></p>
+            <p class="SlotPicker-date t-slot-1-date"><%= @appointment_form.primary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-1-period"><%= @appointment_form.primary_slot.period %></p>
           </div>
         </div>
       </div>
@@ -112,8 +112,8 @@
         <div class="SlotPicker-choiceInner">
           <div class="SlotPicker-position"><span>2</span></div>
           <div class="SlotPicker-choiceContent">
-            <p class="SlotPicker-date t-slot-2-date"><%= @appointment.secondary_slot.formatted_date %></p>
-            <p class="SlotPicker-time t-slot-2-period"><%= @appointment.secondary_slot.period %></p>
+            <p class="SlotPicker-date t-slot-2-date"><%= @appointment_form.secondary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-2-period"><%= @appointment_form.secondary_slot.period %></p>
           </div>
         </div>
       </div>
@@ -122,8 +122,8 @@
         <div class="SlotPicker-choiceInner">
           <div class="SlotPicker-position"><span>3</span></div>
           <div class="SlotPicker-choiceContent">
-            <p class="SlotPicker-date t-slot-3-date"><%= @appointment.tertiary_slot.formatted_date %></p>
-            <p class="SlotPicker-time t-slot-3-period"><%= @appointment.tertiary_slot.period %></p>
+            <p class="SlotPicker-date t-slot-3-date"><%= @appointment_form.tertiary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-3-period"><%= @appointment_form.tertiary_slot.period %></p>
           </div>
         </div>
       </div>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -50,7 +50,7 @@
                 <%= appointment.status.titleize %>
               </td>
               <td>
-                <%= link_to('Cancel/change', '/', class: 'btn btn-danger') %>
+                <%= link_to('Cancel / change', edit_appointment_path(appointment), class: 'btn btn-danger t-edit') %>
               </td>
             </tr>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  resources :appointments, only: %i(index edit)
+  resources :appointments, only: %i(index edit update)
 
   resources :booking_requests, only: :index do
     resources :appointments, only: %i(new create)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  resources :appointments, only: :index
+  resources :appointments, only: %i(index edit)
 
   resources :booking_requests, only: :index do
     resources :appointments, only: %i(new create)

--- a/db/migrate/20160801132404_install_audited.rb
+++ b/db/migrate/20160801132404_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration
+  def self.up
+    create_table :audits, force: true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :text
+      t.column :version, :integer, default: 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_id, :auditable_type], name: 'auditable_index'
+    add_index :audits, [:associated_id, :associated_type], name: 'associated_index'
+    add_index :audits, [:user_id, :user_type], name: 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160728105421) do
+ActiveRecord::Schema.define(version: 20160801132404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,29 @@ ActiveRecord::Schema.define(version: 20160728105421) do
 
   add_index "appointments", ["booking_request_id"], name: "index_appointments_on_booking_request_id", using: :btree
   add_index "appointments", ["location_id"], name: "index_appointments_on_location_id", using: :btree
+
+  create_table "audits", force: :cascade do |t|
+    t.integer  "auditable_id"
+    t.string   "auditable_type"
+    t.integer  "associated_id"
+    t.string   "associated_type"
+    t.integer  "user_id"
+    t.string   "user_type"
+    t.string   "username"
+    t.string   "action"
+    t.text     "audited_changes"
+    t.integer  "version",         default: 0
+    t.string   "comment"
+    t.string   "remote_address"
+    t.string   "request_uuid"
+    t.datetime "created_at"
+  end
+
+  add_index "audits", ["associated_id", "associated_type"], name: "associated_index", using: :btree
+  add_index "audits", ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
+  add_index "audits", ["created_at"], name: "index_audits_on_created_at", using: :btree
+  add_index "audits", ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
+  add_index "audits", ["user_id", "user_type"], name: "user_index", using: :btree
 
   create_table "booking_requests", force: :cascade do |t|
     t.string   "location_id",                null: false

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -14,6 +14,15 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     end
   end
 
+  scenario 'Editing an Appointment causes validation failures' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_is_an_appointment
+      when_the_booking_manager_edits_the_appointment
+      and_provides_invalid_information
+      then_they_see_the_validation_messages
+    end
+  end
+
   scenario 'Update the status of an Appointment' do
     given_the_user_identifies_as_hackneys_booking_manager do
       and_there_is_an_appointment
@@ -108,5 +117,21 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     @page.appointments.first do |appointment|
       expect(appointment).to include('Completed')
     end
+  end
+
+  def and_provides_invalid_information
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+
+    @page.name.set('')
+    @page.email.set('')
+    @page.phone.set('')
+
+    @page.submit.click
+  end
+
+  def then_they_see_the_validation_messages
+    expect(@page).to have_error_summary
+    expect(@page).to have_errors
   end
 end

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -3,14 +3,16 @@ require 'rails_helper'
 
 RSpec.feature 'Booking Manager edits an Appointment' do
   scenario 'Successfully editing an Appointment' do
-    given_the_user_identifies_as_hackneys_booking_manager do
-      and_there_is_an_appointment
-      when_the_booking_manager_edits_the_appointment
-      then_the_appointment_details_are_presented
-      and_they_see_the_requested_slots
-      when_they_modify_the_appointment_details
-      then_the_appointment_is_updated
-      and_the_customer_is_notified
+    perform_enqueued_jobs do
+      given_the_user_identifies_as_hackneys_booking_manager do
+        and_there_is_an_appointment
+        when_the_booking_manager_edits_the_appointment
+        then_the_appointment_details_are_presented
+        and_they_see_the_requested_slots
+        when_they_modify_the_appointment_details
+        then_the_appointment_is_updated
+        and_the_customer_is_notified
+      end
     end
   end
 
@@ -95,7 +97,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
   end
 
   def and_the_customer_is_notified
-    skip
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
   end
 
   def then_they_see_the_original_status

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Booking Manager edits an Appointment' do
+  scenario 'Successfully editing an Appointment' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_is_an_appointment
+      when_the_booking_manager_edits_the_appointment
+      then_the_appointment_details_are_presented
+      when_they_modify_the_appointment_details
+      then_the_appointment_is_updated
+      and_the_customer_is_notified
+    end
+  end
+
+  def and_there_is_an_appointment
+    @appointment = create(:appointment)
+  end
+
+  def when_the_booking_manager_edits_the_appointment
+    @page = Pages::Appointments.new
+    @page.load
+    @page.appointments.first.edit.click
+  end
+
+  def then_the_appointment_details_are_presented
+    skip
+  end
+
+  def when_they_modify_the_appointment_details
+    skip
+  end
+
+  def then_the_appointment_is_updated
+    skip
+  end
+
+  def and_the_customer_is_notified
+    skip
+  end
+end

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -26,12 +26,15 @@ RSpec.feature 'Booking Manager edits an Appointment' do
   end
 
   scenario 'Update the status of an Appointment' do
-    given_the_user_identifies_as_hackneys_booking_manager do
-      and_there_is_an_appointment
-      when_the_booking_manager_edits_the_appointment
-      then_they_see_the_original_status
-      when_they_modify_the_status
-      then_the_status_is_updated
+    perform_enqueued_jobs do
+      given_the_user_identifies_as_hackneys_booking_manager do
+        and_there_is_an_appointment
+        when_the_booking_manager_edits_the_appointment
+        then_they_see_the_original_status
+        when_they_modify_the_status
+        then_the_status_is_updated
+        and_the_customer_is_not_notified
+      end
     end
   end
 
@@ -98,6 +101,10 @@ RSpec.feature 'Booking Manager edits an Appointment' do
 
   def and_the_customer_is_notified
     expect(ActionMailer::Base.deliveries.count).to eq(1)
+  end
+
+  def and_the_customer_is_not_notified
+    expect(ActionMailer::Base.deliveries).to be_empty
   end
 
   def then_they_see_the_original_status

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -14,6 +14,16 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     end
   end
 
+  scenario 'Update the status of an Appointment' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_is_an_appointment
+      when_the_booking_manager_edits_the_appointment
+      then_they_see_the_original_status
+      when_they_modify_the_status
+      then_the_status_is_updated
+    end
+  end
+
   def and_there_is_an_appointment
     @appointment = create(:appointment)
   end
@@ -77,5 +87,26 @@ RSpec.feature 'Booking Manager edits an Appointment' do
 
   def and_the_customer_is_notified
     skip
+  end
+
+  def then_they_see_the_original_status
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+
+    expect(@page.status.value).to eq('pending')
+  end
+
+  def when_they_modify_the_status
+    @page.status.select('Completed')
+    @page.submit_status.click
+  end
+
+  def then_the_status_is_updated
+    @page = Pages::Appointments.new
+    expect(@page).to be_displayed
+
+    @page.appointments.first do |appointment|
+      expect(appointment).to include('Completed')
+    end
   end
 end

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -54,11 +54,25 @@ RSpec.feature 'Booking Manager edits an Appointment' do
   end
 
   def when_they_modify_the_appointment_details
-    skip
+    @page.name.set('Bob Jones')
+    @page.date.set('2016-06-21')
+    @page.time_hour.set('15')
+    @page.time_minute.set('15')
+    @page.guider.select('Bob Johnson')
+
+    @page.submit.click
   end
 
   def then_the_appointment_is_updated
-    skip
+    @page = Pages::Appointments.new
+    expect(@page).to be_displayed
+
+    @page.appointments.first do |appointment|
+      expect(appointment).to include('Bob Jones')
+      expect(appointment).to include('Tues, 21 Jun')
+      expect(appointment).to include('15:15')
+      expect(appointment).to include('Bob Johnson')
+    end
   end
 
   def and_the_customer_is_notified

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/AbcSize
 require 'rails_helper'
 
 RSpec.feature 'Booking Manager edits an Appointment' do
@@ -6,6 +7,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
       and_there_is_an_appointment
       when_the_booking_manager_edits_the_appointment
       then_the_appointment_details_are_presented
+      and_they_see_the_requested_slots
       when_they_modify_the_appointment_details
       then_the_appointment_is_updated
       and_the_customer_is_notified
@@ -23,7 +25,32 @@ RSpec.feature 'Booking Manager edits an Appointment' do
   end
 
   def then_the_appointment_details_are_presented
-    skip
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+
+    expect(@page.name.value).to eq(@appointment.name)
+    expect(@page.email.value).to eq(@appointment.email)
+    expect(@page.phone.value).to eq(@appointment.phone)
+
+    # ensure Hackney is pre-selected
+    expect(@page.location.value).to eq('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+
+    expect(@page.date.value).to eq('2016-06-20')
+    expect(@page.time_hour.value).to eq('14')
+    expect(@page.time_minute.value).to eq('00')
+  end
+
+  def and_they_see_the_requested_slots
+    @booking_request = @appointment.booking_request
+
+    expect(@page.slot_one_date.text).to eq(@booking_request.primary_slot.formatted_date)
+    expect(@page.slot_one_period.text).to eq(@booking_request.primary_slot.period)
+
+    expect(@page.slot_two_date.text).to eq(@booking_request.secondary_slot.formatted_date)
+    expect(@page.slot_two_period.text).to eq(@booking_request.secondary_slot.period)
+
+    expect(@page.slot_three_date.text).to eq(@booking_request.tertiary_slot.formatted_date)
+    expect(@page.slot_three_period.text).to eq(@booking_request.tertiary_slot.period)
   end
 
   def when_they_modify_the_appointment_details

--- a/spec/forms/edit_appointment_form_spec.rb
+++ b/spec/forms/edit_appointment_form_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe EditAppointmentForm do
+  let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
+  let(:appointment) do
+    LocationAwareEntity.new(
+      entity: build_stubbed(:appointment),
+      booking_location: hackney
+    )
+  end
+  let(:params) { Hash.new }
+
+  subject { described_class.new(appointment, params) }
+
+  described_class::ATTRIBUTES.each do |attribute|
+    it "delegates #{attribute} to the appointment" do
+      expect(subject.public_send(attribute)).to eq(appointment.public_send(attribute))
+    end
+  end
+
+  describe 'binding fields when params are passed' do
+    let(:params) do
+      {
+        name: 'name',
+        email: 'email',
+        phone: 'phone',
+        location_id: 'location_id',
+        guider_id: 'guider_id'
+      }
+    end
+
+    described_class::EDITABLE_ATTRIBUTES.each do |attribute|
+      it "correctly binds #{attribute}" do
+        expect(subject.public_send(attribute)).to eq(params[attribute])
+      end
+    end
+  end
+
+  it 'delegates slots to the underlying booking request' do
+    expect(subject.primary_slot).to eq(appointment.booking_request.primary_slot)
+    expect(subject.secondary_slot).to eq(appointment.booking_request.secondary_slot)
+    expect(subject.tertiary_slot).to eq(appointment.booking_request.tertiary_slot)
+  end
+
+  describe '#guiders' do
+    it 'returns the guiders from the booking location' do
+      expect(subject.guiders).to eq(hackney.guiders)
+    end
+  end
+
+  describe '#flattened_locations' do
+    it 'flattens locations with a mapper' do
+      expect(FlattenedLocationMapper).to receive(:map).with(hackney)
+
+      subject.flattened_locations
+    end
+  end
+
+  describe '#proceeded_at' do
+    context 'when the time params are provided' do
+      let(:params) do
+        {
+          'proceeded_at'     => '2016-06-20',
+          'proceeded_at(4i)' => '13',
+          'proceeded_at(5i)' => '15'
+        }
+      end
+
+      it 'is parsed correctly' do
+        expect(subject.proceeded_at).to eq('2016-06-20 13:15')
+      end
+    end
+  end
+end

--- a/spec/forms/edit_appointment_form_spec.rb
+++ b/spec/forms/edit_appointment_form_spec.rb
@@ -9,33 +9,8 @@ RSpec.describe EditAppointmentForm do
       booking_location: hackney
     )
   end
-  let(:params) { Hash.new }
 
-  subject { described_class.new(appointment, params) }
-
-  described_class::ATTRIBUTES.each do |attribute|
-    it "delegates #{attribute} to the appointment" do
-      expect(subject.public_send(attribute)).to eq(appointment.public_send(attribute))
-    end
-  end
-
-  describe 'binding fields when params are passed' do
-    let(:params) do
-      {
-        name: 'name',
-        email: 'email',
-        phone: 'phone',
-        location_id: 'location_id',
-        guider_id: 'guider_id'
-      }
-    end
-
-    described_class::EDITABLE_ATTRIBUTES.each do |attribute|
-      it "correctly binds #{attribute}" do
-        expect(subject.public_send(attribute)).to eq(params[attribute])
-      end
-    end
-  end
+  subject { described_class.new(appointment) }
 
   it 'delegates slots to the underlying booking request' do
     expect(subject.primary_slot).to eq(appointment.booking_request.primary_slot)
@@ -54,50 +29,6 @@ RSpec.describe EditAppointmentForm do
       expect(FlattenedLocationMapper).to receive(:map).with(hackney)
 
       subject.flattened_locations
-    end
-  end
-
-  describe '#proceeded_at' do
-    context 'when the time params are provided' do
-      let(:params) do
-        {
-          'proceeded_at'     => '2016-06-20',
-          'proceeded_at(4i)' => '13',
-          'proceeded_at(5i)' => '15'
-        }
-      end
-
-      it 'is parsed correctly' do
-        expect(subject.proceeded_at).to eq('2016-06-20 13:15')
-      end
-    end
-  end
-
-  describe '#update' do
-    let(:params) do
-      {
-        'name'             => 'Ben Lovell',
-        'email'            => 'ben@example.com',
-        'phone'            => '07715 930 444',
-        'guider_id'        => '2',
-        'location_id'      => 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
-        'proceeded_at'     => '2016-06-20',
-        'proceeded_at(4i)' => '13',
-        'proceeded_at(5i)' => '15'
-      }
-    end
-
-    it 'updates the underlying appointment' do
-      expect(underlying_appointment).to receive(:update).with(
-        name: 'Ben Lovell',
-        email: 'ben@example.com',
-        phone: '07715 930 444',
-        guider_id: '2',
-        location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
-        proceeded_at: Time.zone.parse('2016-06-20 13:15')
-      )
-
-      subject.update
     end
   end
 end

--- a/spec/forms/edit_appointment_form_spec.rb
+++ b/spec/forms/edit_appointment_form_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe EditAppointmentForm do
   let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
+  let(:underlying_appointment) { build_stubbed(:appointment) }
   let(:appointment) do
     LocationAwareEntity.new(
-      entity: build_stubbed(:appointment),
+      entity: underlying_appointment,
       booking_location: hackney
     )
   end
@@ -69,6 +70,34 @@ RSpec.describe EditAppointmentForm do
       it 'is parsed correctly' do
         expect(subject.proceeded_at).to eq('2016-06-20 13:15')
       end
+    end
+  end
+
+  describe '#update' do
+    let(:params) do
+      {
+        'name'             => 'Ben Lovell',
+        'email'            => 'ben@example.com',
+        'phone'            => '07715 930 444',
+        'guider_id'        => '2',
+        'location_id'      => 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
+        'proceeded_at'     => '2016-06-20',
+        'proceeded_at(4i)' => '13',
+        'proceeded_at(5i)' => '15'
+      }
+    end
+
+    it 'updates the underlying appointment' do
+      expect(underlying_appointment).to receive(:update).with(
+        name: 'Ben Lovell',
+        email: 'ben@example.com',
+        phone: '07715 930 444',
+        guider_id: '2',
+        location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
+        proceeded_at: Time.zone.parse('2016-06-20 13:15')
+      )
+
+      subject.update
     end
   end
 end

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -38,6 +38,20 @@ RSpec.describe Appointments do
           'E8 1HE'
         )
       end
+
+      context 'when sending the initial appointment notification' do
+        it 'does not include the lead paragraph for updates' do
+          expect(body).to_not include('Your appointment details were updated')
+        end
+      end
+
+      context 'when sending the updated appointment notification' do
+        before { allow(appointment).to receive(:updated?).and_return(true) }
+
+        it 'includes the lead paragraph for updates' do
+          expect(body).to include('Your appointment details were updated')
+        end
+      end
     end
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Appointment do
-  let(:appointment) { build_stubbed(:appointment) }
+  subject { build_stubbed(:appointment) }
 
   it 'defaults #status to `pending`' do
     expect(described_class.new).to be_pending
   end
 
   it 'delegates `#reference` to the `booking_request`' do
-    expect(appointment.reference).to eq(appointment.booking_request.reference)
+    expect(subject.reference).to eq(subject.booking_request.reference)
   end
 
   it 'audits changes upon update' do
@@ -23,5 +23,19 @@ RSpec.describe Appointment do
     )
 
     expect(original.audits).to be_present
+  end
+
+  describe 'validation' do
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    %i(name email phone guider_id location_id proceeded_at).each do |attribute|
+      it "requires the #{attribute}" do
+        subject[attribute] = ''
+
+        expect(subject).to be_invalid
+      end
+    end
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe Appointment do
   it 'delegates `#reference` to the `booking_request`' do
     expect(appointment.reference).to eq(appointment.booking_request.reference)
   end
+
+  it 'audits changes upon update' do
+    original = create(:appointment)
+
+    original.update(
+      name: 'Dave',
+      email: 'dave@example.com',
+      phone: '0208 252 4729',
+      proceeded_at: '2016-06-21 14:15',
+      guider_id: '3'
+    )
+
+    expect(original.audits).to be_present
+  end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Appointment do
     )
 
     expect(original.audits).to be_present
+    expect(original).to be_updated
   end
 
   describe 'validation' do

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -11,19 +11,39 @@ RSpec.describe Appointment do
     expect(subject.reference).to eq(subject.booking_request.reference)
   end
 
-  it 'audits changes upon update' do
-    original = create(:appointment)
+  describe 'auditing' do
+    let(:original) { create(:appointment) }
 
-    original.update(
-      name: 'Dave',
-      email: 'dave@example.com',
-      phone: '0208 252 4729',
-      proceeded_at: '2016-06-21 14:15',
-      guider_id: '3'
-    )
+    it 'audits changes upon update' do
+      original.update(
+        name: 'Dave',
+        email: 'dave@example.com',
+        phone: '0208 252 4729',
+        proceeded_at: '2016-06-21 14:15',
+        guider_id: '3'
+      )
 
-    expect(original.audits).to be_present
-    expect(original).to be_updated
+      expect(original.audits).to be_present
+      expect(original).to be_updated
+    end
+
+    describe '#notify?' do
+      context 'when the status was changed' do
+        it 'returns false' do
+          original.update(status: 1)
+
+          expect(original).to_not be_notify
+        end
+      end
+
+      context 'when the status was not changed' do
+        it 'returns true' do
+          original.update(name: 'George')
+
+          expect(original).to be_notify
+        end
+      end
+    end
   end
 
   describe 'validation' do

--- a/spec/models/location_aware_entity_spec.rb
+++ b/spec/models/location_aware_entity_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe LocationAwareEntity do
       described_class.new(booking_location: booking_location, entity: booking_request)
     end
 
+    describe '#entity' do
+      it 'unwraps the delegated instance' do
+        expect(subject.entity).to eq(booking_request)
+      end
+    end
+
     describe '#location_name' do
       it 'delegates `location_name` to the entity' do
         expect(booking_location).to receive(:name_for)

--- a/spec/support/pages/appointments.rb
+++ b/spec/support/pages/appointments.rb
@@ -2,6 +2,8 @@ module Pages
   class Appointments < SitePrism::Page
     set_url '/appointments'
 
-    elements :appointments, '.t-appointment'
+    sections :appointments, '.t-appointment' do
+      element :edit, '.t-edit'
+    end
   end
 end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -20,5 +20,8 @@ module Pages
     element :slot_three_period, '.t-slot-3-period'
 
     element :submit, '.t-submit'
+
+    element :status, '.t-status'
+    element :submit_status, '.t-submit-status'
   end
 end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -23,5 +23,8 @@ module Pages
 
     element :status, '.t-status'
     element :submit_status, '.t-submit-status'
+
+    elements :errors, '.field_with_errors'
+    element :error_summary, '.t-errors'
   end
 end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -1,0 +1,22 @@
+module Pages
+  class EditAppointment < SitePrism::Page
+    set_url '/appointments/{id}/edit'
+
+    element :name, '.t-name'
+    element :email, '.t-email'
+    element :phone, '.t-phone'
+    element :location, '.t-location'
+    element :guider, '.t-guider'
+
+    element :date, '.t-date'
+    element :time_hour, '#appointment_proceeded_at_4i'
+    element :time_minute, '#appointment_proceeded_at_5i'
+
+    element :slot_one_date,     '.t-slot-1-date'
+    element :slot_one_period,   '.t-slot-1-period'
+    element :slot_two_date,     '.t-slot-2-date'
+    element :slot_two_period,   '.t-slot-2-period'
+    element :slot_three_date,   '.t-slot-3-date'
+    element :slot_three_period, '.t-slot-3-period'
+  end
+end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -18,5 +18,7 @@ module Pages
     element :slot_two_period,   '.t-slot-2-period'
     element :slot_three_date,   '.t-slot-3-date'
     element :slot_three_period, '.t-slot-3-period'
+
+    element :submit, '.t-submit'
   end
 end


### PR DESCRIPTION
Lets the bookings manager edit an existing appointment. This allows them to alter the customer details, change the guider, location or date and time of an appointment and also change the status of an appointment once complete or otherwise.

We send the customer a notification email upon successful update of the appointment, so long as the status hasn't changed. As-is status changes are mutually exclusive from other customer or appointment detail updates so we simply send the regular fulfilment email - but with a lead in paragraph explaining the appointment has been updated.

We also audit all changes to the appointment using the `audited` gem. This is pretty basic as it stands now, and we don't plan to reify old versions or provide any of those kind of capabilities in the near-future. For now we just store the simple changeset, without presentation of any kind.

![screen shot 2016-08-02 at 14 16 57](https://cloud.githubusercontent.com/assets/41963/17329767/f7e7ebd8-58bb-11e6-8267-2406a59a8b75.png)
