### PR TITLE
Tag emails with environment they were sent from

### DIFF
--- a/lib/mailgun_headers.rb
+++ b/lib/mailgun_headers.rb
@@ -8,7 +8,8 @@ module MailgunHeaders
   def headers_hash(message_type)
     {
       online_booking: true,
-      message_type: message_type
+      message_type: message_type,
+      environment: Rails.env
     }.to_json
   end
 end

--- a/spec/support/shared_examples_for_mailers.rb
+++ b/spec/support/shared_examples_for_mailers.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples 'mailgun identified email' do
   it 'renders the mailgun identification header' do
     expect(mail['X-Mailgun-Variables'].value).to include('"online_booking":true')
+    expect(mail['X-Mailgun-Variables'].value).to include('"environment":"test"')
   end
 end


### PR DESCRIPTION
As emails are delivered using the production mailgun environment,
this allows us to identify the source and whether to include them
in our dashboards.