### PR TITLE
Ensure emails are not sent incorrectly

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -29,7 +29,7 @@ class Appointment < ActiveRecord::Base
   end
 
   def notify?
-    previous_changes.exclude?(:status)
+    previous_changes.any? && previous_changes.exclude?(:status)
   end
 
   def calculate_statistics

--- a/spec/requests/updates_without_changes_do_not_trigger_notifications_spec.rb
+++ b/spec/requests/updates_without_changes_do_not_trigger_notifications_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Updates without changes' do
+  before do
+    @booking_manager = create(:hackney_booking_manager)
+    @appointment     = create(:appointment)
+  end
+
+  let(:params) do
+    Hash[appointment: { status: 'pending' }]
+  end
+
+  it 'do not trigger notifications' do
+    perform_enqueued_jobs do
+      patch appointment_path(@appointment), params: params
+
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
If the manager submitted an edit to the appointment without actual
changes the customer would incorrectly receive an email notification.

This change guards against an empty changeset when asking if it should
notify the customer.