### PR TITLE
Booking manager hides unfulfillable booking

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -6,7 +6,17 @@ class BookingRequestsController < ApplicationController
     )
   end
 
+  def destroy
+    booking_request.deactivate!
+
+    redirect_to booking_requests_path
+  end
+
   private
+
+  def booking_request
+    current_user.booking_requests.find(params[:id])
+  end
 
   def unfulfilled_booking_requests
     current_user.unfulfilled_booking_requests.page(params[:page])

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -25,6 +25,10 @@ class BookingRequest < ActiveRecord::Base
 
   scope :active, -> { where(active: true) }
 
+  def deactivate!
+    update!(active: false)
+  end
+
   def primary_slot
     slots.first
   end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -23,6 +23,8 @@ class BookingRequest < ActiveRecord::Base
 
   alias reference to_param
 
+  scope :active, -> { where(active: true) }
+
   def primary_slot
     slots.first
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ActiveRecord::Base
 
   def unfulfilled_booking_requests
     booking_requests
+      .active
       .includes(:appointment)
       .where(appointments: { booking_request_id: nil })
   end

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -153,6 +153,12 @@
         <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
           Make appointment and notify<br><%= @appointment_form.name %>
         <% end %>
+        <%= link_to 'Hide this Booking Request',
+          @appointment_form.location_aware_booking_request,
+          method: :delete,
+          class: 'btn btn-danger btn-block t-deactivate',
+          data: { confirm: "Are you sure you want to hide #{@appointment_form.name}'s booking request?" }
+        %>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   resources :appointments, only: %i(index edit update)
 
-  resources :booking_requests, only: :index do
+  resources :booking_requests, only: %i(index destroy) do
     resources :activities, only: %i(index create)
 
     resources :appointments, only: %i(new create)

--- a/db/migrate/20160924120319_add_active_to_booking_requests.rb
+++ b/db/migrate/20160924120319_add_active_to_booking_requests.rb
@@ -1,0 +1,5 @@
+class AddActiveToBookingRequests < ActiveRecord::Migration[5.0]
+  def change
+    add_column :booking_requests, :active, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160823125447) do
+ActiveRecord::Schema.define(version: 20160924120319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,9 +22,8 @@ ActiveRecord::Schema.define(version: 20160823125447) do
     t.string   "type",               null: false
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
+    t.index ["booking_request_id", "type"], name: "index_activities_on_booking_request_id_and_type", using: :btree
   end
-
-  add_index "activities", ["booking_request_id", "type"], name: "index_activities_on_booking_request_id_and_type", using: :btree
 
   create_table "appointments", force: :cascade do |t|
     t.integer  "booking_request_id",                    null: false
@@ -40,10 +38,9 @@ ActiveRecord::Schema.define(version: 20160823125447) do
     t.integer  "status",                    default: 0, null: false
     t.integer  "fulfilment_time_seconds",   default: 0, null: false
     t.integer  "fulfilment_window_seconds", default: 0, null: false
+    t.index ["booking_request_id"], name: "index_appointments_on_booking_request_id", using: :btree
+    t.index ["location_id"], name: "index_appointments_on_location_id", using: :btree
   end
-
-  add_index "appointments", ["booking_request_id"], name: "index_appointments_on_booking_request_id", using: :btree
-  add_index "appointments", ["location_id"], name: "index_appointments_on_location_id", using: :btree
 
   create_table "audits", force: :cascade do |t|
     t.integer  "auditable_id"
@@ -60,27 +57,27 @@ ActiveRecord::Schema.define(version: 20160823125447) do
     t.string   "remote_address"
     t.string   "request_uuid"
     t.datetime "created_at"
+    t.index ["associated_id", "associated_type"], name: "associated_index", using: :btree
+    t.index ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
+    t.index ["created_at"], name: "index_audits_on_created_at", using: :btree
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
+    t.index ["user_id", "user_type"], name: "user_index", using: :btree
   end
 
-  add_index "audits", ["associated_id", "associated_type"], name: "associated_index", using: :btree
-  add_index "audits", ["auditable_id", "auditable_type"], name: "auditable_index", using: :btree
-  add_index "audits", ["created_at"], name: "index_audits_on_created_at", using: :btree
-  add_index "audits", ["request_uuid"], name: "index_audits_on_request_uuid", using: :btree
-  add_index "audits", ["user_id", "user_type"], name: "user_index", using: :btree
-
   create_table "booking_requests", force: :cascade do |t|
-    t.string   "location_id",                null: false
-    t.string   "name",                       null: false
-    t.string   "email",                      null: false
-    t.string   "phone",                      null: false
-    t.string   "memorable_word",             null: false
-    t.string   "age_range",                  null: false
-    t.boolean  "accessibility_requirements", null: false
-    t.boolean  "marketing_opt_in",           null: false
-    t.boolean  "defined_contribution_pot",   null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.string   "booking_location_id",        null: false
+    t.string   "location_id",                               null: false
+    t.string   "name",                                      null: false
+    t.string   "email",                                     null: false
+    t.string   "phone",                                     null: false
+    t.string   "memorable_word",                            null: false
+    t.string   "age_range",                                 null: false
+    t.boolean  "accessibility_requirements",                null: false
+    t.boolean  "marketing_opt_in",                          null: false
+    t.boolean  "defined_contribution_pot",                  null: false
+    t.datetime "created_at",                                null: false
+    t.datetime "updated_at",                                null: false
+    t.string   "booking_location_id",                       null: false
+    t.boolean  "active",                     default: true, null: false
   end
 
   create_table "slots", force: :cascade do |t|
@@ -91,9 +88,8 @@ ActiveRecord::Schema.define(version: 20160823125447) do
     t.integer  "priority",           null: false
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
+    t.index ["booking_request_id"], name: "index_slots_on_booking_request_id", using: :btree
   end
-
-  add_index "slots", ["booking_request_id"], name: "index_slots_on_booking_request_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name"

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -2,6 +2,16 @@
 require 'rails_helper'
 
 RSpec.feature 'Fulfiling Booking Requests' do
+  scenario 'Bookings Manager deactivates a Booking Request' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_is_an_unfulfilled_booking_request
+      when_the_booking_manager_attempts_to_fulfil
+      then_they_are_shown_the_fulfilment_page
+      when_they_choose_to_deactivate_the_booking_request
+      then_the_booking_request_is_no_longer_active
+    end
+  end
+
   scenario 'Bookings Manager fulfils a Booking Request' do
     perform_enqueued_jobs do
       travel_to '2016-06-19' do
@@ -108,5 +118,15 @@ RSpec.feature 'Fulfiling Booking Requests' do
   def then_they_see_the_validation_messages
     expect(@page).to have_error_summary
     expect(@page).to have_errors
+  end
+
+  def when_they_choose_to_deactivate_the_booking_request
+    @page.deactivate.click
+  end
+
+  def then_the_booking_request_is_no_longer_active
+    @page = Pages::BookingRequests.new
+    expect(@page).to be_displayed
+    expect(@page).to_not have_booking_requests
   end
 end

--- a/spec/features/booking_manager_views_booking_requests_spec.rb
+++ b/spec/features/booking_manager_views_booking_requests_spec.rb
@@ -12,6 +12,9 @@ RSpec.feature 'Viewing Booking Requests' do
   def and_there_are_booking_requests_for_their_location
     create_list(:hackney_booking_request, 11)
 
+    # this won't be listed as it's not `active`
+    create(:hackney_booking_request, active: false)
+
     # this won't be listed as it's not under Hackney
     create(:booking_request)
 

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -92,4 +92,8 @@ RSpec.describe BookingRequest do
       expect(build(:booking_request, name: 'ben lovell').name).to eq('Ben Lovell')
     end
   end
+
+  it 'defaults `active`' do
+    expect(described_class.new).to be_active
+  end
 end

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -29,6 +29,7 @@ module Pages
     element :time_minute, '#appointment_time_5i'
 
     element :submit, '.t-submit'
+    element :deactivate, '.t-deactivate'
 
     elements :errors, '.field_with_errors'
     element :error_summary, '.t-errors'


### PR DESCRIPTION
Adds a button on the fulfilment view so booking manager can choose to hide /
deactivate booking requests that are considered unfulfillable after a period of
time.

These won't affect the calculation of our KPIs since they're only
calculated on the presence of an associated appointment.

![screen shot 2016-09-24 at 13 44 44](https://cloud.githubusercontent.com/assets/41963/18808545/21eb941e-825d-11e6-9332-91c58e99cb19.png)
