### PR TITLE
Update `audited` dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby IO.read('.ruby-version').strip
 
-gem 'audited-activerecord'
+gem 'audited', github: 'collectiveidea/audited', ref: '3b4b79d'
 gem 'booking_locations'
 gem 'gds-sso'
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git://github.com/collectiveidea/audited.git
+  revision: 3b4b79ddebc34729dd3e5bb9aa5ee2a7605076c0
+  ref: 3b4b79d
+  specs:
+    audited (4.2.0)
+      activerecord (>= 4.0, < 5.1)
+      rails-observers (~> 0.1.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -39,11 +48,6 @@ GEM
     addressable (2.4.0)
     arel (6.0.3)
     ast (2.2.0)
-    audited (4.2.1)
-      rails-observers (~> 0.1.2)
-    audited-activerecord (4.2.1)
-      activerecord (~> 4.0)
-      audited (= 4.2.1)
     autoprefixer-rails (6.3.6)
       execjs
     binding_of_caller (0.7.2)
@@ -282,7 +286,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  audited-activerecord
+  audited!
   booking_locations
   bootstrap-kaminari-views
   bugsnag


### PR DESCRIPTION
This is to make way for changes I am making for the activity feed. To
make audit's entries work polymorphically for activities.

The prior version of `audited` was directly mixed in to
`ActiveRecord::Base` as a module so wasn't (at least easily, without
hacks) possible to latently hook the `after_create` for audit entries.

I'll need to reopen the `Audited::Audit` class to add an `after_create`
handler responsible for the creation of the activity entries.

This may seem a fair bit of juggling just to get audits to work as
activities polymorphically, but since audits will eventually make such
a small part of activity type events and we have auditing working
nicely it seems legit to me.