### PR TITLE
Include the booking location name on the customer emails

### DIFF
--- a/app/views/booking_requests/customer.html.erb
+++ b/app/views/booking_requests/customer.html.erb
@@ -3,8 +3,8 @@
 
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
 0;font-size: 16px;line-height: 1.315789474;">Thank you for requesting a
-guidance appointment with Pension Wise, we'll confirm the appointment slot
-within the next two working days.</p>
+guidance appointment with Pension Wise. We’ll confirm your appointment in the
+next 2 working days.</p>
 
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
 0;font-size: 16px;line-height: 1.315789474;">Your first choice is<br><strong
@@ -18,6 +18,11 @@ within the next two working days.</p>
 0;font-size: 16px;line-height: 1.315789474;">Your third choice is<br><strong
   class="emphasize" style="font-size: 24px;"><%= @booking_request.tertiary_slot
   %></strong></p>
+
+  <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
+0;font-size: 16px;line-height: 1.315789474;">Your appointment location is<br><strong
+  class="emphasize" style="font-size: 24px;">
+  <%= @booking_location.name_for(@booking_request.location_id) %></strong></p>
 
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
 0;font-size: 16px;line-height: 1.315789474;">Your contact number<br> <strong

--- a/app/views/booking_requests/customer.text.erb
+++ b/app/views/booking_requests/customer.text.erb
@@ -1,7 +1,7 @@
 Dear <%= @booking_request.name %>,
 
-Thank you for requesting a guidance appointment with Pension Wise, we'll confirm
-the appointment slot within the next two working days.
+Thank you for requesting a guidance appointment with Pension Wise.
+We’ll confirm your appointment in the next 2 working days.
 
 Your first choice is
 <%= @booking_request.primary_slot %>
@@ -11,6 +11,9 @@ Your second choice is
 
 Your third choice is
 <%= @booking_request.tertiary_slot %>
+
+Your appointment location is
+<%= @booking_location.name_for(@booking_request.location_id) %>
 
 Your contact number
 <%= @booking_request.phone %>

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -2,10 +2,12 @@ require 'rails_helper'
 
 RSpec.describe BookingRequests do
   describe 'Customer notification' do
-    let(:booking_location) do
-      instance_double(BookingLocations::Location, online_booking_twilio_number: '+441234567890')
+    let(:location_id) { '183080c6-642b-4b8f-96fd-891f5cd9f9c7' }
+    let(:booking_location_id) { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
+    let(:booking_location) { BookingLocations.find(booking_location_id) }
+    let(:booking_request) do
+      create(:booking_request, location_id: location_id, booking_location_id: booking_location_id)
     end
-    let(:booking_request) { create(:booking_request) }
 
     subject(:mail) { BookingRequests.customer(booking_request, booking_location) }
 
@@ -29,6 +31,7 @@ RSpec.describe BookingRequests do
       end
 
       it 'includes the booking location particulars' do
+        expect(body).to include(booking_location.name_for(location_id))
         expect(body).to include(booking_location.online_booking_twilio_number)
       end
 


### PR DESCRIPTION
So we can identify which booking location to contact in the case
that the customer responds to the email.
