### PR TITLE
Ensure statistics fields are not audited

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,5 +1,5 @@
 class Appointment < ActiveRecord::Base
-  audited on: [:update]
+  audited on: [:update], except: %i(fulfilment_time_seconds fulfilment_window_seconds)
 
   enum status: %i(
     pending

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -67,6 +67,15 @@ RSpec.describe Appointment do
       expect(original).to be_updated
     end
 
+    it 'does not audit changes to statistics attributes' do
+      original.update(
+        fulfilment_time_seconds: 1,
+        fulfilment_window_seconds: 1
+      )
+
+      expect(original.audits).to be_empty
+    end
+
     describe '#notify?' do
       context 'when the status was changed' do
         it 'returns false' do


### PR DESCRIPTION
We don't need to track the changes to these fields and their presence
in the audit history will bust up presentation of the activity feed so
I've excluded them.

I'll remove any existing ones separately as this only affects the
production environment.