### PR TITLE
Scheduled customer appointment reminders

### DIFF
--- a/app/jobs/appointment_reminder_job.rb
+++ b/app/jobs/appointment_reminder_job.rb
@@ -1,0 +1,11 @@
+class AppointmentReminderJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(appointment)
+    booking_location = BookingLocations.find(appointment.location_id)
+
+    ReminderActivity.from(appointment)
+
+    Appointments.reminder(appointment, booking_location).deliver_later
+  end
+end

--- a/app/jobs/appointment_reminders_job.rb
+++ b/app/jobs/appointment_reminders_job.rb
@@ -1,0 +1,9 @@
+class AppointmentRemindersJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    Appointment.needing_reminder.each do |appointment|
+      AppointmentReminderJob.perform_later(appointment)
+    end
+  end
+end

--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -10,6 +10,17 @@ class Appointments < ApplicationMailer
     mail to: appointment.email, subject: 'Your Pension Wise Appointment'
   end
 
+  def reminder(appointment, booking_location)
+    @appointment = LocationAwareEntity.new(
+      entity: appointment,
+      booking_location: booking_location
+    )
+
+    mailgun_headers :appointment_reminder
+
+    mail to: appointment.email, subject: 'Your Pension Wise Appointment Reminder'
+  end
+
   private
 
   def identification_headers_for(appointment)

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -41,6 +41,14 @@ class Appointment < ActiveRecord::Base
     super || Time.zone.now
   end
 
+  def self.needing_reminder
+    pending
+      .where(proceeded_at: Time.zone.now..24.hours.from_now)
+      .where.not(
+        booking_request_id: ReminderActivity.pluck(:booking_request_id)
+      )
+  end
+
   private
 
   def after_audit

--- a/app/models/reminder_activity.rb
+++ b/app/models/reminder_activity.rb
@@ -1,0 +1,8 @@
+class ReminderActivity < Activity
+  def self.from(appointment)
+    create!(
+      booking_request: appointment.booking_request,
+      message: ''
+    )
+  end
+end

--- a/app/views/activities/_reminder_activity.html.erb
+++ b/app/views/activities/_reminder_activity.html.erb
@@ -1,0 +1,5 @@
+<li class="activity-feed__item t-activity" id="activity-<%= reminder_activity.id %>">
+  <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
+  <strong>The system</strong> sent an appointment reminder email to the customer
+  <em class="badge"><%= time_ago_in_words(reminder_activity.created_at) %> ago</em>
+</li>

--- a/app/views/appointments/reminder.html.erb
+++ b/app/views/appointments/reminder.html.erb
@@ -1,0 +1,112 @@
+<h1 style="color: #0B0C0C !important;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  Appointment reminder
+</h1>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  Dear <%= @appointment.name %>,
+</p>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  This is a reminder that you have a Pension Wise appointment booked for:
+</p>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  Date:
+  <br>
+  <strong class="emphasize" style="font-size: 24px;">
+    <%= @appointment.proceeded_at.to_date.to_s(:govuk_date) %>
+  </strong>
+</p>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  Time:
+  <br>
+  <strong class="emphasize" style="font-size: 24px;">
+    <%= @appointment.proceeded_at.to_s(:govuk_time) %>
+  </strong>
+</p>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  Appointment location:
+  <br>
+  <strong class="emphasize" style="font-size: 24px;">
+    <%= @appointment.location_name %><br>
+    <% @appointment.address_lines.each do |line| %>
+      <%= line %><br>
+    <% end %>
+  </strong>
+</p>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  Guidance specialist:
+  <br>
+  <strong class="emphasize" style="font-size: 24px;">
+    <%= @appointment.guider_name.split.first %>
+  </strong>
+</p>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  Reference number:
+  <br>
+  <strong class="emphasize" style="font-size: 24px;">
+    <%= @appointment.reference %>
+  </strong>
+</p>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  Call <%= @appointment.booking_location.online_booking_twilio_number %> or email us to
+  change or cancel your booking. You may be asked for your booking reference number.
+</p>
+
+<h1 style="color: #0B0C0C !important;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  Preparing for your appointment
+</h1>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  To make the most of your appointment it would be helpful if you know:
+</p>
+
+<ul style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin-top: 15px;margin-bottom: 15px;font-size: 16px;line-height: 1.315789474;">
+  <li>
+    <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+      the value of your pension pot(s) - check your pension paperwork or ask your provider
+    </p>
+  </li>
+  <li>
+    <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+      an estimate of your State Pension - call the Future Pension Centre on 0345 3000 168 for a State Pension statement
+    </p>
+  </li>
+  <li>
+    <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+      any special arrangements attached to your pension pot, eg a guaranteed annuity rate or a guaranteed pot value at a certain time - ask your provider
+    </p>
+  </li>
+</ul>
+
+<p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+  Think about your financial circumstances in general and plans for retirement, eg:
+</p>
+
+<ul style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin-top: 15px;margin-bottom: 15px;font-size: 16px;line-height: 1.315789474;">
+  <li>
+    <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+    sources of income like salary, benefits, savings, investments
+    </p>
+  </li>
+  <li>
+    <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+      debts and repayments you might have
+    </p>
+  </li>
+  <li>
+    <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+      when you want to stop working
+    </p>
+  </li>
+  <li>
+    <p style="color: #0B0C0C;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-size: 16px;line-height: 1.315789474;">
+      if you want a fixed or flexible income in retirement
+    </p>
+  </li>
+</ul>

--- a/app/views/appointments/reminder.text.erb
+++ b/app/views/appointments/reminder.text.erb
@@ -1,0 +1,45 @@
+Appointment reminder
+
+Dear <%= @appointment.name %>,
+
+This is a reminder that you have a Pension Wise appointment booked for:
+
+Date:
+<%= @appointment.proceeded_at.to_date.to_s(:govuk_date) %>
+
+Time:
+<%= @appointment.proceeded_at.to_s(:govuk_time) %>
+
+Appointment location:
+<%= @appointment.location_name %>
+<% @appointment.address_lines.each do |line| %>
+<%= line %>
+<% end %>
+
+Guidance specialist:
+<%= @appointment.guider_name.split.first %>
+
+Reference number:
+<%= @appointment.reference %>
+
+Call <%= @appointment.booking_location.online_booking_twilio_number %> or email us to change or cancel 
+your booking. You may be asked for your booking reference number.
+
+Preparing for your appointment
+
+To make the most of your appointment it would be helpful if you know:
+
+* the value of your pension pot(s) - check your pension paperwork or ask your
+  provider
+* an estimate of your State Pension - call the Future Pension Centre on
+  0345 3000 168 for a State Pension statement
+* any special arrangements attached to your pension pot, eg a guaranteed
+  annuity rate or a guaranteed pot value at a certain time - ask your provider
+
+Think about your financial circumstances in general and plans for retirement,
+eg:
+
+* sources of income like salary, benefits, savings, investments
+* debts and repayments you might have
+* when you want to stop working
+* if you want a fixed or flexible income in retirement

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -5,4 +5,10 @@ FactoryGirl.define do
     message 'did a thing to a thing'
     type 'AuditActivity'
   end
+
+  factory :reminder_activity do
+    booking_request
+    message ''
+    type 'ReminderActivity'
+  end
 end

--- a/spec/features/scheduled_appointment_reminders_spec.rb
+++ b/spec/features/scheduled_appointment_reminders_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Scheduled appointment reminders' do
+  scenario 'sends reminders for suitable appointments' do
+    perform_enqueued_jobs do
+      travel_to '2016-06-19 15:00' do
+        given_suitable_and_unsuitable_appointments_exist
+        when_the_reminder_job_runs
+        then_the_email_reminder_is_delivered
+        and_a_reminder_activity_is_logged
+      end
+    end
+  end
+
+  def given_suitable_and_unsuitable_appointments_exist
+    @proceeded_at = Time.zone.parse('2016-06-20 12:00')
+
+    @needing_reminder = create(:appointment, proceeded_at: @proceeded_at)
+
+    @already_reminded = create(:appointment, proceeded_at: @proceeded_at) do |a|
+      create(:reminder_activity, booking_request: a.booking_request)
+    end
+  end
+
+  def when_the_reminder_job_runs
+    AppointmentRemindersJob.new.perform
+  end
+
+  def then_the_email_reminder_is_delivered
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+
+    expect(ActionMailer::Base.deliveries.first.subject).to eq(
+      'Your Pension Wise Appointment Reminder'
+    )
+  end
+
+  def and_a_reminder_activity_is_logged
+    expect(@needing_reminder.activities.first).to be_a(ReminderActivity)
+  end
+end

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -4,11 +4,48 @@ RSpec.describe Appointments do
   let(:appointment) { build_stubbed(:appointment) }
   let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
 
-  subject(:mail) { described_class.customer(appointment, hackney) }
+  describe 'Customer reminder' do
+    subject(:mail) { described_class.reminder(appointment, hackney) }
 
-  it_behaves_like 'mailgun identified email'
+    it_behaves_like 'mailgun identified email'
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Your Pension Wise Appointment Reminder')
+      expect(mail.to).to eq([appointment.email])
+      expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+    end
+
+    describe 'rendering the body' do
+      let(:body) { subject.body.encoded }
+
+      it 'includes the appointment particulars' do
+        expect(body).to include('2:00pm')
+        expect(body).to include('20 June 2016')
+        expect(body).to include('Hackney')
+        expect(body).to include('+443344556677')
+        expect(body).to include(appointment.reference)
+      end
+
+      it 'includes the guider first name' do
+        expect(body).to include('Ben')
+      end
+
+      it 'includes the address' do
+        expect(body).to include(
+          '300 Mare St',
+          'HACKNEY',
+          'London',
+          'E8 1HE'
+        )
+      end
+    end
+  end
 
   describe 'Customer notification' do
+    subject(:mail) { described_class.customer(appointment, hackney) }
+
+    it_behaves_like 'mailgun identified email'
+
     it 'renders the headers' do
       expect(mail.subject).to eq('Your Pension Wise Appointment')
       expect(mail.to).to eq([appointment.email])

--- a/spec/mailers/previews/appointments_preview.rb
+++ b/spec/mailers/previews/appointments_preview.rb
@@ -2,7 +2,20 @@ class AppointmentsPreview < ActionMailer::Preview
   def customer
     Appointments.customer(
       FactoryGirl.create(:appointment),
-      BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+      booking_location
     )
+  end
+
+  def reminder
+    Appointments.reminder(
+      FactoryGirl.create(:appointment),
+      booking_location
+    )
+  end
+
+  private
+
+  def booking_location
+    BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
   end
 end


### PR DESCRIPTION
We will now send scheduled appointment reminders at 3PM every day. This
will send an email reminder to the customer, containing their
appointment details. We are hoping this causes an uplift in appointment
attendance and in turn reduces the no-show rate.

The system guards against multiple reminder deliveries based on the
presence of the newly introduced `ReminderActivity` which also shows in
the activity feed as a record of this reminder being sent.

For this to run we will need to schedule creation of the
`AppointmentRemindersJob`, that in turn fans out a job per appointment
that needs a reminder sent.

## Email copy ##

![screen shot 2017-02-17 at 12 41 23](https://cloud.githubusercontent.com/assets/41963/23066085/b53d4d54-f510-11e6-960e-7ea0acbd3750.png)

## Activity Feed ##

![screen shot 2017-02-13 at 15 03 10](https://cloud.githubusercontent.com/assets/41963/22888658/719d953c-f1fe-11e6-9471-e9c38a62b78a.png)

