### PR TITLE
Show appointment edits as activities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,9 @@ group :development do
 end
 
 group :test do
+  gem 'database_cleaner'
   gem 'webmock'
+  gem 'poltergeist'
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,18 +67,20 @@ GEM
     bugsnag (4.2.1)
     builder (3.2.2)
     byebug (8.2.4)
-    capybara (2.7.1)
+    capybara (2.8.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
@@ -167,6 +169,10 @@ GEM
     phantomjs (1.9.8.0)
     pkg-config (1.1.7)
     plek (1.12.0)
+    poltergeist (1.10.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -294,6 +300,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -306,6 +315,7 @@ DEPENDENCIES
   bootstrap-kaminari-views
   bugsnag
   capybara
+  database_cleaner
   factory_girl_rails
   faraday
   faraday-conductivity
@@ -320,6 +330,7 @@ DEPENDENCIES
   pg (~> 0.15)
   phantomjs (= 1.9.8.0)
   plek
+  poltergeist
   pry-byebug
   puma
   rails (= 4.2.7.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,13 +1,4 @@
-// This is a manifest file that'll be compiled into application.js, which will include all the files
-// listed below.
-//
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or any plugin's vendor/assets/javascripts directory can be referenced here using a relative path.
-//
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// compiled file.
-//
-// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
-// about supported directives.
-//
+//= require jquery
 //= require_tree .
+
+PWPlanner.poller.init();

--- a/app/assets/javascripts/collapse.js
+++ b/app/assets/javascripts/collapse.js
@@ -1,0 +1,11 @@
+(function($) {
+  var $collapseItems = $('main [data-toggle="collapse"]');
+  $collapseItems.removeClass('hidden');
+
+  $collapseItems.each(function() {
+    $item = $(this);
+    var targetId = $item.attr('data-target') || $item.attr('href');
+
+    $(targetId).addClass('collapse');
+  });
+})(jQuery);

--- a/app/assets/javascripts/poller.js
+++ b/app/assets/javascripts/poller.js
@@ -1,0 +1,58 @@
+(function($) {
+  'use strict';
+
+  var poller = {
+    init: function() {
+      this.$poller = $('.js-poller');
+
+      if (this.$poller.length) {
+        this.setLast(this.timestamp());
+        this.start();
+      }
+    },
+
+    start: function() {
+      setInterval($.proxy(this.poll, this), this.interval());
+    },
+
+    poll: function() {
+      $.ajax({ url: this.url(), data: { timestamp: this.getLast() } })
+       .always($.proxy(this.handleResponse, this));
+    },
+
+    handleResponse: function(data, status, request) {
+      if (request.status == 200) {
+        this.setLast(this.timestamp());
+        this.insertActivity(data);
+      }
+    },
+
+    setLast: function(value) {
+      this._last = value;
+    },
+
+    getLast: function() {
+      return this._last;
+    },
+
+    insertActivity: function(text) {
+      $(text).hide().prependTo(this.$poller).fadeIn();
+    },
+
+    timestamp: function() {
+      return new Date().valueOf();
+    },
+
+    interval: function() {
+      return this.$poller.data('interval');
+    },
+
+    url: function() {
+      return this.$poller.data('url');
+    }
+  };
+
+  window.PWPlanner = window.PWPlanner || {};
+  window.PWPlanner.poller = poller;
+
+})(jQuery);

--- a/app/assets/stylesheets/components/_activity-feed.scss
+++ b/app/assets/stylesheets/components/_activity-feed.scss
@@ -1,0 +1,8 @@
+.activity-feed {
+
+}
+
+.activity-feed__table {
+  border: 1px solid #ebebeb;
+  border-width: 0 1px 1px;
+}

--- a/app/assets/stylesheets/components/_activity-feed.scss
+++ b/app/assets/stylesheets/components/_activity-feed.scss
@@ -2,7 +2,28 @@
 
 }
 
-.activity-feed__table {
+.activity-feed__list {
   border: 1px solid #ebebeb;
-  border-width: 0 1px 1px;
+  border-width: 1px 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  & + & {
+    border-width: 0;
+  }
+}
+
+.activity-feed__item {
+    border: 1px solid #ebebeb;
+    border-width: 0 1px;
+    padding: 6px;
+
+    & + & {
+      border-width: 1px;
+    }
+}
+
+.activity-feed__btn {
+  margin-top: 5px;
 }

--- a/app/assets/stylesheets/helpers/_borders.scss
+++ b/app/assets/stylesheets/helpers/_borders.scss
@@ -1,0 +1,5 @@
+.border-bottom {
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid #ebebeb;
+}

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,22 @@
+class ActivitiesController < ApplicationController
+  def index
+    @activities = booking_request.activities.since(since)
+
+    if @activities.present?
+      render partial: @activities
+    else
+      head :not_modified
+    end
+  end
+
+  private
+
+  def since
+    timestamp = params[:timestamp].to_i / 1000
+    Time.zone.at(timestamp)
+  end
+
+  def booking_request
+    current_user.booking_requests.find(params[:booking_request_id])
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,11 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def poll_interval_milliseconds
+    Integer(ENV.fetch(Activity::POLLING_KEY, 5000))
+  end
+  helper_method :poll_interval_milliseconds
+
   def booking_location
     @booking_location ||= BookingLocations.find(current_user.booking_location_id)
   end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -10,6 +10,7 @@ class AppointmentsController < ApplicationController
   end
 
   def edit
+    @activities = location_aware_appointment.activities
   end
 
   def update

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,12 @@
+class Activity < ActiveRecord::Base
+  belongs_to :booking_request
+  belongs_to :user
+
+  def owner_name
+    user ? user.name : 'Someone'
+  end
+
+  def to_partial_path
+    "activities/#{model_name.singular}"
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,6 +1,10 @@
 class Activity < ActiveRecord::Base
+  POLLING_KEY = 'POLL_INTERVAL_MILLISECONDS'.freeze
+
   belongs_to :booking_request
   belongs_to :user
+
+  scope :since, -> (since) { where('created_at > ?', since) }
 
   def owner_name
     user ? user.name : 'Someone'

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -15,7 +15,7 @@ class Appointment < ActiveRecord::Base
 
   belongs_to :booking_request
 
-  delegate :reference, to: :booking_request
+  delegate :reference, :activities, to: :booking_request
 
   validates :name, presence: true
   validates :email, presence: true
@@ -42,6 +42,10 @@ class Appointment < ActiveRecord::Base
   end
 
   private
+
+  def after_audit
+    AuditActivity.from(audits.last, booking_request)
+  end
 
   def calculate_fulfilment_time
     self.fulfilment_time_seconds =

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,5 +1,5 @@
 class Appointment < ActiveRecord::Base
-  audited on: [:update], except: %i(fulfilment_time_seconds fulfilment_window_seconds)
+  audited on: :update, except: %i(fulfilment_time_seconds fulfilment_window_seconds)
 
   enum status: %i(
     pending

--- a/app/models/audit_activity.rb
+++ b/app/models/audit_activity.rb
@@ -1,0 +1,9 @@
+class AuditActivity < Activity
+  def self.from(audit, booking_request)
+    create!(
+      user_id: audit.user_id,
+      message: audit.audited_changes.keys.map(&:humanize).to_sentence.downcase,
+      booking_request_id: booking_request.id
+    )
+  end
+end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -5,6 +5,8 @@ class BookingRequest < ActiveRecord::Base
 
   has_many :slots, -> { order(:priority) }, dependent: :destroy
 
+  has_many :activities, -> { order('created_at DESC') }
+
   accepts_nested_attributes_for :slots, limit: 3, allow_destroy: false
 
   validates :name, presence: true

--- a/app/views/activities/_audit_activity.html.erb
+++ b/app/views/activities/_audit_activity.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="t-activity">
-    <span class="glyphicon glyphicon-pencil"></span>
+    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
     <b><%= audit_activity.owner_name %></b> changed the <%= audit_activity.message %> <em class="badge"><%= time_ago_in_words(audit_activity.created_at) %> ago</em>
   </td>
 </tr>

--- a/app/views/activities/_audit_activity.html.erb
+++ b/app/views/activities/_audit_activity.html.erb
@@ -1,6 +1,4 @@
-<tr>
-  <td class="t-activity">
-    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-    <b><%= audit_activity.owner_name %></b> changed the <%= audit_activity.message %> <em class="badge"><%= time_ago_in_words(audit_activity.created_at) %> ago</em>
-  </td>
-</tr>
+<li class="activity-feed__item t-activity">
+  <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+  <b><%= audit_activity.owner_name %></b> changed the <%= audit_activity.message %> <em class="badge"><%= time_ago_in_words(audit_activity.created_at) %> ago</em>
+</li>

--- a/app/views/activities/_audit_activity.html.erb
+++ b/app/views/activities/_audit_activity.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td class="t-activity">
+    <span class="glyphicon glyphicon-pencil"></span>
+    <b><%= audit_activity.owner_name %></b> changed the <%= audit_activity.message %> <em class="badge"><%= time_ago_in_words(audit_activity.created_at) %> ago</em>
+  </td>
+</tr>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -19,6 +19,21 @@
       <div class="activity-feed t-activity-feed">
         <table class="activity-feed__table table">
           <%= render @activities.first %>
+
+          <% if @activities.count > 1 %>
+            <tbody class="collapse t-hidden-activities" id="collapse">
+              <%= render(@activities - Array(@activities.first)) %>
+            </tbody>
+
+            <tr>
+              <td>
+                <a class="t-further-activities" role="button" data-toggle="collapse" href="#collapse" aria-expanded="false" aria-controls="collapseExample">
+                  <span class="glyphicon glyphicon-th-list" aria-hidden="true"></span>
+                  All activity
+                </a>
+              </td>
+            </tr>
+          <% end %>
         </table>
       </div>
     <% else %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -17,27 +17,20 @@
 
     <% if @activities.present? %>
       <div class="activity-feed t-activity-feed">
-        <table class="activity-feed__table table js-poller"
+        <ul class="activity-feed__list js-poller"
            data-interval="<%= poll_interval_milliseconds %>"
            data-url="<%= booking_request_activities_path(@appointment_form.booking_request) %>">
-
           <%= render @activities.first %>
-
-          <% if @activities.count > 1 %>
-            <tbody class="collapse t-hidden-activities" id="collapse">
-              <%= render(@activities - Array(@activities.first)) %>
-            </tbody>
-
-            <tr>
-              <td>
-                <a class="t-further-activities" role="button" data-toggle="collapse" href="#collapse" aria-expanded="false" aria-controls="collapseExample">
-                  <span class="glyphicon glyphicon-th-list" aria-hidden="true"></span>
-                  All activity
-                </a>
-              </td>
-            </tr>
-          <% end %>
-        </table>
+        </ul>
+        <% if @activities.count > 1 %>
+          <ul class="activity-feed__list t-hidden-activities" id="collapse">
+            <%= render(@activities - Array(@activities.first)) %>
+          </ul>
+          <button class="activity-feed__btn btn btn-default t-further-activities hidden" data-target="#collapse" data-toggle="collapse" aria-expanded="false" aria-controls="collapse">
+            <span class="glyphicon glyphicon-th-list" aria-hidden="true"></span>
+            All activity
+          </button>
+        <% end %>
       </div>
     <% else %>
       <p>No activities.</p>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -12,6 +12,22 @@
 </div>
 
 <div class="row">
+  <div class="col-md-12 border-bottom">
+    <h3>Recent activity</h3>
+
+    <% if @activities.present? %>
+      <div class="activity-feed t-activity-feed">
+        <table class="activity-feed__table table">
+          <%= render @activities.first %>
+        </table>
+      </div>
+    <% else %>
+      <p>No activities.</p>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
   <div class="col-md-4">
     <h3>Change appointment details</h3>
     <p class="lead">Use the form below to change the details of the appointment.</p>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -17,7 +17,10 @@
 
     <% if @activities.present? %>
       <div class="activity-feed t-activity-feed">
-        <table class="activity-feed__table table">
+        <table class="activity-feed__table table js-poller"
+           data-interval="<%= poll_interval_milliseconds %>"
+           data-url="<%= booking_request_activities_path(@appointment_form.booking_request) %>">
+
           <%= render @activities.first %>
 
           <% if @activities.count > 1 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   resources :appointments, only: %i(index edit update)
 
   resources :booking_requests, only: :index do
+    resources :activities, only: :index
+
     resources :appointments, only: %i(new create)
   end
 

--- a/db/migrate/20160823125447_create_activities.rb
+++ b/db/migrate/20160823125447_create_activities.rb
@@ -1,0 +1,14 @@
+class CreateActivities < ActiveRecord::Migration
+  def change
+    create_table :activities do |t|
+      t.string :message, null: false
+      t.references :user
+      t.references :booking_request, null: false
+      t.string :type, null: false
+
+      t.timestamps null: false
+
+      t.index %w(booking_request_id type)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160810103222) do
+ActiveRecord::Schema.define(version: 20160823125447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "activities", force: :cascade do |t|
+    t.string   "message",            null: false
+    t.integer  "user_id"
+    t.integer  "booking_request_id", null: false
+    t.string   "type",               null: false
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+  end
+
+  add_index "activities", ["booking_request_id", "type"], name: "index_activities_on_booking_request_id_and_type", using: :btree
 
   create_table "appointments", force: :cascade do |t|
     t.integer  "booking_request_id",                    null: false

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     user
     booking_request
     message 'did a thing to a thing'
+    type 'AuditActivity'
   end
 end

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :activity do
+    user
+    booking_request
+    message 'did a thing to a thing'
+  end
+end

--- a/spec/features/booking_manager_views_booking_activities_spec.rb
+++ b/spec/features/booking_manager_views_booking_activities_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
-RSpec.feature 'Booking Manager views Booking / Appointment Activities' do
+RSpec.feature 'Booking Manager views Booking / Appointment Activities', js: true do
   scenario 'Viewing activities from an Appointment' do
     given_the_user_identifies_as_hackneys_booking_manager do
       and_there_is_an_appointment_for_their_location
       and_the_appointment_was_updated_multiple_times
       when_they_view_the_appointment
-      then_they_see_the_update_displayed_as_an_activity
+      then_they_see_the_last_activity
+      when_they_request_further_activities
+      then_they_see_all_the_activities
     end
   end
 
@@ -27,9 +29,23 @@ RSpec.feature 'Booking Manager views Booking / Appointment Activities' do
     @page.load(id: @appointment.id)
   end
 
-  def then_they_see_the_update_displayed_as_an_activity
+  def then_they_see_the_last_activity
     @page.activity_feed.tap do |feed|
       expect(feed).to have_activities(count: 1)
+      expect(feed.activities.first).to have_text('email')
+    end
+  end
+
+  def when_they_request_further_activities
+    @page.activity_feed.further_activities.click
+  end
+
+  def then_they_see_all_the_activities
+    @page.activity_feed.tap do |feed|
+      feed.wait_for_hidden_activities
+
+      expect(feed).to have_activities(count: 2)
+      expect(feed.activities.last).to have_text('name')
     end
   end
 end

--- a/spec/features/booking_manager_views_booking_activities_spec.rb
+++ b/spec/features/booking_manager_views_booking_activities_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.feature 'Booking Manager views Booking / Appointment Activities' do
+  scenario 'Viewing activities from an Appointment' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_is_an_appointment_for_their_location
+      and_the_appointment_was_updated_multiple_times
+      when_they_view_the_appointment
+      then_they_see_the_update_displayed_as_an_activity
+    end
+  end
+
+  def and_there_is_an_appointment_for_their_location
+    @appointment = create(:appointment)
+  end
+
+  def and_the_appointment_was_updated_multiple_times
+    @appointment.name = 'Mortimer Birdperson'
+    @appointment.save!
+
+    @appointment.email = 'mortimer@example.com'
+    @appointment.save!
+  end
+
+  def when_they_view_the_appointment
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def then_they_see_the_update_displayed_as_an_activity
+    @page.activity_feed.tap do |feed|
+      expect(feed).to have_activities(count: 1)
+    end
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Activity do
+  describe '#owner_name' do
+    context 'when it has no associated user' do
+      subject { build_stubbed(:activity, user: nil) }
+
+      it 'returns a place holder' do
+        expect(subject.owner_name).to eq('Someone')
+      end
+    end
+
+    context 'when it has an associated user' do
+      subject { build(:activity) }
+
+      it 'returns the name of the associated user' do
+        expect(subject.owner_name).to eq(subject.user.name)
+      end
+    end
+  end
+end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Appointment do
     expect(subject.reference).to eq(subject.booking_request.reference)
   end
 
+  it 'delegates `#activities` to the `booking_request`' do
+    expect(subject.activities).to eq(subject.booking_request.activities)
+  end
+
   it 'defaults `#created_at`' do
     expect(described_class.new.created_at).to be_present
   end
@@ -65,6 +69,10 @@ RSpec.describe Appointment do
 
       expect(original.audits).to be_present
       expect(original).to be_updated
+    end
+
+    it 'creates an activity linking to the audited entry' do
+      expect { original.update(name: 'Mr. Meseeks') }.to change { original.activities.count }.by(1)
     end
 
     it 'does not audit changes to statistics attributes' do

--- a/spec/models/audit_activity_spec.rb
+++ b/spec/models/audit_activity_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe AuditActivity do
+  describe '.from' do
+    before do
+      @appointment = create(:appointment).tap do |a|
+        # this will trigger the `after_audit` hook on `Appointment`
+        a.update(
+          name: 'Dave Jones',
+          email: 'dj@dj.com',
+          phone: '07715 930 455'
+        )
+      end
+    end
+
+    let(:audit) { @appointment.audits.last }
+
+    subject { @appointment.activities.last }
+
+    it 'creates an audit activity from the given audit' do
+      expect(subject).to be_a(described_class)
+
+      expect(subject).to have_attributes(
+        user_id: audit.user_id,
+        booking_request_id: @appointment.booking_request.id,
+        message: 'name, email, and phone'
+      )
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rails'
+require 'database_cleaner'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
@@ -14,7 +15,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,17 @@
+RSpec.configure do |config|
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) { DatabaseCleaner.clean_with :truncation }
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = if Capybara.current_driver == :rack_test
+                                 :transaction
+                               else
+                                 :truncation
+                               end
+
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) { DatabaseCleaner.clean }
+end

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -1,3 +1,6 @@
+require_relative '../sections/activity'
+require_relative '../sections/activity_feed'
+
 module Pages
   class EditAppointment < SitePrism::Page
     set_url '/appointments/{id}/edit'
@@ -26,5 +29,7 @@ module Pages
 
     elements :errors, '.field_with_errors'
     element :error_summary, '.t-errors'
+
+    section :activity_feed, Sections::ActivityFeed, '.t-activity-feed'
   end
 end

--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -1,4 +1,4 @@
 require 'capybara/poltergeist'
 
 Capybara.javascript_driver = :poltergeist
-Capybara.default_max_wait_time = 10
+Capybara.default_max_wait_time = 20

--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -1,0 +1,4 @@
+require 'capybara/poltergeist'
+
+Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 10

--- a/spec/support/sections/activity.rb
+++ b/spec/support/sections/activity.rb
@@ -1,0 +1,4 @@
+module Sections
+  class Activity < SitePrism::Section
+  end
+end

--- a/spec/support/sections/activity_feed.rb
+++ b/spec/support/sections/activity_feed.rb
@@ -1,0 +1,5 @@
+module Sections
+  class ActivityFeed < SitePrism::Section
+    sections :activities, Sections::Activity, '.t-activity'
+  end
+end

--- a/spec/support/sections/activity_feed.rb
+++ b/spec/support/sections/activity_feed.rb
@@ -1,5 +1,8 @@
 module Sections
   class ActivityFeed < SitePrism::Section
     sections :activities, Sections::Activity, '.t-activity'
+
+    element :further_activities, '.t-further-activities'
+    element :hidden_activities, '.t-hidden-activities'
   end
 end


### PR DESCRIPTION
Converts and displays appointment edits (provided by `audited`) as
activities in the feed.

I went with an STI approach to make the addition of further activity types
easier in future. Having the activity `message` as simple text affords us
lots of possibilities / control over how and what we display as the
activity summary.

The activities themselves are linked to the booking request and an owning
user. For those activities that do not have a natural owner, we display
'Somebody' as a placeholder.


