### PR TITLE
Use your local system `phantomjs` binary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ group :test do
   gem 'database_cleaner'
   gem 'webmock'
   gem 'poltergeist'
-  gem 'phantomjs-binaries'
 end
 
 group :staging, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,8 +170,6 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.19.0)
-    phantomjs-binaries (2.1.1.1)
-      sys-uname (= 0.9.0)
     plek (1.12.0)
     poltergeist (1.11.0)
       capybara (~> 2.1)
@@ -289,8 +287,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sys-uname (0.9.0)
-      ffi (>= 1.0.0)
     term-ansicolor (1.4.0)
       tins (~> 1.0)
     thor (0.19.1)
@@ -337,7 +333,6 @@ DEPENDENCIES
   kaminari
   newrelic_rpm
   pg
-  phantomjs-binaries
   plek
   poltergeist
   pry-byebug


### PR DESCRIPTION
As per TAP, this speeds up the test runs locally and avoids problems
with the cross-project, shared gem sets.