### PR TITLE
Load our phantomjs binaries reliably

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ group :development, :test do
   gem 'capybara'
   gem 'pry-byebug'
   gem 'factory_girl_rails'
-  gem 'phantomjs', '1.9.8.0'
   gem 'rspec-rails'
   gem 'site_prism'
 end
@@ -42,6 +41,7 @@ group :test do
   gem 'database_cleaner'
   gem 'webmock'
   gem 'poltergeist'
+  gem 'phantomjs-binaries'
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ GEM
     bugsnag (4.2.1)
     builder (3.2.2)
     byebug (9.0.5)
-    capybara (2.9.0)
+    capybara (2.10.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -98,6 +98,7 @@ GEM
       faraday (~> 0.8)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
+    ffi (1.9.14)
     foreman (0.78.0)
       thor (~> 0.19.1)
     gds-sso (13.0.0)
@@ -141,9 +142,8 @@ GEM
     mustermann (1.0.0.beta2)
     newrelic_rpm (3.16.2.321)
     nio4r (1.2.1)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -162,10 +162,10 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.19.0)
-    phantomjs (1.9.8.0)
-    pkg-config (1.1.7)
+    phantomjs-binaries (2.1.1.1)
+      sys-uname (= 0.9.0)
     plek (1.12.0)
-    poltergeist (1.10.0)
+    poltergeist (1.11.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
@@ -271,6 +271,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sys-uname (0.9.0)
+      ffi (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -313,7 +315,7 @@ DEPENDENCIES
   kaminari
   newrelic_rpm
   pg
-  phantomjs (= 1.9.8.0)
+  phantomjs-binaries
   plek
   poltergeist
   pry-byebug
@@ -335,4 +337,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.1


### PR DESCRIPTION
The `phantomjs` gem was causing problems with gem activation. The
replacement has locally built binaries for OSX / Linux so it's
generally quicker too.