### PR TITLE
Tag emails with `message_type` in headers

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,8 +1,9 @@
+require 'mailgun_headers'
+
 class ApplicationMailer < ActionMailer::Base
-  default(
-    from: 'appointments@pensionwise.gov.uk',
-    'X-Mailgun-Variables' => { online_booking: true }.to_json
-  )
+  include MailgunHeaders
+
+  default from: 'appointments@pensionwise.gov.uk'
 
   layout 'mailer'
 end

--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -5,6 +5,7 @@ class Appointments < ApplicationMailer
       booking_location: booking_location
     )
 
+    mailgun_headers('appointment_confirmation')
     mail to: appointment.email, subject: 'Your Pension Wise Appointment'
   end
 end

--- a/app/mailers/booking_requests.rb
+++ b/app/mailers/booking_requests.rb
@@ -3,10 +3,12 @@ class BookingRequests < ApplicationMailer
     @booking_request  = booking_request
     @booking_location = booking_location
 
+    mailgun_headers('customer_booking_request')
     mail to: booking_request.email, subject: 'Your Pension Wise Appointment Request'
   end
 
   def booking_manager(booking_manager)
+    mailgun_headers('booking_manager_booking_request')
     mail to: booking_manager.email, subject: 'Pension Wise Booking Request'
   end
 end

--- a/lib/mailgun_headers.rb
+++ b/lib/mailgun_headers.rb
@@ -1,0 +1,14 @@
+module MailgunHeaders
+  def mailgun_headers(message_type)
+    headers['X-Mailgun-Variables'] = headers_hash(message_type)
+  end
+
+  private
+
+  def headers_hash(message_type)
+    {
+      online_booking: true,
+      message_type: message_type
+    }.to_json
+  end
+end

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Appointments do
       expect(mail.subject).to eq('Your Pension Wise Appointment')
       expect(mail.to).to eq([appointment.email])
       expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+      expect(mail['X-Mailgun-Variables'].value).to include('"message_type":"appointment_confirmation"')
     end
 
     describe 'rendering the body' do

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe BookingRequests do
       expect(mail.subject).to eq('Your Pension Wise Appointment Request')
       expect(mail.to).to eq([booking_request.email])
       expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+      expect(mail['X-Mailgun-Variables'].value).to include('"message_type":"customer_booking_request"')
     end
 
     describe 'rendering the body' do
@@ -50,6 +51,7 @@ RSpec.describe BookingRequests do
       expect(mail.subject).to eq('Pension Wise Booking Request')
       expect(mail.to).to eq([booking_manager.email])
       expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+      expect(mail['X-Mailgun-Variables'].value).to include('"message_type":"booking_manager_booking_request"')
     end
 
     describe 'rendering the body' do

--- a/spec/support/shared_examples_for_mailers.rb
+++ b/spec/support/shared_examples_for_mailers.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples 'mailgun identified email' do
   it 'renders the mailgun identification header' do
-    expect(mail['X-Mailgun-Variables'].value).to eq('{"online_booking":true}')
+    expect(mail['X-Mailgun-Variables'].value).to include('"online_booking":true')
   end
 end


### PR DESCRIPTION
Allows for more granular analysis of email deliveries and
interaction.