### PR TITLE
Don't run travis on `prototypes/*` branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ node_js:
 before_script:
 - npm install
 - bundle exec rake db:create db:migrate RAILS_ENV=test
+branches:
+  except:
+    - /^prototypes\/.*$/


### PR DESCRIPTION
Stop Travis reporting build failures while we develop prototype features.