### PR TITLE
Paginate booking requests list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby IO.read('.ruby-version').strip
 gem 'audited-activerecord'
 gem 'booking_locations'
 gem 'gds-sso'
+gem 'kaminari'
+gem 'bootstrap-kaminari-views'
 gem 'rails', '4.2.6'
 gem 'pg', '~> 0.15'
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
     booking_locations (0.6.0)
       activesupport (>= 4, < 5.1)
       globalid
+    bootstrap-kaminari-views (0.0.5)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
@@ -102,6 +105,9 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.4)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -266,12 +272,14 @@ PLATFORMS
 DEPENDENCIES
   audited-activerecord
   booking_locations
+  bootstrap-kaminari-views
   bugsnag
   capybara
   factory_girl_rails
   foreman
   gds-sso
   govuk_admin_template
+  kaminari
   newrelic_rpm
   pg (~> 0.15)
   plek

--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -1,8 +1,14 @@
 class BookingRequestsController < ApplicationController
   def index
     @booking_requests = LocationAwareEntities.new(
-      current_user.unfulfilled_booking_requests,
+      unfulfilled_booking_requests,
       booking_location
-    ).all
+    )
+  end
+
+  private
+
+  def unfulfilled_booking_requests
+    current_user.unfulfilled_booking_requests.page(params[:page])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def paginate(objects, options = {})
+    options.reverse_merge!(theme: 'twitter-bootstrap-3')
+    super(objects, options)
+  end
 end

--- a/app/models/location_aware_entities.rb
+++ b/app/models/location_aware_entities.rb
@@ -1,4 +1,6 @@
 class LocationAwareEntities
+  attr_reader :entities
+
   def initialize(entities, booking_location)
     @booking_location = booking_location
     @entities = entities
@@ -15,5 +17,5 @@ class LocationAwareEntities
 
   private
 
-  attr_reader :booking_location, :entities
+  attr_reader :booking_location
 end

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -9,9 +9,11 @@
 
 <div class="row">
   <div class="col-md-12">
-    <% if @booking_requests.empty? %>
+    <% if @booking_requests.all.empty? %>
       <p class="no-content t-notice">No booking requests requiring attention.</p>
     <% else %>
+      <%= paginate @booking_requests.entities %>
+
       <table class="table table-bordered">
         <thead>
           <tr class="table-header">
@@ -24,7 +26,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @booking_requests.each do |booking_request| %>
+          <% @booking_requests.all.each do |booking_request| %>
             <tr class="t-booking-request">
               <td>
                 <%= time_ago_in_words(booking_request.updated_at) %> ago
@@ -50,6 +52,8 @@
           <% end %>
         </tbody>
       </table>
+
+      <%= paginate @booking_requests.entities %>
     <% end %>
   </div>
 </div>

--- a/config/initializers/kaminari.rb
+++ b/config/initializers/kaminari.rb
@@ -1,0 +1,3 @@
+Kaminari.configure do |config|
+  config.default_per_page = 10
+end

--- a/spec/features/booking_manager_views_booking_requests_spec.rb
+++ b/spec/features/booking_manager_views_booking_requests_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Viewing Booking Requests' do
   end
 
   def and_there_are_booking_requests_for_their_location
-    create(:hackney_booking_request)
+    create_list(:hackney_booking_request, 11)
 
     # this won't be listed as it's not under Hackney
     create(:booking_request)
@@ -26,7 +26,7 @@ RSpec.feature 'Viewing Booking Requests' do
   def then_they_are_shown_booking_requests_for_their_locations
     @page = Pages::BookingRequests.new
     expect(@page).to be_displayed
-    expect(@page).to have_booking_requests(count: 1)
+    expect(@page).to have_booking_requests(count: 10)
     expect(@page).to have_content('Hackney')
   end
 end


### PR DESCRIPTION
Paginates the booking requests list with a default page size of 10.
Styled using the typical bootstrap 3 compatible kaminari views.

Rather than start delegating kaminari required things through the
decorated booking requests, I just exposed the underlying (undecorated)
arel and therefore kaminari paginateable thing.

![screen shot 2016-08-08 at 11 43 44](https://cloud.githubusercontent.com/assets/41963/17477478/6c5d1a74-5d5d-11e6-8f03-d3b3c1d2cd4b.png)
