### PR TITLE
Paginate appointments

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -4,9 +4,9 @@ class AppointmentsController < ApplicationController
 
   def index
     @appointments = LocationAwareEntities.new(
-      current_user.appointments,
+      current_user.appointments.page(params[:page]),
       booking_location
-    ).all
+    )
   end
 
   def edit

--- a/app/models/location_aware_entities.rb
+++ b/app/models/location_aware_entities.rb
@@ -6,8 +6,8 @@ class LocationAwareEntities
     @entities = entities
   end
 
-  def all
-    @all ||= entities.map do |entity|
+  def page
+    @page ||= entities.map do |entity|
       LocationAwareEntity.new(
         booking_location: booking_location,
         entity: entity

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -9,7 +9,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <% if @appointments.all.empty? %>
+    <% if @appointments.page.empty? %>
       <p class="no-content t-notice">No appointments.</p>
     <% else %>
       <%= paginate @appointments.entities %>
@@ -28,7 +28,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @appointments.all.each do |appointment| %>
+          <% @appointments.page.each do |appointment| %>
             <tr class="t-appointment">
               <td>
                 <%= appointment.proceeded_at.strftime('%A, %b %e') %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -9,9 +9,11 @@
 
 <div class="row">
   <div class="col-md-12">
-    <% if @appointments.empty? %>
+    <% if @appointments.all.empty? %>
       <p class="no-content t-notice">No appointments.</p>
     <% else %>
+      <%= paginate @appointments.entities %>
+
       <table class="table table-bordered">
         <thead>
           <tr class="table-header">
@@ -26,7 +28,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @appointments.each do |appointment| %>
+          <% @appointments.all.each do |appointment| %>
             <tr class="t-appointment">
               <td>
                 <%= appointment.proceeded_at.strftime('%A, %b %e') %>
@@ -56,6 +58,8 @@
           <% end %>
         </tbody>
       </table>
+
+      <%= paginate @appointments.entities %>
     <% end %>
   </div>
 </div>

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -9,7 +9,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <% if @booking_requests.all.empty? %>
+    <% if @booking_requests.page.empty? %>
       <p class="no-content t-notice">No booking requests requiring attention.</p>
     <% else %>
       <%= paginate @booking_requests.entities %>
@@ -26,7 +26,7 @@
           </tr>
         </thead>
         <tbody>
-          <% @booking_requests.all.each do |booking_request| %>
+          <% @booking_requests.page.each do |booking_request| %>
             <tr class="t-booking-request">
               <td>
                 <%= time_ago_in_words(booking_request.updated_at) %> ago

--- a/spec/features/booking_manager_views_appointments_spec.rb
+++ b/spec/features/booking_manager_views_appointments_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Booking manager views appointments' do
   end
 
   def and_there_are_appointments_for_their_location
-    create(:appointment)
+    create_list(:appointment, 11)
 
     # this won't be listed as it's not in Hackney
     create(:appointment, booking_request: create(:booking_request))
@@ -23,7 +23,7 @@ RSpec.feature 'Booking manager views appointments' do
   def then_they_are_shown_appointments_for_their_location
     @page = Pages::Appointments.new
     expect(@page).to be_displayed
-    expect(@page).to have_appointments(count: 1)
+    expect(@page).to have_appointments(count: 10)
     expect(@page).to have_content('Hackney')
   end
 end

--- a/spec/models/location_aware_entities_spec.rb
+++ b/spec/models/location_aware_entities_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe LocationAwareEntities do
 
   subject { described_class.new(booking_requests, booking_location) }
 
-  describe '#all' do
+  describe '#page' do
     it 'returns decorated booking requests' do
-      expect(subject.all.map(&:class)).to match_array(LocationAwareEntity)
+      expect(subject.page.map(&:class)).to match_array(LocationAwareEntity)
     end
   end
 end


### PR DESCRIPTION
Paginates appointments the same as booking requests.

Also improve naming for paging: `#all` doesn't make much sense now we're
actually returning a paginated set. This improves the naming and makes it more
obvious what we're dealing with in the front end.