### PR TITLE
Handle incoming bounce webhooks from MailGun

### DIFF
--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -14,6 +14,7 @@ module MailGun
         :event,
         :recipient,
         :description,
+        :message_type,
         :timestamp,
         :token,
         :signature

--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -1,0 +1,23 @@
+module MailGun
+  class DropsController < ActionController::Base
+    def create
+      form = DropForm.new(drop_params)
+      form.create_activity
+
+      head :created
+    end
+
+    private
+
+    def drop_params
+      params.permit(
+        :event,
+        :recipient,
+        :description,
+        :timestamp,
+        :token,
+        :signature
+      )
+    end
+  end
+end

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -8,6 +8,7 @@ class DropForm
   attr_accessor :event
   attr_accessor :recipient
   attr_accessor :description
+  attr_accessor :message_type
   attr_accessor :timestamp
   attr_accessor :token
   attr_accessor :signature
@@ -19,9 +20,10 @@ class DropForm
   def create_activity
     verify_token!
 
-    DropActivity.create(
-      booking_request: booking_request,
-      message: description
+    DropActivity.from(
+      message_type,
+      description,
+      booking_request
     )
   end
 

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -1,0 +1,47 @@
+require 'openssl'
+
+TokenVerificationFailure = Class.new(StandardError)
+
+class DropForm
+  include ActiveModel::Model
+
+  attr_accessor :event
+  attr_accessor :recipient
+  attr_accessor :description
+  attr_accessor :timestamp
+  attr_accessor :token
+  attr_accessor :signature
+
+  validates :timestamp, presence: true
+  validates :token, presence: true
+  validates :signature, presence: true
+
+  def create_activity
+    verify_token!
+
+    DropActivity.create(
+      booking_request: booking_request,
+      message: description
+    )
+  end
+
+  private
+
+  def booking_request
+    BookingRequest.latest(recipient)
+  end
+
+  # rubocop:disable Style/GuardClause
+  def verify_token!
+    digest = OpenSSL::Digest::SHA256.new
+    data   = timestamp + token
+
+    unless valid? && signature == OpenSSL::HMAC.hexdigest(digest, api_token, data)
+      raise TokenVerificationFailure
+    end
+  end
+
+  def api_token
+    ENV['MAILGUN_API_TOKEN']
+  end
+end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -21,6 +21,8 @@ class BookingRequest < ActiveRecord::Base
   validates :defined_contribution_pot, inclusion: { in: [true, false] }
   validate :validate_slots
 
+  scope :latest, ->(email) { where(email: email).order(:created_at).last }
+
   alias reference to_param
 
   def primary_slot

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -1,2 +1,14 @@
 class DropActivity < Activity
+  def self.from(message_type, description, booking_request)
+    create(
+      message: "#{message_from(message_type)}#{description}",
+      booking_request_id: booking_request.id
+    )
+  end
+
+  def self.message_from(message_type)
+    return '' unless message_type
+
+    message_type.humanize.downcase + ' - '
+  end
 end

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -1,0 +1,2 @@
+class DropActivity < Activity
+end

--- a/app/views/activities/_drop_activity.html.erb
+++ b/app/views/activities/_drop_activity.html.erb
@@ -1,0 +1,4 @@
+<li class="activity-feed__item t-activity" id="activity-<%= drop_activity.id %>">
+  <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+  <b>Delivery failure</b> <em><%= drop_activity.message %></em> <em class="badge"><%= time_ago_in_words(drop_activity.created_at) %> ago</em>
+</li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  namespace :mail_gun do
+    resources :drops, only: :create
+  end
+
   resources :appointments, only: %i(index edit update)
 
   resources :booking_requests, only: :index do

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DropForm, '#create_activity' do
       'event' => 'dropped',
       'recipient' => 'morty@example.com',
       'description' => 'the reasoning',
+      'message_type' => 'customer_booking_request',
       'timestamp' => '1474638633',
       'token' => 'secret',
       'signature' => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
@@ -37,10 +38,13 @@ RSpec.describe DropForm, '#create_activity' do
 
   context 'when the signature is verified' do
     it 'creates the drop activity' do
-      expect(subject.create_activity).to have_attributes(
-        booking_request_id: booking_request.id,
-        message: params['description']
+      expect(DropActivity).to receive(:from).with(
+        params['message_type'],
+        params['description'],
+        booking_request
       )
+
+      subject.create_activity
     end
   end
 end

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe DropForm, '#create_activity' do
+  let!(:booking_request) { create(:hackney_booking_request) }
+  let(:params) do
+    {
+      'event' => 'dropped',
+      'recipient' => 'morty@example.com',
+      'description' => 'the reasoning',
+      'timestamp' => '1474638633',
+      'token' => 'secret',
+      'signature' => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+    }
+  end
+  let(:token) { 'deadbeef' }
+
+  around do |example|
+    begin
+      existing = ENV['MAILGUN_API_TOKEN']
+
+      ENV['MAILGUN_API_TOKEN'] = token
+      example.run
+    ensure
+      ENV['MAILGUN_API_TOKEN'] = existing
+    end
+  end
+
+  subject { described_class.new(params) }
+
+  context 'when the signature is not verified' do
+    it 'raises an error' do
+      params['signature'] = 'whoops'
+
+      expect { subject.create_activity }.to raise_error(TokenVerificationFailure)
+    end
+  end
+
+  context 'when the signature is verified' do
+    it 'creates the drop activity' do
+      expect(subject.create_activity).to have_attributes(
+        booking_request_id: booking_request.id,
+        message: params['description']
+      )
+    end
+  end
+end

--- a/spec/models/drop_activity_spec.rb
+++ b/spec/models/drop_activity_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe DropActivity, '.from' do
+  let(:message_type) { 'customer_online_booking' }
+  let(:message) { 'the message' }
+  let(:booking_request) { create(:hackney_booking_request) }
+
+  subject do
+    described_class.from(message_type, message, booking_request)
+  end
+
+  context 'without a `message_type`' do
+    let(:message_type) { nil }
+
+    it 'does not include the email message type' do
+      expect(subject.message).to eq('the message')
+    end
+  end
+
+  context 'with a `message_type`' do
+    it 'includes the email message type' do
+      expect(subject.message).to eq('customer online booking - the message')
+    end
+  end
+end

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /mail_gun/drops' do
+  scenario 'inbound hooks create activity entries' do
+    with_a_configured_token('deadbeef') do
+      given_a_hackney_booking_request
+      when_mail_gun_posts_a_drop_notification
+      then_an_activity_is_created
+      and_the_service_responds_with_a_201
+    end
+  end
+
+  def with_a_configured_token(token)
+    existing = ENV['MAILGUN_API_TOKEN']
+
+    ENV['MAILGUN_API_TOKEN'] = token
+    yield
+  ensure
+    ENV['MAILGUN_API_TOKEN'] = existing
+  end
+
+  def given_a_hackney_booking_request
+    @booking_request = create(:hackney_booking_request)
+  end
+
+  def when_mail_gun_posts_a_drop_notification
+    post mail_gun_drops_path, params: {
+      'event' => 'dropped',
+      'recipient' => 'morty@example.com',
+      'description' => 'the reasoning',
+      'timestamp' => '1474638633',
+      'token' => 'secret',
+      'signature' => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+    }
+  end
+
+  def then_an_activity_is_created
+    expect(@booking_request.activities).to_not be_empty
+  end
+
+  def and_the_service_responds_with_a_201
+    expect(response).to be_created
+  end
+end


### PR DESCRIPTION
When MailGun sends an inbound bounce webhook we look up the latest
matching booking request from the original recipient's email and create
an activity containing the actual reasoning for the hard bounce.

Any problems raise an error that bubbles up to bug snag.

Requires the `MAILGUN_API_TOKEN` to be set.

![screen shot 2016-09-23 at 19 38 36](https://cloud.githubusercontent.com/assets/41963/18797373/97f921b4-81c5-11e6-81b1-1bbbd5147b23.png)
