### PR TITLE
Show environment label in navigation

### DIFF
--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,3 +1,5 @@
+GovukAdminTemplate.environment_style = ENV['RAILS_ENV']
+
 GovukAdminTemplate.configure do |c|
   c.app_title = 'Appointment Planner'
   c.show_flash = true


### PR DESCRIPTION
So we can easily distinguish between environments at a glance.