### PR TITLE
Cached booking locations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,6 @@ group :development do
   gem 'web-console', '~> 2.0'
 end
 
-group :production do
+group :staging, :production do
   gem 'rails_12factor'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,6 +57,9 @@ Rails.application.configure do
   # Use a different cache store in production.
   config.cache_store = :memory_store
 
+  # Log cache hits / misses
+  ActiveSupport::Cache::Store.logger = Rails.logger
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/initializers/booking_locations.rb
+++ b/config/initializers/booking_locations.rb
@@ -1,5 +1,5 @@
 if Rails.env.production? || Rails.env.staging?
-  require_relative '../../lib/cached_booking_locations_api'
+  require 'cached_booking_locations_api'
 
   BookingLocations.api = CachedBookingLocationsApi.new
 else

--- a/lib/cached_booking_locations_api.rb
+++ b/lib/cached_booking_locations_api.rb
@@ -1,15 +1,19 @@
-class CachedBookingLocationsApi < BookingLocations::Api
-  def initialize(cache: Rails.cache)
+class CachedBookingLocationsApi
+  def initialize(cache: Rails.cache, booking_locations_api: BookingLocations::Api.new)
     @cache = cache
+    @booking_locations_api = booking_locations_api
   end
 
-  def find(location_id)
+  def get(location_id)
     cache.fetch(location_id, expires_in: 2.hours) do
-      super
+      booking_locations_api.get(location_id) do |response_hash|
+        BookingLocations::Location.new(response_hash)
+      end
     end
   end
 
   private
 
   attr_reader :cache
+  attr_reader :booking_locations_api
 end

--- a/spec/lib/cached_booking_locations_api_spec.rb
+++ b/spec/lib/cached_booking_locations_api_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require_relative '../../lib/cached_booking_locations_api'
+
+RSpec.describe CachedBookingLocationsApi do
+  let(:location_id) { 'birdperson' }
+  let(:booking_locations_api) { double }
+  let(:location) { 'location' }
+
+  subject { described_class.new(booking_locations_api: booking_locations_api) }
+
+  before { Rails.cache.clear }
+
+  it 'caches the result after the first call yields' do
+    expect(booking_locations_api).to receive(:get)
+      .once
+      .with(location_id)
+      .and_return(location)
+
+    expect(subject.get(location_id)).to eq(location)
+
+    # trigger the second call, this response is cached now
+    subject.get(location_id)
+  end
+end


### PR DESCRIPTION
Cache booking locations in memory for 2 hours. This wasn't 100% effective prior to these changes. 