### PR TITLE
Web hook improvements

### DIFF
--- a/lib/statistics_web_hook.rb
+++ b/lib/statistics_web_hook.rb
@@ -28,8 +28,8 @@ class StatisticsWebHook
     {
       url: hook_uri,
       request: {
-        timeout:      ENV.fetch('STATISTICS_WEB_HOOK_TIMEOUT', 2),
-        open_timeout: ENV.fetch('STATISTICS_WEB_HOOK_OPEN_TIMEOUT', 2)
+        timeout:      Integer(ENV.fetch('STATISTICS_WEB_HOOK_TIMEOUT', 2)),
+        open_timeout: Integer(ENV.fetch('STATISTICS_WEB_HOOK_OPEN_TIMEOUT', 2))
       }
     }
   end

--- a/lib/statistics_web_hook.rb
+++ b/lib/statistics_web_hook.rb
@@ -18,7 +18,6 @@ class StatisticsWebHook
     @connection ||= Faraday.new(connection_options) do |faraday|
       faraday.request  :json
       faraday.response :raise_error
-      faraday.response :json
       faraday.use      :instrumentation
       faraday.adapter  Faraday.default_adapter
     end

--- a/spec/lib/statistics_web_hook_spec.rb
+++ b/spec/lib/statistics_web_hook_spec.rb
@@ -11,13 +11,17 @@ RSpec.describe StatisticsWebHook, '#call' do
 
   context 'when a hook URI is configured' do
     let(:json) { Hash[thing: true] }
+    let(:body) { '<html/>' }
 
     let!(:request) do
       stub_request(:post, 'https://example.com/')
         .with(
           body: json.to_json,
           headers: { 'Content-Type' => 'application/json' }
-        ).to_return(status: status_code)
+        ).to_return(
+          status: status_code,
+          body: body
+        )
     end
 
     subject { described_class.new('https://example.com') }


### PR DESCRIPTION
The google sheets API was returning HTML but we were trying to parse this
as JSON. We can rely on a successful status code, the response body is not
important.

Faraday doesn't coerce options from strings. Derp.