### PR TITLE
Provide simple webhook support for statistics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ gem 'sidekiq'
 gem 'sinatra', require: false
 gem 'bugsnag'
 gem 'newrelic_rpm'
+gem 'faraday'
+gem 'faraday-conductivity'
+gem 'faraday_middleware'
 
 group :development, :test do
   gem 'capybara'
@@ -31,6 +34,10 @@ end
 group :development do
   gem 'rubocop'
   gem 'web-console', '~> 2.0'
+end
+
+group :test do
+  gem 'webmock'
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
@@ -81,6 +83,10 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday-conductivity (0.3.1)
+      faraday (~> 0.8)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
     foreman (0.78.0)
       thor (~> 0.19.1)
     gds-sso (12.1.0)
@@ -98,6 +104,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
+    hashdiff (0.3.0)
     hashie (3.4.4)
     i18n (0.7.0)
     jquery-rails (3.1.4)
@@ -219,6 +226,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.7.5)
+    safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -263,6 +271,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -276,6 +288,9 @@ DEPENDENCIES
   bugsnag
   capybara
   factory_girl_rails
+  faraday
+  faraday-conductivity
+  faraday_middleware
   foreman
   gds-sso
   govuk_admin_template
@@ -295,6 +310,7 @@ DEPENDENCIES
   site_prism
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  webmock
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/app/jobs/statistic_hooks_job.rb
+++ b/app/jobs/statistic_hooks_job.rb
@@ -1,0 +1,7 @@
+class StatisticHooksJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    BookingLocationStatistics.new.call
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ Bundler.require(*Rails.groups)
 
 module Planner
   class Application < Rails::Application
+    config.autoload_paths << Rails.root.join('lib')
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/lib/booking_location_statistics.rb
+++ b/lib/booking_location_statistics.rb
@@ -1,0 +1,16 @@
+class BookingLocationStatistics
+  def initialize(statistics_serializer = StatisticsSerializer.new, statistics_web_hook = StatisticsWebHook.new)
+    @statistics_serializer = statistics_serializer
+    @statistics_web_hook   = statistics_web_hook
+  end
+
+  def call
+    payload = statistics_serializer.json
+    statistics_web_hook.call(payload)
+  end
+
+  private
+
+  attr_reader :statistics_serializer
+  attr_reader :statistics_web_hook
+end

--- a/lib/statistics_serializer.rb
+++ b/lib/statistics_serializer.rb
@@ -1,0 +1,24 @@
+class StatisticsSerializer
+  def json
+    statistics.to_json(
+      only: [
+        :booking_location_id,
+        :average_fulfilment_time_seconds,
+        :average_window_time_seconds
+      ]
+    )
+  end
+
+  private
+
+  def statistics
+    Appointment
+      .joins(:booking_request)
+      .select(
+        :booking_location_id,
+        'avg(appointments.fulfilment_time_seconds) as average_fulfilment_time_seconds',
+        'avg(appointments.fulfilment_window_seconds) as average_window_time_seconds'
+      )
+      .group('booking_requests.booking_location_id')
+  end
+end

--- a/lib/statistics_web_hook.rb
+++ b/lib/statistics_web_hook.rb
@@ -1,0 +1,38 @@
+require 'faraday'
+require 'faraday/conductivity'
+
+class StatisticsWebHook
+  def initialize(hook_uri = ENV.fetch('STATISTICS_WEB_HOOK_URI'))
+    @hook_uri = hook_uri
+  end
+
+  def call(json_payload)
+    connection.post do |request|
+      request.body = json_payload
+    end
+  end
+
+  private
+
+  def connection
+    @connection ||= Faraday.new(connection_options) do |faraday|
+      faraday.request  :json
+      faraday.response :raise_error
+      faraday.response :json
+      faraday.use      :instrumentation
+      faraday.adapter  Faraday.default_adapter
+    end
+  end
+
+  def connection_options
+    {
+      url: hook_uri,
+      request: {
+        timeout:      ENV.fetch('STATISTICS_WEB_HOOK_TIMEOUT', 2),
+        open_timeout: ENV.fetch('STATISTICS_WEB_HOOK_OPEN_TIMEOUT', 2)
+      }
+    }
+  end
+
+  attr_reader :hook_uri
+end

--- a/spec/lib/booking_location_statistics_spec.rb
+++ b/spec/lib/booking_location_statistics_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe BookingLocationStatistics, '#call' do
+  let(:json) { '{}' }
+  let(:statistics_serializer) { instance_double(StatisticsSerializer) }
+  let(:webhook) { instance_double(StatisticsWebHook) }
+
+  before do
+    allow(statistics_serializer).to receive(:json).and_return(json)
+    allow(webhook).to receive(:call).with(json).and_return(true)
+
+    subject.call
+  end
+
+  subject { described_class.new(statistics_serializer, webhook) }
+
+  it 'retrieves the booking location statistics JSON' do
+    expect(statistics_serializer).to have_received(:json)
+  end
+
+  it 'calls the webhook with the JSON payload' do
+    expect(webhook).to have_received(:call).with(json)
+  end
+end

--- a/spec/lib/statistics_serializer_spec.rb
+++ b/spec/lib/statistics_serializer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe StatisticsSerializer, '#json' do
+  before do
+    create_list(:appointment, 2).each do |appointment|
+      # force persistence for these statistics that would otherwise
+      # be overwritten by the `#calculate_statistics` callback
+      appointment.update_columns(fulfilment_time_seconds: 1, fulfilment_window_seconds: 10)
+    end
+  end
+
+  subject { JSON.parse(described_class.new.json) }
+
+  it 'returns fulfilment statistics as JSON' do
+    expect(subject.first).to eq(
+      'booking_location_id' => 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
+      'average_fulfilment_time_seconds' => '1.0',
+      'average_window_time_seconds' => '10.0'
+    )
+  end
+end

--- a/spec/lib/statistics_web_hook_spec.rb
+++ b/spec/lib/statistics_web_hook_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe StatisticsWebHook, '#call' do
+  subject { described_class.new }
+
+  context 'when a hook URI is unconfigured' do
+    it 'raises an error' do
+      expect { subject }.to raise_error(IndexError)
+    end
+  end
+
+  context 'when a hook URI is configured' do
+    let(:json) { Hash[thing: true] }
+
+    let!(:request) do
+      stub_request(:post, 'https://example.com/')
+        .with(
+          body: json.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        ).to_return(status: status_code)
+    end
+
+    subject { described_class.new('https://example.com') }
+
+    context 'when successful' do
+      let(:status_code) { 200 }
+
+      it 'POSTs the provided JSON payload to the hook URI' do
+        subject.call(json)
+
+        expect(request).to have_been_requested
+      end
+    end
+
+    context 'when not successful' do
+      let(:status_code) { 500 }
+
+      it 'raises an error' do
+        expect { subject.call(json) }.to raise_error(Faraday::ClientError)
+      end
+    end
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,3 @@
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
This simply calculates the averages for fulfilment timings and the
window of time between the appointment date and the customer's first
selected slot -- per booking location.

This is then sent POSTed to the configured `STATISTICS_WEB_HOOK_URI` as
a JSON payload. Upon receipt of a non-successful status code it throws
an error. This would be handled during retries, since this would be
scheduled to execute in the context of a sidekiq worker.

Timeouts for the hook can be configured using
`STATISTICS_WEB_HOOK_TIMEOUT` and `STATISTICS_WEB_HOOK_OPEN_TIMEOUT`.

This can be scheduled with `bundle exec rails runner 'StatisticHooksJob.perform_later'`