### PR TITLE
Correctly authenticate for sidekiq panel

### DIFF
--- a/app/constraints/authenticated_user.rb
+++ b/app/constraints/authenticated_user.rb
@@ -1,6 +1,9 @@
 class AuthenticatedUser
   def matches?(request)
-    warden = request.tnv['warden']
-    warden&.authenticated? && !warden.user.remotely_signed_out?
+    warden = request.env['warden']
+
+    return unless warden.authenticate?
+
+    warden.user && !warden.user.remotely_signed_out?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,5 +23,5 @@ Rails.application.routes.draw do
     end
   end
 
-  mount Sidekiq::Web, at: '/sidekiq', constraint: AuthenticatedUser.new
+  mount Sidekiq::Web, at: '/sidekiq', constraints: AuthenticatedUser.new
 end

--- a/spec/requests/sidekiq_authentication_spec.rb
+++ b/spec/requests/sidekiq_authentication_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Sidekiq control panel' do
+  scenario 'requires authentication' do
+    with_real_sso do
+      they_are_required_to_authenticate
+    end
+  end
+
+  scenario 'successfully authenticating' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      when_they_visit_the_sidekiq_panel
+      then_they_are_authenticated
+    end
+  end
+
+  def when_they_visit_the_sidekiq_panel
+    get '/sidekiq'
+  end
+
+  def they_are_required_to_authenticate
+    expect { get '/sidekiq' }.to raise_error(ActionController::RoutingError)
+  end
+
+  def then_they_are_authenticated
+    expect(response).to be_ok
+  end
+end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -1,4 +1,13 @@
 module UserHelpers
+  def with_real_sso
+    sso_env = ENV['GDS_SSO_MOCK_INVALID']
+    ENV['GDS_SSO_MOCK_INVALID'] = '1'
+
+    yield
+  ensure
+    ENV['GDS_SSO_MOCK_INVALID'] = sso_env
+  end
+
   def given_the_user_identifies_as_hackneys_administrator
     @user = create(:hackney_administrator)
     GDS::SSO.test_user = @user


### PR DESCRIPTION
It turns out there were multiple problems with how this was implemented.
This ensures only authenticated users are permitted access to the
sidekiq control panel.