### PR TITLE
Allow managers to reactivate hidden bookings

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -8,6 +8,7 @@ class BookingRequestsController < ApplicationController
 
   def update
     booking_request.toggle_activation!
+    ActivationActivity.from(booking_request, current_user)
 
     redirect_to booking_requests_path
   end
@@ -20,7 +21,7 @@ class BookingRequestsController < ApplicationController
   helper_method :show_hidden_booking_requests?
 
   def booking_request
-    current_user.booking_requests.find(params[:id])
+    @booking_request ||= current_user.booking_requests.find(params[:id])
   end
 
   def unfulfilled_booking_requests

--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -6,8 +6,8 @@ class BookingRequestsController < ApplicationController
     )
   end
 
-  def destroy
-    booking_request.deactivate!
+  def update
+    booking_request.toggle_activation!
 
     redirect_to booking_requests_path
   end

--- a/app/helpers/booking_request_helper.rb
+++ b/app/helpers/booking_request_helper.rb
@@ -1,0 +1,15 @@
+module BookingRequestHelper
+  def toggle_activation_link(booking_request)
+    action = booking_request.active? ? 'hide' : 'show'
+
+    link_to(
+      "#{action.capitalize} this Booking Request",
+      booking_request,
+      method: :patch,
+      class: 'btn btn-danger btn-block t-toggle-activation',
+      data: {
+        confirm: "Are you sure you want to #{action} #{booking_request.name}'s booking request?"
+      }
+    )
+  end
+end

--- a/app/models/activation_activity.rb
+++ b/app/models/activation_activity.rb
@@ -1,0 +1,9 @@
+class ActivationActivity < Activity
+  def self.from(booking_request, initiator)
+    create!(
+      booking_request: booking_request,
+      message: booking_request.active? ? 'active' : 'inactive',
+      user: initiator
+    )
+  end
+end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -36,8 +36,8 @@ class BookingRequest < ActiveRecord::Base
     super().to_s.gsub(/(?!\A).(?!\Z)/, '*')
   end
 
-  def deactivate!
-    update!(active: false)
+  def toggle_activation!
+    toggle!(:active)
   end
 
   def primary_slot

--- a/app/views/activities/_activation_activity.html.erb
+++ b/app/views/activities/_activation_activity.html.erb
@@ -1,0 +1,4 @@
+<li class="activity-feed__item t-activity" id="activity-<%= activation_activity.id %>">
+  <span class="glyphicon glyphicon-off" aria-hidden="true"></span>
+  <b><%= activation_activity.owner_name %></b> made the booking request <%= activation_activity.message %> <em class="badge"><%= time_ago_in_words(activation_activity.created_at) %> ago</em>
+</li>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -156,12 +156,8 @@
         <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
           Make appointment and notify<br><%= @appointment_form.name %>
         <% end %>
-        <%= link_to 'Hide this Booking Request',
-          @appointment_form.location_aware_booking_request,
-          method: :delete,
-          class: 'btn btn-danger btn-block t-deactivate',
-          data: { confirm: "Are you sure you want to hide #{@appointment_form.name}'s booking request?" }
-        %>
+
+        <%= toggle_activation_link(@appointment_form.location_aware_booking_request) %>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   resources :appointments, only: %i(index edit update)
 
-  resources :booking_requests, only: %i(index destroy) do
+  resources :booking_requests, only: %i(index update) do
     resources :activities, only: %i(index create)
 
     resources :appointments, only: %i(new create)

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -2,13 +2,15 @@
 require 'rails_helper'
 
 RSpec.feature 'Fulfiling Booking Requests' do
-  scenario 'Bookings Manager deactivates a Booking Request' do
+  scenario 'Bookings Manager deactivates and activates a Booking Request' do
     given_the_user_identifies_as_hackneys_booking_manager do
       and_there_is_an_unfulfilled_booking_request
       when_the_booking_manager_attempts_to_fulfil
       then_they_are_shown_the_fulfilment_page
       when_they_choose_to_deactivate_the_booking_request
       then_the_booking_request_is_no_longer_active
+      when_they_choose_to_activate_the_booking_request
+      then_the_booking_request_is_now_active
     end
   end
 
@@ -122,12 +124,26 @@ RSpec.feature 'Fulfiling Booking Requests' do
   end
 
   def when_they_choose_to_deactivate_the_booking_request
-    @page.deactivate.click
+    @page.toggle_activation.click
   end
 
   def then_the_booking_request_is_no_longer_active
     @page = Pages::BookingRequests.new
     expect(@page).to be_displayed
     expect(@page).to_not have_booking_requests
+  end
+
+  def when_they_choose_to_activate_the_booking_request
+    @page.show_hidden_bookings.click
+    @page.booking_requests.first.fulfil.click
+
+    @page = Pages::FulfilBookingRequest.new
+    @page.toggle_activation.click
+  end
+
+  def then_the_booking_request_is_now_active
+    @page = Pages::BookingRequests.new
+    expect(@page).to be_displayed
+    expect(@page).to have_booking_requests
   end
 end

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
       then_the_booking_request_is_no_longer_active
       when_they_choose_to_activate_the_booking_request
       then_the_booking_request_is_now_active
+      and_the_booking_request_has_associated_activation_activities
     end
   end
 
@@ -145,5 +146,9 @@ RSpec.feature 'Fulfiling Booking Requests' do
     @page = Pages::BookingRequests.new
     expect(@page).to be_displayed
     expect(@page).to have_booking_requests
+  end
+
+  def and_the_booking_request_has_associated_activation_activities
+    expect(@booking_request.activities.count).to eq(2)
   end
 end

--- a/spec/models/activation_activity_spec.rb
+++ b/spec/models/activation_activity_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ActivationActivity, '.from' do
+  let(:initiator) { create(:user) }
+
+  subject { described_class.from(booking_request, initiator) }
+
+  context 'with an active booking' do
+    let(:booking_request) { create(:booking_request) }
+
+    it 'sets the message correctly' do
+      expect(subject.message).to eq('active')
+    end
+  end
+
+  context 'with an inactive booking' do
+    let(:booking_request) { create(:booking_request, active: false) }
+
+    it 'sets the message correctly' do
+      expect(subject.message).to eq('inactive')
+    end
+  end
+end

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -30,7 +30,7 @@ module Pages
     element :time_minute, '#appointment_time_5i'
 
     element :submit, '.t-submit'
-    element :deactivate, '.t-deactivate'
+    element :toggle_activation, '.t-toggle-activation'
 
     elements :errors, '.field_with_errors'
     element :error_summary, '.t-errors'


### PR DESCRIPTION
Since we now display hidden bookings we should also allow the
booking managers to reactivate previously hidden bookings when necessary.

Also we now log an activity when a booking request's activation changes.

## Reactivate
![screen shot 2017-01-04 at 10 39 45](https://cloud.githubusercontent.com/assets/41963/21640936/6363301a-d270-11e6-8704-f2b42aaeb20b.png)

## Activities
![screen shot 2017-01-04 at 11 23 09](https://cloud.githubusercontent.com/assets/41963/21640947/70f9fbe6-d270-11e6-91d0-ac41ce74bd35.png)

