### PR TITLE
Corrects stats for fulfilment time

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -11,7 +11,7 @@ class Appointment < ActiveRecord::Base
     cancelled_by_pension_wise
   )
 
-  before_validation :calculate_statistics, if: :proceeded_at_changed?
+  before_save :calculate_statistics, if: :proceeded_at_changed?
 
   belongs_to :booking_request
 
@@ -37,10 +37,15 @@ class Appointment < ActiveRecord::Base
     calculate_fulfilment_window
   end
 
+  def created_at
+    super || Time.zone.now
+  end
+
   private
 
   def calculate_fulfilment_time
-    self.fulfilment_time_seconds = (proceeded_at.to_i - booking_request.created_at.to_i).abs
+    self.fulfilment_time_seconds =
+      (created_at.to_i - booking_request.created_at.to_i).abs
   end
 
   def calculate_fulfilment_window

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Appointment do
     expect(subject.reference).to eq(subject.booking_request.reference)
   end
 
+  it 'defaults `#created_at`' do
+    expect(described_class.new.created_at).to be_present
+  end
+
   describe '#fulfilment_time_seconds' do
     subject { build(:appointment) }
 
@@ -23,7 +27,7 @@ RSpec.describe Appointment do
         subject.save!
 
         expect(subject.fulfilment_time_seconds).to eq(
-          (subject.proceeded_at.to_i - subject.booking_request.created_at.to_i).abs
+          (subject.created_at.to_i - subject.booking_request.created_at.to_i).abs
         )
       end
     end


### PR DESCRIPTION
This should look to the difference between the `created_at` timestamps
of both the appointment and underlying booking request.

Since this calculation can be performed when the appointment is
initially persisted - and since Rails (rightly) doesn't default the
`created_at` timestamp we depend on for our calculation - I provided a
default value that serves this purpose. Rails will do the Right Thing
as far as setting this timestamp is concerned, after it is persisted.

Since the calculations are performed against seconds after the epoch
the potential for drift isn't something we should be concerned about.