### PR TITLE
Allow administrators to switch locations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.6.1)
+    booking_locations (0.7.0)
       activesupport (>= 4, < 5.1)
       globalid
     bootstrap-kaminari-views (0.0.5)
@@ -135,7 +135,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)

--- a/app/assets/javascripts/location.js
+++ b/app/assets/javascripts/location.js
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+  $('.js-location').on('change', function() {
+    $('.js-location-form').submit();
+  });
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,16 @@
+class UsersController < ApplicationController
+  before_action do
+    authorise_user!(User::ADMINISTRATOR_PERMISSION)
+  end
+
+  def update
+    current_user.update!(user_params)
+    redirect_back fallback_location: booking_requests_path
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:organisation_content_id)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,4 +3,13 @@ module ApplicationHelper
     options.reverse_merge!(theme: 'twitter-bootstrap-3')
     super(objects, options)
   end
+
+  def booking_location_options
+    location_ids = BookingRequest.distinct.pluck(:booking_location_id)
+
+    location_ids.map do |id|
+      location = BookingLocations.find(id)
+      [location.name, location.id]
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 class User < ActiveRecord::Base
   PENSION_WISE_API_PERMISSION = 'pension_wise_api_user'
   BOOKING_MANAGER_PERMISSION  = 'booking_manager'
+  ADMINISTRATOR_PERMISSION    = 'administrator'
 
   include GDS::SSO::User
 
@@ -23,5 +24,9 @@ class User < ActiveRecord::Base
       .active
       .includes(:appointment)
       .where(appointments: { booking_request_id: nil })
+  end
+
+  def administrator?
+    permissions.include?(ADMINISTRATOR_PERMISSION)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,17 @@
   <li>
     <%= link_to 'Appointments', appointments_path %>
   </li>
+  <% if current_user.administrator? %>
+    <%= form_for current_user, html: { class: 'navbar-form navbar-right js-location-form' } do |f| %>
+      <div class="form-group">
+        <%= f.select :organisation_content_id,
+              options_for_select(booking_location_options, current_user.organisation_content_id),
+              {},
+              { class: 't-location js-location' }
+        %>
+      </div>
+    <% end %>
+  <% end %>
 <% end %>
 
 <% content_for :body_end do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
     resources :drops, only: :create
   end
 
+  resources :users, only: :update
+
   resources :appointments, only: %i(index edit update)
 
   resources :booking_requests, only: %i(index destroy) do

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -23,5 +23,10 @@ FactoryGirl.define do
       booking_location_id 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
       location_id 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
     end
+
+    factory :taunton_booking_request do
+      booking_location_id '7f916cf6-d2bd-4bcc-90dc-594207c8b1f4'
+      location_id '7f916cf6-d2bd-4bcc-90dc-594207c8b1f4'
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,5 +17,14 @@ FactoryGirl.define do
     factory :hackney_booking_manager, parent: :booking_manager do
       organisation_content_id 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
     end
+
+    factory :hackney_administrator, parent: :hackney_booking_manager do
+      permissions do
+        [
+          User::BOOKING_MANAGER_PERMISSION,
+          User::ADMINISTRATOR_PERMISSION
+        ]
+      end
+    end
   end
 end

--- a/spec/features/booking_manager_views_booking_requests_spec.rb
+++ b/spec/features/booking_manager_views_booking_requests_spec.rb
@@ -1,12 +1,38 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing Booking Requests' do
+  scenario 'Administrator changes their location', js: true do
+    given_the_user_identifies_as_hackneys_administrator do
+      and_there_are_booking_requests_for_their_location
+      when_they_visit_the_site
+      then_they_are_shown_booking_requests_for_their_locations
+      when_they_change_their_location
+      then_they_are_shown_booking_requests_for_their_new_location
+    end
+  end
+
   scenario 'Bookings Manager views their Booking Requests' do
     given_the_user_identifies_as_hackneys_booking_manager do
       and_there_are_booking_requests_for_their_location
       when_they_visit_the_site
       then_they_are_shown_booking_requests_for_their_locations
+      and_they_do_not_see_the_administrative_location_choices
     end
+  end
+
+  def and_they_do_not_see_the_administrative_location_choices
+    expect(@page).to have_no_location
+  end
+
+  def when_they_change_their_location
+    @page.location.select 'Taunton'
+  end
+
+  def then_they_are_shown_booking_requests_for_their_new_location
+    # this will wait for the JS triggered reload
+    expect(@page.booking_requests.first).to have_content('Taunton')
+
+    expect(@page).to have_booking_requests(count: 1)
   end
 
   def and_there_are_booking_requests_for_their_location
@@ -16,7 +42,7 @@ RSpec.feature 'Viewing Booking Requests' do
     create(:hackney_booking_request, active: false)
 
     # this won't be listed as it's not under Hackney
-    create(:booking_request)
+    create(:taunton_booking_request)
 
     # this won't be listed as it's fulfilled
     create(:appointment)
@@ -30,6 +56,6 @@ RSpec.feature 'Viewing Booking Requests' do
     @page = Pages::BookingRequests.new
     expect(@page).to be_displayed
     expect(@page).to have_booking_requests(count: 10)
-    expect(@page).to have_content('Hackney')
+    expect(@page.booking_requests.first).to have_content('Hackney')
   end
 end

--- a/spec/support/pages/booking_requests.rb
+++ b/spec/support/pages/booking_requests.rb
@@ -6,5 +6,7 @@ module Pages
     sections :booking_requests, '.t-booking-request' do
       element :fulfil, '.t-fulfil'
     end
+
+    element :location, '.t-location'
   end
 end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -1,4 +1,13 @@
 module UserHelpers
+  def given_the_user_identifies_as_hackneys_administrator
+    @user = create(:hackney_administrator)
+    GDS::SSO.test_user = @user
+
+    yield
+  ensure
+    GDS::SSO.test_user = nil
+  end
+
   def given_the_user_identifies_as_hackneys_booking_manager
     @user = create(:hackney_booking_manager)
     GDS::SSO.test_user = @user


### PR DESCRIPTION
This allows users with the necessary privileges to switch their booking
location 'ownership' thus allowing them to see bookings / appointments
from any location.

Prior to this the user would have to go to signon and change their
organisation then log out / in.

Note: The chosen organisation will be reverted upon the next sign in,
depending on what organisation is assigned in the signon application.

As you'll see, the styling could do with some loving:

![screen shot 2016-10-14 at 11 41 01](https://cloud.githubusercontent.com/assets/41963/19384822/3b27267c-9203-11e6-924a-a6c72edac45f.png)
