### PR TITLE
Permit and display DC pot confirmation

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -40,7 +40,7 @@ module Api
           :date_of_birth,
           :accessibility_requirements,
           :marketing_opt_in,
-          :defined_contribution_pot,
+          :defined_contribution_pot_confirmed,
           slots: %i(date from to priority)
         ).tap { |p| p[:slots_attributes] = p.delete(:slots) }
       end

--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -62,6 +62,10 @@ class AppointmentForm
     Time.zone.parse(@time)
   end
 
+  def defined_contribution_pot_confirmed
+    location_aware_booking_request.defined_contribution_pot_confirmed ? 'Yes' : 'Not sure'
+  end
+
   private
 
   def validate_not_with_an_existing_booking_request

--- a/app/forms/edit_appointment_form.rb
+++ b/app/forms/edit_appointment_form.rb
@@ -10,4 +10,8 @@ class EditAppointmentForm < SimpleDelegator
   def flattened_locations
     FlattenedLocationMapper.map(booking_location)
   end
+
+  def defined_contribution_pot_confirmed
+    booking_request.defined_contribution_pot_confirmed ? 'Yes' : 'Not sure'
+  end
 end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -18,7 +18,7 @@ class BookingRequest < ActiveRecord::Base
   validates :age_range, inclusion: { in: PERMITTED_AGE_RANGES }
   validates :accessibility_requirements, inclusion: { in: [true, false] }
   validates :marketing_opt_in, inclusion: { in: [true, false] }
-  validates :defined_contribution_pot, inclusion: { in: [true, false] }
+  validates :defined_contribution_pot_confirmed, inclusion: { in: [true, false] }
   validate :validate_slots
 
   alias reference to_param

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -49,6 +49,11 @@
       </div>
 
       <div class="form-group">
+        <%= f.label :defined_contribution_pot_confirmed, 'Defined contribution pot confirmed?' %>
+        <%= f.text_field :defined_contribution_pot_confirmed, class: 'form-control t-defined-contribution-pot-confirmed', readonly: true %>
+      </div>
+
+      <div class="form-group">
         <%= f.label :memorable_word %>
         <%= f.text_field :memorable_word, class: 'form-control t-memorable-word', readonly: true %>
       </div>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -31,6 +31,11 @@
       <%= @appointment_form.phone %>
     </p>
 
+    <h3 class="h4">Defined contribution pot confirmed?</h2>
+    <p class="lead">
+      <strong class="t-defined-contribution-pot-confirmed"><%= @appointment_form.defined_contribution_pot_confirmed %></strong>
+    </p>
+
     <h3 class="h4">Requested location:</h3>
     <p class="lead">
       <strong>

--- a/db/migrate/20170201135525_rename_defined_contribution_pot.rb
+++ b/db/migrate/20170201135525_rename_defined_contribution_pot.rb
@@ -1,0 +1,5 @@
+class RenameDefinedContributionPot < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :booking_requests, :defined_contribution_pot, :defined_contribution_pot_confirmed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161104144629) do
+ActiveRecord::Schema.define(version: 20170201135525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,19 +65,19 @@ ActiveRecord::Schema.define(version: 20161104144629) do
   end
 
   create_table "booking_requests", force: :cascade do |t|
-    t.string   "location_id",                               null: false
-    t.string   "name",                                      null: false
-    t.string   "email",                                     null: false
-    t.string   "phone",                                     null: false
-    t.string   "memorable_word",                            null: false
-    t.string   "age_range",                                 null: false
-    t.boolean  "accessibility_requirements",                null: false
-    t.boolean  "marketing_opt_in",                          null: false
-    t.boolean  "defined_contribution_pot",                  null: false
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
-    t.string   "booking_location_id",                       null: false
-    t.boolean  "active",                     default: true, null: false
+    t.string   "location_id",                                       null: false
+    t.string   "name",                                              null: false
+    t.string   "email",                                             null: false
+    t.string   "phone",                                             null: false
+    t.string   "memorable_word",                                    null: false
+    t.string   "age_range",                                         null: false
+    t.boolean  "accessibility_requirements",                        null: false
+    t.boolean  "marketing_opt_in",                                  null: false
+    t.boolean  "defined_contribution_pot_confirmed",                null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
+    t.string   "booking_location_id",                               null: false
+    t.boolean  "active",                             default: true, null: false
     t.date     "date_of_birth"
   end
 

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
     date_of_birth '1950-01-01'
     accessibility_requirements false
     marketing_opt_in false
-    defined_contribution_pot true
+    defined_contribution_pot_confirmed true
 
     after(:build) do |booking_request|
       booking_request.slots << build(:slot, priority: 1)

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -57,6 +57,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     expect(@page.phone.value).to eq(@appointment.phone)
     expect(@page.memorable_word.value).to eq(@appointment.memorable_word)
     expect(@page.date_of_birth.value).to eq(@appointment.date_of_birth.iso8601)
+    expect(@page.defined_contribution_pot_confirmed.value).to eq('Yes')
 
     # ensure Hackney is pre-selected
     expect(@page.location.value).to eq('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -70,6 +70,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
     expect(@page.memorable_word.text).to eq(@booking_request.memorable_word)
     expect(@page.age_range.text).to eq(@booking_request.age_range)
     expect(@page.date_of_birth.text).to eq(@booking_request.date_of_birth.to_s(:gov_uk))
+    expect(@page.defined_contribution_pot_confirmed.text).to eq('Yes')
   end
 
   def and_they_see_the_requested_slots

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe BookingRequest do
       expect(build(:booking_request, marketing_opt_in: '')).to_not be_valid
     end
 
-    it 'requires defined_contribution_pot' do
-      expect(build(:booking_request, defined_contribution_pot: '')).to_not be_valid
+    it 'requires defined_contribution_pot_confirmed' do
+      expect(build(:booking_request, defined_contribution_pot_confirmed: '')).to_not be_valid
     end
 
     it 'requires 3 slots' do

--- a/spec/requests/create_a_booking_request_spec.rb
+++ b/spec/requests/create_a_booking_request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
         'date_of_birth' => '1950-01-01',
         'accessibility_requirements' => false,
         'marketing_opt_in' => true,
-        'defined_contribution_pot' => true,
+        'defined_contribution_pot_confirmed' => true,
         'slots' => [
           {
             'date' => '2016-01-01',
@@ -79,7 +79,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
       date_of_birth: Date.parse('1950-01-01'),
       accessibility_requirements: false,
       marketing_opt_in: true,
-      defined_contribution_pot: true
+      defined_contribution_pot_confirmed: true
     )
   end
 

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -12,6 +12,7 @@ module Pages
     element :date_of_birth, '.t-date-of-birth'
     element :location, '.t-location'
     element :guider, '.t-guider'
+    element :defined_contribution_pot_confirmed, '.t-defined-contribution-pot-confirmed'
 
     element :date, '.t-date'
     element :time_hour, '#appointment_proceeded_at_4i'

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -13,6 +13,7 @@ module Pages
     element :age_range, '.t-age-range'
     element :date_of_birth, '.t-date-of-birth'
     element :accessibility_requirements, '.t-accessibility'
+    element :defined_contribution_pot_confirmed, '.t-defined-contribution-pot-confirmed'
 
     element :slot_one_date,     '.t-slot-1-date'
     element :slot_one_period,   '.t-slot-1-period'


### PR DESCRIPTION
Displays this information at both the bookings and appointments stage.

Best reviewed commit-by-commit.

## Booking
![booking](https://cloud.githubusercontent.com/assets/41963/22511623/2764769e-e88e-11e6-9b3b-11863635bbb3.png)

## Appointment
![appointment](https://cloud.githubusercontent.com/assets/41963/22511631/2d7f1fc0-e88e-11e6-8b95-4652a10c877f.png)
