### PR TITLE
Ensure inbound hooks are filtered

### DIFF
--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -4,17 +4,19 @@ module MailGun
       form = DropForm.new(drop_params)
       form.create_activity
 
-      head :created
+      head :ok
     end
 
     private
 
-    def drop_params
+    def drop_params # rubocop:disable Metrics/MethodLength
       params.permit(
         :event,
         :recipient,
         :description,
         :message_type,
+        :environment,
+        :online_booking,
         :timestamp,
         :token,
         :signature

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -9,6 +9,8 @@ class DropForm
   attr_accessor :recipient
   attr_accessor :description
   attr_accessor :message_type
+  attr_accessor :environment
+  attr_accessor :online_booking
   attr_accessor :timestamp
   attr_accessor :token
   attr_accessor :signature
@@ -16,8 +18,13 @@ class DropForm
   validates :timestamp, presence: true
   validates :token, presence: true
   validates :signature, presence: true
+  validates :booking_request, presence: true
+  validates :environment, inclusion: { in: %w(production) }
+  validates :online_booking, inclusion: { in: %w(True) }
 
   def create_activity
+    return unless valid?
+
     verify_token!
 
     DropActivity.from(
@@ -38,7 +45,7 @@ class DropForm
     digest = OpenSSL::Digest::SHA256.new
     data   = timestamp + token
 
-    unless valid? && signature == OpenSSL::HMAC.hexdigest(digest, api_token, data)
+    unless signature == OpenSSL::HMAC.hexdigest(digest, api_token, data)
       raise TokenVerificationFailure
     end
   end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -21,11 +21,13 @@ class BookingRequest < ActiveRecord::Base
   validates :defined_contribution_pot, inclusion: { in: [true, false] }
   validate :validate_slots
 
-  scope :latest, ->(email) { where(email: email).order(:created_at).last }
-
   alias reference to_param
 
   scope :active, -> { where(active: true) }
+
+  def self.latest(email)
+    where(email: email).order(:created_at).last
+  end
 
   def deactivate!
     update!(active: false)

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'POST /mail_gun/drops' do
       given_a_hackney_booking_request
       when_mail_gun_posts_a_drop_notification
       then_an_activity_is_created
-      and_the_service_responds_with_a_201
+      and_the_service_responds_ok
     end
   end
 
@@ -28,6 +28,8 @@ RSpec.describe 'POST /mail_gun/drops' do
       'event' => 'dropped',
       'recipient' => 'morty@example.com',
       'description' => 'the reasoning',
+      'environment' => 'production',
+      'online_booking' => 'True',
       'timestamp' => '1474638633',
       'token' => 'secret',
       'signature' => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
@@ -38,7 +40,7 @@ RSpec.describe 'POST /mail_gun/drops' do
     expect(@booking_request.activities).to_not be_empty
   end
 
-  def and_the_service_responds_with_a_201
-    expect(response).to be_created
+  def and_the_service_responds_ok
+    expect(response).to be_success
   end
 end


### PR DESCRIPTION
Fixes a bug with our usage of the `latest` scope. See the commit for details.

Also changes our approach to further validate the required properties of a
message. Essentially we only care about online booking messages from production
that have an associated recipient.

There are cases when the booking request may not be found that we cannot
action. Such as during a race when the initial email was sent, but
subsequently the booking manager changed the client email during
fulfillment so we cover this fully.

Due to the way webhooks are configured we cannot route inbound requests on
to the correct environment without our own custom routing infrastructure.
In which case we'll silently drop messages meant for other environments
outside of production.

Ideally we'd have multiple mailgun configurations to match per project but
that's perhaps a step for the future.

We also drop messages that did not actually originate from online bookings
/ planner.