### PR TITLE
Use the latest phantomjs where possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   group :development, :test do
     gem 'capybara'
     gem 'factory_girl_rails'
+    gem 'phantomjs-binaries'
     gem 'pry-byebug'
     gem 'rspec-rails'
     gem 'site_prism'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,8 @@ GEM
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
+    phantomjs-binaries (2.1.1.1)
+      sys-uname (= 0.9.0)
     plek (1.12.0)
     poltergeist (1.11.0)
       capybara (~> 2.1)
@@ -297,6 +299,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sys-uname (0.9.0)
+      ffi (>= 1.0.0)
     term-ansicolor (1.4.0)
       tins (~> 1.0)
     thor (0.19.4)
@@ -344,6 +348,7 @@ DEPENDENCIES
   kaminari!
   newrelic_rpm!
   pg!
+  phantomjs-binaries!
   plek!
   poltergeist!
   pry-byebug!
@@ -366,4 +371,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.14.4


### PR DESCRIPTION
This gem loads the phantomjs binary from its own local bin path. This
ensures we get the latest / greatest phantomjs in all environments.

We removed this a while back to instead fallback on the locally sourced
binary since it was causing issues on my local machine, I've since
narrowed this down to `exec` spawning shells 'slowly' and patched the
issue.