### PR TITLE
Only notify active booking managers

### DIFF
--- a/app/jobs/booking_manager_confirmation_job.rb
+++ b/app/jobs/booking_manager_confirmation_job.rb
@@ -5,7 +5,7 @@ class BookingManagerConfirmationJob < ActiveJob::Base
 
   def perform(booking_request)
     booking_location = BookingLocations.find(booking_request.location_id)
-    booking_managers = User.where(organisation_content_id: booking_location.id)
+    booking_managers = User.active.where(organisation_content_id: booking_location.id)
 
     raise BookingManagersNotFoundError unless booking_managers.present?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@ class User < ActiveRecord::Base
 
   alias_attribute :booking_location_id, :organisation_content_id
 
+  scope :active, -> { where(disabled: false) }
+
   def unfulfilled_booking_requests(hidden: false)
     scope = booking_requests
             .includes(:appointment)

--- a/spec/jobs/booking_manager_confirmation_job_spec.rb
+++ b/spec/jobs/booking_manager_confirmation_job_spec.rb
@@ -25,4 +25,14 @@ RSpec.describe BookingManagerConfirmationJob, '#perform' do
       assert_enqueued_jobs(1) { subject }
     end
   end
+
+  context 'with only inactive booking managers' do
+    before { create(:hackney_booking_manager, disabled: true) }
+
+    let(:booking_location) { double(id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
+
+    it 'raises an error' do
+      expect { subject }.to raise_error(BookingManagersNotFoundError)
+    end
+  end
 end


### PR DESCRIPTION
We were attempting to notify `disabled` (this is GDS-SSO terminology
sadly) booking managers that have had their accounts revoked on our
signon instance. One concrete example being Matt's email account that
has been causing hard bounces since he left the Pension Wise
organisation.