### PR TITLE
Correct timestamp for dating booking requests

### DIFF
--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -34,7 +34,7 @@
           <% @booking_requests.page.each do |booking_request| %>
             <tr class="t-booking-request">
               <td>
-                <%= time_ago_in_words(booking_request.updated_at) %> ago
+                <%= time_ago_in_words(booking_request.created_at) %> ago
               </td>
               <td>
                 <%= booking_request.name %>


### PR DESCRIPTION
We were using the `updated_at` which isn't actually the time when the
customer made the real booking request. This was highlighted with the
hidden requests since it was reflecting the time when they were hidden
and thus updated at.