### PR TITLE
Remove minimum permitted date

### DIFF
--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -129,7 +129,6 @@
           <%= f.label :date %>
           <%= f.date_field(
             :date,
-            min: @appointment_form.date,
             value: @appointment_form.date,
             class: 't-date form-control'
           ) %>


### PR DESCRIPTION
This was blocking the booking manager from fulfilling the booking
request with an appointment date prior to the customer's first selected
slot choice.