### PR TITLE
Obscure memorable word in customer confirmations

### DIFF
--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -29,6 +29,12 @@ class BookingRequest < ActiveRecord::Base
     where(email: email).order(:created_at).last
   end
 
+  def memorable_word(obscure: false)
+    return super() unless obscure
+
+    super().to_s.gsub(/(?!\A).(?!\Z)/, '*')
+  end
+
   def deactivate!
     update!(active: false)
   end

--- a/app/views/booking_requests/customer.html.erb
+++ b/app/views/booking_requests/customer.html.erb
@@ -30,7 +30,7 @@ class="emphasize" style="font-size: 24px;"><%= @booking_request.phone %></strong
 
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
 0;font-size: 16px;line-height: 1.315789474;">Your memorable word<br> <strong
-class="emphasize" style="font-size: 24px;"><%= @booking_request.memorable_word
+class="emphasize" style="font-size: 24px;"><%= @booking_request.memorable_word(obscure: true)
 %></strong></p>
 
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px

--- a/app/views/booking_requests/customer.text.erb
+++ b/app/views/booking_requests/customer.text.erb
@@ -19,7 +19,7 @@ Your contact number
 <%= @booking_request.phone %>
 
 Your memorable word
-<%= @booking_request.memorable_word %>
+<%= @booking_request.memorable_word(obscure: true) %>
 
 Your reference number
 <%= @booking_request.reference %>

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe BookingRequests do
         expect(body).to include(booking_request.name)
         expect(body).to include(booking_request.phone)
         expect(body).to include(booking_request.reference)
-        expect(body).to include(booking_request.memorable_word)
+        expect(body).to include('s*******p')
       end
 
       it 'includes the booking location particulars' do

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -96,4 +96,12 @@ RSpec.describe BookingRequest do
   it 'defaults `active`' do
     expect(described_class.new).to be_active
   end
+
+  describe '#memorable_word' do
+    it 'can be obscured' do
+      expect(build_stubbed(:booking_request).memorable_word).to eq('spaceship')
+      expect(build_stubbed(:booking_request).memorable_word(obscure: true)).to eq('s*******p')
+      expect(build_stubbed(:booking_request, memorable_word: nil).memorable_word(obscure: true)).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
This hides all but the first and last characters of the memorable word
with the asterisk character.