### PR TITLE
Permit the `date_of_birth` via the booking API

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -37,6 +37,7 @@ module Api
           :phone,
           :memorable_word,
           :age_range,
+          :date_of_birth,
           :accessibility_requirements,
           :marketing_opt_in,
           :defined_contribution_pot,

--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -6,6 +6,7 @@ class AppointmentForm
     email
     phone
     age_range
+    date_of_birth
     reference
     location_name
     memorable_word

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -46,6 +46,9 @@
     <h3 class="h4">Age range:</h3>
     <p class="lead"><strong class="t-age-range"><%= @appointment_form.age_range %></strong></p>
 
+    <h3 class="h4">Date of birth:</h3>
+    <p class="lead"><strong class="t-date-of-birth"><%= @appointment_form.date_of_birth.to_s(:gov_uk) %></strong></p>
+
     <h3 class="h4">Accessibility requirements:</h3>
     <p class="lead">
       <strong class="t-accessibility_requirements">

--- a/db/migrate/20161104144629_add_date_of_birth_to_booking_requests.rb
+++ b/db/migrate/20161104144629_add_date_of_birth_to_booking_requests.rb
@@ -1,0 +1,5 @@
+class AddDateOfBirthToBookingRequests < ActiveRecord::Migration[5.0]
+  def change
+    add_column :booking_requests, :date_of_birth, :date, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160924120319) do
+ActiveRecord::Schema.define(version: 20161104144629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 20160924120319) do
     t.datetime "updated_at",                                null: false
     t.string   "booking_location_id",                       null: false
     t.boolean  "active",                     default: true, null: false
+    t.date     "date_of_birth"
   end
 
   create_table "slots", force: :cascade do |t|

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -9,6 +9,7 @@ FactoryGirl.define do
     phone '0208 252 4723'
     memorable_word 'spaceship'
     age_range '50-54'
+    date_of_birth '1950-01-01'
     accessibility_requirements false
     marketing_opt_in false
     defined_contribution_pot true

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -66,6 +66,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
     expect(@page.location_name.text).to eq('Hackney')
     expect(@page.memorable_word.text).to eq(@booking_request.memorable_word)
     expect(@page.age_range.text).to eq(@booking_request.age_range)
+    expect(@page.date_of_birth.text).to eq(@booking_request.date_of_birth.to_s(:gov_uk))
   end
 
   def and_they_see_the_requested_slots

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe AppointmentForm do
     expect(subject.email).to eq(booking_request.email)
     expect(subject.phone).to eq(booking_request.phone)
     expect(subject.age_range).to eq(booking_request.age_range)
+    expect(subject.date_of_birth).to eq(booking_request.date_of_birth)
     expect(subject.reference).to eq(booking_request.reference)
     expect(subject.memorable_word).to eq(booking_request.memorable_word)
     expect(subject.accessibility_requirements).to eq(booking_request.accessibility_requirements)

--- a/spec/requests/create_a_booking_request_spec.rb
+++ b/spec/requests/create_a_booking_request_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
         'phone' => '0208 252 4729',
         'memorable_word' => 'science',
         'age_range' => '50-54',
+        'date_of_birth' => '1950-01-01',
         'accessibility_requirements' => false,
         'marketing_opt_in' => true,
         'defined_contribution_pot' => true,
@@ -75,6 +76,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
       phone: '0208 252 4729',
       memorable_word: 'science',
       age_range: '50-54',
+      date_of_birth: Date.parse('1950-01-01'),
       accessibility_requirements: false,
       marketing_opt_in: true,
       defined_contribution_pot: true

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -11,6 +11,7 @@ module Pages
     element :location_name, '.t-location-name'
     element :memorable_word, '.t-memorable-word'
     element :age_range, '.t-age-range'
+    element :date_of_birth, '.t-date-of-birth'
     element :accessibility_requirements, '.t-accessibility'
 
     element :slot_one_date,     '.t-slot-1-date'


### PR DESCRIPTION
Clients can now pass an optional date of birth to the booking request
API. This is displayed on the booking fulfilment page.