### PR TITLE
Simplify drop messages

### DIFF
--- a/app/views/activities/_drop_activity.html.erb
+++ b/app/views/activities/_drop_activity.html.erb
@@ -1,4 +1,5 @@
 <li class="activity-feed__item t-activity" id="activity-<%= drop_activity.id %>">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-  <b>Delivery failure</b> <em><%= drop_activity.message %></em> <em class="badge"><%= time_ago_in_words(drop_activity.created_at) %> ago</em>
+  <b>Email delivery failure: </b>
+  <em>An email confirmation could not be delivered. Check the customer's email address for mistakes or typos.</em> <em class="badge"><%= time_ago_in_words(drop_activity.created_at) %> ago</em>
 </li>


### PR DESCRIPTION
The drop messages sometimes reflect the SMTP language directly,
depending on the recipient address. This is probably too complex for
the bookings managers to understand and cannot be actioned by them.

We'll continue to store the original SMTP language and reasoning, but
only display a friendly message to the user that they can action.