### PR TITLE
Don't include guider's last name in confirmations

### DIFF
--- a/app/views/appointments/customer.html.erb
+++ b/app/views/appointments/customer.html.erb
@@ -10,7 +10,7 @@
 0;font-size: 16px;line-height: 1.315789474;">Thank you for booking an
 appointment with Pension Wise. We can confirm your appointment will be at <%=
 @appointment.proceeded_at.to_s(:govuk_date) %>. The appointment will take place
-at <%= @appointment.location_name %> and will be with <%= @appointment.guider_name %>.</p>
+at <%= @appointment.location_name %> and will be with <%= @appointment.guider_name.split.first %>.</p>
 
 <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px
 0;font-size: 16px;line-height: 1.315789474;">

--- a/app/views/appointments/customer.text.erb
+++ b/app/views/appointments/customer.text.erb
@@ -7,7 +7,7 @@ Your appointment details were updated.
 Thank you for booking an appointment with Pension Wise. We can confirm your
 appointment will be at <%= @appointment.proceeded_at.to_s(:govuk_date) %>. The
 appointment will take place at <%= @appointment.location_name %> and will be
-with <%= @appointment.guider_name %>.
+with <%= @appointment.guider_name.split.first %>.
 
 <% @appointment.address_lines.each do |line| %>
   <%= line %>

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Appointments do
         expect(body).to include("reference number, #{appointment.reference}")
       end
 
-      it 'includes the guider' do
-        expect(body).to include('Ben Lovell')
+      it 'includes the guider first name' do
+        expect(body).to include('Ben')
       end
 
       it 'includes the address' do


### PR DESCRIPTION
We've been asked to exclude the guider's last name when sending the
confirmation emails upon successful fulfilment.