### PR TITLE
Aligning text in appointments table to aid readability

### DIFF
--- a/app/assets/stylesheets/components/_appointments.scss
+++ b/app/assets/stylesheets/components/_appointments.scss
@@ -1,0 +1,3 @@
+.appointments tbody tr td { // scss-lint:disable SelectorDepth
+  vertical-align: middle;
+}

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -14,7 +14,7 @@
     <% else %>
       <%= paginate @appointments.entities %>
 
-      <table class="table table-bordered">
+      <table class="appointments table table-bordered table-striped">
         <thead>
           <tr class="table-header">
             <th>Date of appointment</th>


### PR DESCRIPTION
<img width="1165" alt="screen shot 2016-12-14 at 14 57 33" src="https://cloud.githubusercontent.com/assets/6049076/21186795/aa6c35a6-c20d-11e6-9939-34e2e2a732c8.png">
