### PR TITLE
Display memorable word and date of birth

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -15,7 +15,7 @@ class Appointment < ActiveRecord::Base
 
   belongs_to :booking_request
 
-  delegate :reference, :activities, to: :booking_request
+  delegate :reference, :activities, :memorable_word, :date_of_birth, to: :booking_request
 
   validates :name, presence: true
   validates :email, presence: true

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -49,6 +49,16 @@
       </div>
 
       <div class="form-group">
+        <%= f.label :memorable_word %>
+        <%= f.text_field :memorable_word, class: 'form-control t-memorable-word', readonly: true %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :date_of_birth %>
+        <%= f.date_field :date_of_birth, class: 't-date-of-birth form-control', readonly: true %>
+      </div>
+
+      <div class="form-group">
         <%= f.label :guider_id %>
         <%= f.select(
           :guider_id,

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -48,13 +48,15 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     @page.appointments.first.edit.click
   end
 
-  def then_the_appointment_details_are_presented
+  def then_the_appointment_details_are_presented # rubocop:disable Metrics/MethodLength
     @page = Pages::EditAppointment.new
     expect(@page).to be_displayed
 
     expect(@page.name.value).to eq(@appointment.name)
     expect(@page.email.value).to eq(@appointment.email)
     expect(@page.phone.value).to eq(@appointment.phone)
+    expect(@page.memorable_word.value).to eq(@appointment.memorable_word)
+    expect(@page.date_of_birth.value).to eq(@appointment.date_of_birth.iso8601)
 
     # ensure Hackney is pre-selected
     expect(@page.location.value).to eq('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -8,6 +8,8 @@ module Pages
     element :name, '.t-name'
     element :email, '.t-email'
     element :phone, '.t-phone'
+    element :memorable_word, '.t-memorable-word'
+    element :date_of_birth, '.t-date-of-birth'
     element :location, '.t-location'
     element :guider, '.t-guider'
 


### PR DESCRIPTION
Show these fields as readonly on the appointment screen.

![screen shot 2017-01-03 at 10 08 52](https://cloud.githubusercontent.com/assets/41963/21604773/07165b8a-d19d-11e6-9076-9f2c4804f384.png)
