### PR TITLE
Add mailer previews

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,6 +16,9 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  # default options for booking manager confirmation
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/spec/mailers/previews/appointments_preview.rb
+++ b/spec/mailers/previews/appointments_preview.rb
@@ -1,0 +1,8 @@
+class AppointmentsPreview < ActionMailer::Preview
+  def customer
+    Appointments.customer(
+      FactoryGirl.create(:appointment),
+      BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+    )
+  end
+end

--- a/spec/mailers/previews/booking_requests_preview.rb
+++ b/spec/mailers/previews/booking_requests_preview.rb
@@ -1,0 +1,14 @@
+class BookingRequestsPreview < ActionMailer::Preview
+  def customer
+    BookingRequests.customer(
+      FactoryGirl.create(:hackney_booking_request),
+      BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+    )
+  end
+
+  def booking_manager
+    BookingRequests.booking_manager(
+      FactoryGirl.create(:booking_manager)
+    )
+  end
+end


### PR DESCRIPTION
This lets us easily verify the content and layout of our transactional emails
at various points in the service.