### PR TITLE
Cascade booking request deletes to slots

### DIFF
--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -3,7 +3,7 @@ class BookingRequest < ActiveRecord::Base
 
   has_one :appointment
 
-  has_many :slots, -> { order(:priority) }
+  has_many :slots, -> { order(:priority) }, dependent: :destroy
 
   accepts_nested_attributes_for :slots, limit: 3, allow_destroy: false
 

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -76,10 +76,14 @@ RSpec.describe BookingRequest do
   end
 
   describe '#slots' do
-    it 'is returned in order of #priority' do
-      request = create(:booking_request)
+    let(:request) { create(:booking_request) }
 
+    it 'is returned in order of #priority' do
       expect(request.slots.pluck(:priority)).to eq([1, 2, 3])
+    end
+
+    it 'cascades deletes to the associated slots' do
+      expect { request.destroy }.to change { request.slots.count }.by(-3)
     end
   end
 end


### PR DESCRIPTION
We don't actually expose this functionality in the application (as-yet)
but it's helpful when deleting dud booking requests for maintenance.