### PR TITLE
Guard against old bookings prior to mandatory DOB

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -40,6 +40,10 @@ class AppointmentForm
     super(params)
   end
 
+  def date_of_birth
+    location_aware_booking_request.date_of_birth || ''
+  end
+
   def appointment_params
     AppointmentMapper.map(self)
   end

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe AppointmentForm do
     end
   end
 
+  context 'when the date of birth is not present' do
+    it 'returns an empty string' do
+      booking_request.date_of_birth = nil
+      expect(subject.date_of_birth).to eq('')
+    end
+  end
+
   it 'delegates booking specifics to the booking request' do
     expect(subject.name).to eq(booking_request.name)
     expect(subject.email).to eq(booking_request.email)


### PR DESCRIPTION
We still have unfulfilled bookings in production without date of birth
values provided since this was not mandatory before that change. We
have to guard against these (temporarily) until the last request prior
to this change is fulfilled.