### PR TITLE
Titleize statuses for consistency

### DIFF
--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -47,7 +47,7 @@
                 <%= appointment.reference %>
               </td>
               <td>
-                <%= appointment.status.humanize %>
+                <%= appointment.status.titleize %>
               </td>
               <td>
                 <%= link_to('Cancel/change', '/', class: 'btn btn-danger') %>


### PR DESCRIPTION
We titleize the status when presenting it to the booking manager for
updating an appointment, so we should do it here too.