### PR TITLE
Allow filtering by reference or customer

### DIFF
--- a/app/assets/stylesheets/components/_appointments.scss
+++ b/app/assets/stylesheets/components/_appointments.scss
@@ -1,3 +1,7 @@
 .appointments tbody tr td { // scss-lint:disable SelectorDepth
   vertical-align: middle;
 }
+
+.panel-default .panel-heading {
+  background-color: transparent;
+}

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -3,8 +3,10 @@ class AppointmentsController < ApplicationController
   before_action :populate_edit_appointment_form, only: %i(edit update)
 
   def index
+    @search = AppointmentsSearchForm.new(search_params)
+
     @appointments = LocationAwareEntities.new(
-      current_user.appointments.page(params[:page]),
+      @search.results,
       booking_location
     )
   end
@@ -37,6 +39,14 @@ class AppointmentsController < ApplicationController
   end
 
   private
+
+  def search_params
+    {
+      search_term: params.dig(:search, :search_term),
+      current_user: current_user,
+      page: params[:page]
+    }
+  end
 
   def notify_customer(appointment)
     return unless appointment.notify?

--- a/app/forms/appointments_search_form.rb
+++ b/app/forms/appointments_search_form.rb
@@ -1,0 +1,26 @@
+class AppointmentsSearchForm
+  include ActiveModel::Model
+
+  attr_accessor :page
+  attr_accessor :search_term
+  attr_accessor :current_user
+
+  def results
+    scope = current_user.appointments
+    scope = search_term_scope(scope)
+
+    scope.page(page)
+  end
+
+  private
+
+  def search_term_scope(scope)
+    return scope unless search_term.present?
+
+    if /\A\d+\Z/ === search_term # rubocop:disable Style/CaseEquality
+      scope.where(booking_request_id: search_term)
+    else
+      scope.where('appointments.name ILIKE ?', "%#{search_term}%")
+    end
+  end
+end

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -7,6 +7,24 @@
   <h1>Appointments</h1>
 </div>
 
+<nav class="t-search">
+  <div class="panel panel-default">
+    <header class="panel-heading">
+      <ul class="nav nav-compact nav-pills">
+        <li>
+          <%= form_for @search, url: appointments_path, as: :search, method: :get, html: { class: 'inline form-inline' } do |f| %>
+            <div class="form-group">
+              <%= f.label :search_term, 'Customer / Booking Reference', class: 'add-right-margin' %>
+              <%= f.text_field :search_term, class: 't-search-term form-control' %>
+            </div>
+            <%= f.submit 'Search', class: 't-submit btn btn-default' %>
+          <% end %>
+        </li>
+      </ul>
+    </header>
+  </div>
+</div>
+
 <div class="row">
   <div class="col-md-12">
     <% if @appointments.page.empty? %>

--- a/spec/features/booking_manager_views_appointments_spec.rb
+++ b/spec/features/booking_manager_views_appointments_spec.rb
@@ -9,6 +9,44 @@ RSpec.feature 'Booking manager views appointments' do
     end
   end
 
+  scenario 'Searching appointments' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_are_matching_appointments_for_their_location
+      when_they_search_by_booking_reference
+      then_they_are_shown_the_appointment_matching_the_reference
+      when_they_search_by_customer_name
+      then_they_are_shown_the_appointment_matching_the_customer_name
+    end
+  end
+
+  def and_there_are_matching_appointments_for_their_location
+    @found_by_booking_reference = create(:appointment, name: 'Mr Reference')
+    @found_by_customer_name     = create(:appointment, name: 'Bob Bobson')
+  end
+
+  def when_they_search_by_booking_reference
+    @page = Pages::Appointments.new.tap(&:load)
+    expect(@page).to have_appointments(count: 2)
+
+    @page.search.search_term.set(@found_by_booking_reference.booking_request_id)
+    @page.search.submit.click
+  end
+
+  def then_they_are_shown_the_appointment_matching_the_reference
+    expect(@page).to have_appointments(count: 1)
+    expect(@page).to have_content('Mr Reference')
+  end
+
+  def when_they_search_by_customer_name
+    @page.search.search_term.set('Bobson')
+    @page.search.submit.click
+  end
+
+  def then_they_are_shown_the_appointment_matching_the_customer_name
+    expect(@page).to have_appointments(count: 1)
+    expect(@page).to have_content('Bob Bobson')
+  end
+
   def and_there_are_appointments_for_their_location
     create_list(:appointment, 11)
 

--- a/spec/support/pages/appointments.rb
+++ b/spec/support/pages/appointments.rb
@@ -5,5 +5,11 @@ module Pages
     sections :appointments, '.t-appointment' do
       element :edit, '.t-edit'
     end
+
+    section :search, '.t-search' do
+      element :search_term, '.t-search-term'
+
+      element :submit, '.t-submit'
+    end
   end
 end


### PR DESCRIPTION
Allows booking managers to search appointments by either the booking
reference or a fuzzy match on the customer's first / last name.

<img width="1130" alt="screen shot 2017-02-03 at 08 50 19" src="https://cloud.githubusercontent.com/assets/41963/22585084/e5f55e6a-e9ed-11e6-918e-a570d64d149b.png">
