### PR TITLE
Don't explicitly show no activities

### DIFF
--- a/app/assets/javascripts/poller.js
+++ b/app/assets/javascripts/poller.js
@@ -41,8 +41,6 @@
 
       if (!document.getElementById(element.attr('id'))) {
         element.hide().prependTo(this.$poller).fadeIn();
-
-        $('.js-no-activities').remove();
       }
     },
 

--- a/app/views/activities/_activity_feed.html.erb
+++ b/app/views/activities/_activity_feed.html.erb
@@ -17,13 +17,9 @@
         <% end %>
       </div>
       <ul class="activity-feed__list js-poller"
-         data-interval="<%= poll_interval_milliseconds %>"
-         data-url="<%= booking_request_activities_path(booking_request) %>">
-        <% if activities.present? %>
-          <%= render activities.first if activities.present? %>
-        <% else %>
-          <li class="activity-feed__item js-no-activities">No activities.</li>
-        <% end %>
+        data-interval="<%= poll_interval_milliseconds %>"
+        data-url="<%= booking_request_activities_path(booking_request) %>">
+        <%= render activities.first if activities.present? %>
       </ul>
 
       <% if activities.count > 1 %>

--- a/app/views/activities/_message_activity.js.erb
+++ b/app/views/activities/_message_activity.js.erb
@@ -1,3 +1,2 @@
 $("<%= j(render partial: @activity, formats: :html) %>").hide().prependTo($('.activity-feed__list:first-of-type')).fadeIn();
 $('.js-message').val('');
-$('.js-no-activities').remove();


### PR DESCRIPTION
We were explicitly displaying a 'no activities' message that I felt was
no longer necessary. This made more sense when we didn't have the
'message' activity form above since the area under the activities
heading would have been empty.

## Before
![screen shot 2016-09-25 at 19 00 03](https://cloud.githubusercontent.com/assets/41963/18817230/9ddbfd92-8353-11e6-9690-a167e4c098a6.png)

## After
![screen shot 2016-09-25 at 19 02 43](https://cloud.githubusercontent.com/assets/41963/18817232/b2467a50-8353-11e6-9430-74e4509417ca.png)

The list element still seems to have a border despite having no content. It needs to be rendered as this is the target for the poller. Perhaps someone can have a look at collapsing the border when it has no child elements?