### PR TITLE
Toggle display of hidden booking requests

### DIFF
--- a/app/assets/stylesheets/components/_booking-requests.scss
+++ b/app/assets/stylesheets/components/_booking-requests.scss
@@ -1,0 +1,3 @@
+.booking-request-tabs {
+  margin-bottom: 16px;
+}

--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -14,11 +14,18 @@ class BookingRequestsController < ApplicationController
 
   private
 
+  def show_hidden_booking_requests?
+    params.fetch(:hidden, 'false') == 'true'
+  end
+  helper_method :show_hidden_booking_requests?
+
   def booking_request
     current_user.booking_requests.find(params[:id])
   end
 
   def unfulfilled_booking_requests
-    current_user.unfulfilled_booking_requests.page(params[:page])
+    current_user
+      .unfulfilled_booking_requests(hidden: show_hidden_booking_requests?)
+      .page(params[:page])
   end
 end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -24,6 +24,7 @@ class BookingRequest < ActiveRecord::Base
   alias reference to_param
 
   scope :active, -> { where(active: true) }
+  scope :inactive, -> { where(active: false) }
 
   def self.latest(email)
     where(email: email).order(:created_at).last

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,11 +19,12 @@ class User < ActiveRecord::Base
 
   alias_attribute :booking_location_id, :organisation_content_id
 
-  def unfulfilled_booking_requests
-    booking_requests
-      .active
-      .includes(:appointment)
-      .where(appointments: { booking_request_id: nil })
+  def unfulfilled_booking_requests(hidden: false)
+    scope = booking_requests
+            .includes(:appointment)
+            .where(appointments: { booking_request_id: nil })
+
+    hidden ? scope.inactive : scope.active
   end
 
   def administrator?

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -5,21 +5,20 @@
   </ol>
 
   <h1>Booking requests</h1>
-
-  <% if show_hidden_booking_requests? %>
-    <%= link_to 'Hide hidden booking requests', booking_requests_path(hidden: false), class: 't-hide-hidden-bookings' %>
-  <% else %>
-    <%= link_to 'Show hidden booking requests', booking_requests_path(hidden: true), class: 't-show-hidden-bookings' %>
-  <% end %>
 </div>
 
 <div class="row">
   <div class="col-md-12">
+    <nav aria-label="Active/hidden bookings" class="booking-request-tabs">
+      <ul class="nav nav-tabs">
+        <li role="presentation" <% unless show_hidden_booking_requests? %>class="active"<% end %>><%= link_to 'Active requests', booking_requests_path(hidden: false), class: 't-hide-hidden-bookings' %></li>
+        <li role="presentation" <% if show_hidden_booking_requests? %>class="active"<% end %>><%= link_to 'Hidden requests', booking_requests_path(hidden: true), class: 't-show-hidden-bookings' %></li>
+      </ul>
+    </nav>
     <% if @booking_requests.page.empty? %>
-      <p class="no-content t-notice">No booking requests requiring attention.</p>
+      <p class="no-content t-notice">No <% if show_hidden_booking_requests? %>hidden<% else %>active<% end %> booking requests.</p>
     <% else %>
       <%= paginate @booking_requests.entities %>
-
       <table class="table table-bordered">
         <thead>
           <tr class="table-header">

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -5,6 +5,12 @@
   </ol>
 
   <h1>Booking requests</h1>
+
+  <% if show_hidden_booking_requests? %>
+    <%= link_to 'Hide hidden booking requests', booking_requests_path(hidden: false), class: 't-hide-hidden-bookings' %>
+  <% else %>
+    <%= link_to 'Show hidden booking requests', booking_requests_path(hidden: true), class: 't-show-hidden-bookings' %>
+  <% end %>
 </div>
 
 <div class="row">

--- a/spec/features/booking_manager_views_booking_requests_spec.rb
+++ b/spec/features/booking_manager_views_booking_requests_spec.rb
@@ -17,7 +17,23 @@ RSpec.feature 'Viewing Booking Requests' do
       when_they_visit_the_site
       then_they_are_shown_booking_requests_for_their_locations
       and_they_do_not_see_the_administrative_location_choices
+      when_they_choose_to_show_hidden_booking_requests
+      then_they_are_shown_hidden_booking_requests
+      when_they_choose_to_hide_hidden_booking_requests
+      then_they_are_shown_booking_requests_for_their_locations
     end
+  end
+
+  def when_they_choose_to_show_hidden_booking_requests
+    @page.show_hidden_bookings.click
+  end
+
+  def then_they_are_shown_hidden_booking_requests
+    expect(@page).to have_booking_requests(count: 1)
+  end
+
+  def when_they_choose_to_hide_hidden_booking_requests
+    @page.hide_hidden_bookings.click
   end
 
   def and_they_do_not_see_the_administrative_location_choices

--- a/spec/support/pages/booking_requests.rb
+++ b/spec/support/pages/booking_requests.rb
@@ -1,11 +1,14 @@
 module Pages
   class BookingRequests < SitePrism::Page
     set_url '/booking_requests'
-    set_url_matcher %r{/\z|/booking_requests\z}
+    set_url_matcher %r{/\z|/booking_requests(?:.*)\z}
 
     sections :booking_requests, '.t-booking-request' do
       element :fulfil, '.t-fulfil'
     end
+
+    element :show_hidden_bookings, '.t-show-hidden-bookings'
+    element :hide_hidden_bookings, '.t-hide-hidden-bookings'
 
     element :location, '.t-location'
   end


### PR DESCRIPTION
Booking managers can view booking requests that have been hidden, or
just the regular booking requests.

<img width="1175" alt="screen shot 2017-01-03 at 15 13 45" src="https://cloud.githubusercontent.com/assets/6049076/21612016/4377097e-d1c7-11e6-9ed4-463128b44612.png">

