### PR TITLE
Alter button colour to avoid having multiple primary buttons

### DIFF
--- a/app/views/activities/_activity_feed.html.erb
+++ b/app/views/activities/_activity_feed.html.erb
@@ -8,7 +8,7 @@
           <div class="input-group">
             <%= f.text_field :message, placeholder: 'Add an action to keep others in the loop', class: 'form-control js-message t-message' %>
             <span class="input-group-btn">
-              <%= f.button class: 'btn btn-primary btn-block t-submit-message', data: { disable_with: 'Adding message...' } do %>
+              <%= f.button class: 'btn btn-info btn-block t-submit-message', data: { disable_with: 'Adding message...' } do %>
                 <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
                 Add message
               <% end %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -80,7 +80,7 @@
                 <%= appointment.status.titleize %>
               </td>
               <td>
-                <%= link_to('Manage', edit_appointment_path(appointment), class: 'btn btn-primary t-edit') %>
+                <%= link_to('Manage', edit_appointment_path(appointment), class: 'btn btn-info t-edit') %>
               </td>
             </tr>
           <% end %>

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -51,7 +51,7 @@
                 <%= booking_request.reference %>
               </td>
               <td>
-                <%= link_to('Fulfil', new_booking_request_appointment_path(booking_request), class: 'btn btn-primary t-fulfil') %>
+                <%= link_to('Fulfil', new_booking_request_appointment_path(booking_request), class: 'btn btn-info t-fulfil') %>
               </td>
             </tr>
           <% end %>


### PR DESCRIPTION

<img width="1183" alt="screen shot 2017-02-09 at 16 37 11" src="https://cloud.githubusercontent.com/assets/6049076/22792846/0880f69a-eee6-11e6-9d6a-21c35626d7c2.png">
<img width="1241" alt="screen shot 2017-02-09 at 16 37 07" src="https://cloud.githubusercontent.com/assets/6049076/22792847/089b30e6-eee6-11e6-82a1-45e39c473025.png">



Ideally we want just one primary button per page, so here we
use 'info' buttons (from the bootstrap choice of button types)