### PR TITLE
Allow modifications to booking when fulfilling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'gds-sso'
   gem 'govuk_admin_template'
   gem 'kaminari'
+  gem 'momentjs-rails'
   gem 'newrelic_rpm'
   gem 'pg'
   gem 'plek'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    momentjs-rails (2.15.1)
+      railties (>= 3.1)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -346,6 +348,7 @@ DEPENDENCIES
   gds-sso!
   govuk_admin_template!
   kaminari!
+  momentjs-rails!
   newrelic_rpm!
   pg!
   phantomjs-binaries!
@@ -371,4 +374,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.4
+   1.14.5

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,4 +4,5 @@
 //= require_tree .
 
 PWPlanner.poller.init();
-PWPlanner.picker.init();
+PWPlanner.dateRangePicker.init();
+PWPlanner.dateTimePicker.init();

--- a/app/assets/javascripts/date-range-picker.js
+++ b/app/assets/javascripts/date-range-picker.js
@@ -3,9 +3,9 @@
 (function($) {
   'use strict';
 
-  var picker = {
+  var dateRangePicker = {
     init: function() {
-      this.$picker = $('.js-picker');
+      this.$picker = $('.js-date-range-picker');
 
       this.$picker.daterangepicker({
         ranges: {
@@ -34,6 +34,6 @@
   };
 
   window.PWPlanner = window.PWPlanner || {};
-  window.PWPlanner.picker = picker;
+  window.PWPlanner.dateRangePicker = dateRangePicker;
 
 })(jQuery);

--- a/app/assets/javascripts/date-time-picker.js
+++ b/app/assets/javascripts/date-time-picker.js
@@ -1,0 +1,22 @@
+/* global moment */
+
+(function($) {
+  'use strict';
+
+  var dateTimePicker = {
+    init: function() {
+      this.$picker = $('.js-date-time-picker');
+
+      this.$picker.daterangepicker({
+        singleDatePicker: true,
+        locale: {
+          format: 'DD MMMM YYYY'
+        }
+      });
+    }
+  };
+
+  window.PWPlanner = window.PWPlanner || {};
+  window.PWPlanner.dateTimePicker = dateTimePicker;
+
+})(jQuery);

--- a/app/assets/javascripts/modules/customer-age.es6
+++ b/app/assets/javascripts/modules/customer-age.es6
@@ -1,0 +1,58 @@
+/* global moment */
+{
+  'use strict';
+
+  class CustomerAge {
+    start(el) {
+      this.$el = el;
+
+      this.$day = this.$el.find('.js-dob-day');
+      this.$month = this.$el.find('.js-dob-month');
+      this.$year = this.$el.find('.js-dob-year');
+      this.$output = $(`#${this.$el.data('output-id')}`);
+
+      this.bindEvents();
+    }
+
+    bindEvents() {
+      this.$day.on('change input', this.renderCustomerAge.bind(this));
+      this.$month.on('change input', this.renderCustomerAge.bind(this));
+      this.$year.on('change input', this.renderCustomerAge.bind(this));
+      this.renderCustomerAge();
+    }
+
+    padNumber(val) {
+      return (`00${val}`).substr(-2, 2);
+    }
+
+    renderCustomerAge() {
+      this.emptyAge();
+
+      let day = parseInt(this.$day.val()),
+        month = parseInt(this.$month.val()),
+        year = parseInt(this.$year.val()),
+        today = moment(),
+        inputDate = null,
+        age = null;
+
+      if (!day || !month || !year || year < 1900 || year >= today.format('Y')) {
+        return;
+      }
+
+      day = this.padNumber(day);
+      month = this.padNumber(month);
+      inputDate = moment(`${year}-${month}-${day}`);
+      age = Math.floor(today.diff(inputDate, 'year'));
+
+      if (age) {
+        this.$output.html(`<b>${age}</b> years old`);
+      }
+    }
+
+    emptyAge() {
+      this.$output.html('');
+    }
+  }
+
+  window.GOVUKAdmin.Modules.CustomerAge = CustomerAge;
+}

--- a/app/assets/stylesheets/components/_activity-feed.scss
+++ b/app/assets/stylesheets/components/_activity-feed.scss
@@ -12,6 +12,10 @@
   & + & {
     border-width: 0;
   }
+
+  &:empty {
+    border: 0;
+  }
 }
 
 .activity-feed__item {

--- a/app/assets/stylesheets/components/_dob-form-field.scss
+++ b/app/assets/stylesheets/components/_dob-form-field.scss
@@ -1,0 +1,40 @@
+.form-dob {
+  .form-group {
+    display: inline;
+    margin-bottom: 0;
+  }
+
+  // scss-lint:disable SelectorFormat
+  .field_with_errors {
+    label {
+      display: inline-block;
+    }
+
+    .form-dob-label {
+      color: $state-danger-text;
+    }
+  }
+  // scss-lint:enable SelectorFormat
+
+  .form-dob-label {
+    margin-bottom: 10px;
+  }
+}
+
+.form-dob__inputs-container {
+  float: left;
+}
+
+.form-dob__input {
+  width: 64px;
+}
+
+.form-dob__input--year {
+  width: 90px;
+}
+
+.form-dob__age {
+  display: inline-block;
+  clear: left;
+  margin: 25px 0 0 5px;
+}

--- a/app/assets/stylesheets/components/_slot-picker.scss
+++ b/app/assets/stylesheets/components/_slot-picker.scss
@@ -44,6 +44,7 @@
 .SlotPicker-choice.is-chosen .SlotPicker-choiceInner {
   padding-left: 60px;
   padding-right: 0;
+  cursor: default;
 }
 
 .SlotPicker-choice.is-chosen .SlotPicker-choiceInner p {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  add_flash_types :success
+
   include GDS::SSO::ControllerMethods
 
   before_action do

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -33,7 +33,7 @@ class AppointmentsController < ApplicationController
       @appointment = Appointment.create(@appointment_form.appointment_params)
       notify_customer(@appointment)
 
-      redirect_to booking_requests_path
+      redirect_to booking_requests_path, success: 'Appointment was created'
     else
       render :new
     end
@@ -116,10 +116,17 @@ class AppointmentsController < ApplicationController
     appointment_params[:proceeded_at] += " #{hour}:#{minute}" if hour && minute
   end
 
-  def appointment_params
+  def appointment_params # rubocop:disable Metrics/MethodLength
     params
       .fetch(:appointment, {})
       .permit(
+        :name,
+        :email,
+        :phone,
+        :defined_contribution_pot_confirmed,
+        :accessibility_requirements,
+        :memorable_word,
+        :date_of_birth,
         :guider_id,
         :location_id,
         :date,

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -1,4 +1,16 @@
 module AppointmentHelper
+  def field_with_errors_wrapper(form, field, klass)
+    error_class = form.object.errors[field].any? ? "field_with_errors #{klass}" : klass
+
+    content_tag(:div, class: error_class) { yield }
+  end
+
+  def required_label(field = nil)
+    content_tag(:span, field.to_s.humanize) +
+      content_tag(:span, '*', class: 'text-danger', 'aria-hidden': true) +
+      content_tag(:span, 'Required', class: 'sr-only')
+  end
+
   def friendly_options(statuses)
     statuses.map { |k, _| [k.titleize, k] }.to_h
   end

--- a/app/mappers/appointment_mapper.rb
+++ b/app/mappers/appointment_mapper.rb
@@ -1,9 +1,13 @@
 class AppointmentMapper
-  def self.map(appointment_form)
+  def self.map(appointment_form) # rubocop:disable Metrics/MethodLength
     {
       name: appointment_form.name,
       email: appointment_form.email,
       phone: appointment_form.phone,
+      memorable_word: appointment_form.memorable_word,
+      date_of_birth: appointment_form.date_of_birth,
+      defined_contribution_pot_confirmed: appointment_form.defined_contribution_pot_confirmed,
+      accessibility_requirements: appointment_form.accessibility_requirements,
       guider_id: appointment_form.guider_id,
       location_id: appointment_form.location_id,
       proceeded_at: Time.zone.parse("#{appointment_form.date} #{appointment_form.time.strftime('%H:%M')}"),

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -15,11 +15,14 @@ class Appointment < ActiveRecord::Base
 
   belongs_to :booking_request
 
-  delegate :reference, :activities, :memorable_word, :date_of_birth, to: :booking_request
+  delegate :reference, :activities, to: :booking_request
 
   validates :name, presence: true
   validates :email, presence: true, email: true
   validates :phone, presence: true
+  validates :memorable_word, presence: true
+  validates :accessibility_requirements, inclusion: { in: [true, false] }
+  validates :defined_contribution_pot_confirmed, inclusion: { in: [true, false] }
   validates :location_id, presence: true
   validates :guider_id, presence: true
   validate  :validate_proceeded_at

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -16,7 +16,7 @@
             <%= f.label :search_term, 'Customer / Reference', class: 'filters__label' %><%= f.text_field :search_term, class: 't-search-term form-control filters__form-control' %>
           </li>
           <li class="filters__item">
-            <%= f.label :appointment_date, 'Date', class: 'filters__label' %><%= f.text_field :appointment_date, class: 'js-picker t-appointment-date form-control filters__form-control', readonly: true %>
+            <%= f.label :appointment_date, 'Date', class: 'filters__label' %><%= f.text_field :appointment_date, class: 'js-date-range-picker t-appointment-date form-control filters__form-control', readonly: true %>
           </li>
           <li class="filters__item">
             <%= f.label :status, class: 'filters__label' %><%= f.select :status, friendly_options(Appointment.statuses), { include_blank: 'All Statuses' }, { class: 'form-control filters__form-control t-status' } %>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -2,9 +2,8 @@
   <ol class="breadcrumb">
     <li><a href="<%= root_path %>">Appointment planner</a></li>
     <li><a href="<%= root_path %>">Booking requests</a></li>
-    <li class="active t-name"><%= @appointment_form.name %></li>
+    <li class="active"><%= @appointment_form.name %></li>
   </ol>
-
   <h1>
     Make appointment for <%= @appointment_form.name %><br>
     <small>Booking reference: <span class="t-reference"><%= @appointment_form.reference %></span></small>
@@ -18,52 +17,17 @@
 
 <div class="row">
   <div class="col-md-12">
-    <p class="lead">If no appointments are available within the customer's preferences, please contact the customer directly to find a suitable time slot, and return to this page to make the appointment.</p>
+    <p class="lead">If the customer’s appointment choices are unavailable, contact them to arrange a new time and date. Return to this page to book the appointment.</p>
   </div>
 </div>
 
+<%= form_for @appointment_form,
+    url: booking_request_appointments_path(@appointment_form.location_aware_booking_request),
+    as: :appointment do |f|
+%>
 <div class="row">
-  <div class="col-md-4 dont-break-out">
-    <h2 class="h3">Customer details</h2>
-    <p class="lead">
-      <%= @appointment_form.name %><br>
-      <a href="mailto:<%= @appointment_form.email %>" class="t-email"><%= @appointment_form.email %></a><br>
-      <%= @appointment_form.phone %>
-    </p>
-
-    <h3 class="h4">Defined contribution pot confirmed?</h2>
-    <p class="lead">
-      <strong class="t-defined-contribution-pot-confirmed"><%= @appointment_form.defined_contribution_pot_confirmed %></strong>
-    </p>
-
-    <h3 class="h4">Requested location:</h3>
-    <p class="lead">
-      <strong>
-        <a href="https://www.pensionwise.gov.uk/locations/<%= @appointment_form.location_id %>" class="t-location-name">
-          <%= @appointment_form.location_name %>
-        </a>
-      </strong>
-    </p>
-
-    <h3 class="h4">Memorable word:</h3>
-    <p class="lead"><strong class="t-memorable-word"><%= @appointment_form.memorable_word %></strong></p>
-
-    <h3 class="h4">Age range:</h3>
-    <p class="lead"><strong class="t-age-range"><%= @appointment_form.age_range %></strong></p>
-
-    <h3 class="h4">Date of birth:</h3>
-    <p class="lead"><strong class="t-date-of-birth"><%= @appointment_form.date_of_birth.try(:to_s, :gov_uk) %></strong></p>
-
-    <h3 class="h4">Accessibility requirements:</h3>
-    <p class="lead">
-      <strong class="t-accessibility_requirements">
-        <%= t("booking_request.accessibility_requirements.is_#{@appointment_form.accessibility_requirements}") %>
-      </strong>
-    </p>
-  </div>
-
   <div class="col-md-4">
-    <h2 class="h3">Slots requested</h2>
+    <h2 class="h3">Requested appointment</h2>
     <p>The customer has requested the following time slots, in order of preference.</p>
 
     <div class="SlotPicker-choices is-chosen SlotPicker--selected">
@@ -97,11 +61,23 @@
         </div>
       </div>
     </div>
+
+    <h3 class="h4">Requested location:</h3>
+    <p class="lead">
+      <strong>
+        <a href="https://www.pensionwise.gov.uk/locations/<%= @appointment_form.location_aware_booking_request.location_id %>" class="t-location-name">
+          <%= @appointment_form.location_aware_booking_request.location_name %>
+        </a>
+      </strong>
+    </p>
+
+    <hr style="margin-bottom: 24px;">
+    <br><br>
+    <%= toggle_activation_link(@appointment_form.location_aware_booking_request) %>
   </div>
 
-  <div class="col-md-4">
-    <div class="well">
-      <h2 class="h3">Appointment details</h2>
+  <div class="col-md-8">
+    <div class="well" style="overflow: hidden;">
 
       <% if @appointment_form.errors.any? %>
         <div class="alert alert-danger t-errors" role="alert">
@@ -114,10 +90,40 @@
         </div>
       <% end %>
 
-      <%= form_for @appointment_form,
-        url: booking_request_appointments_path(@appointment_form.location_aware_booking_request),
-        as: :appointment do |f|
-      %>
+      <div class="col-md-6">
+        <h2 class="h3" style="margin-top: 0;">Customer details</h2>
+        <div class="form-group">
+          <%= f.label :name %>
+          <%= f.text_field :name, class: 'form-control t-name' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :email %>
+          <%= f.text_field :email, class: 'form-control t-email' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :phone %>
+          <%= f.text_field :phone, class: 'form-control t-phone' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :memorable_word %>
+          <%= f.text_field :memorable_word, class: 'form-control t-memorable-word' %>
+        </div>
+        <%= render partial: 'shared/date_of_birth_form_field', locals: { form: f } %>
+        <div class="form-group">
+          <%= f.label :defined_contribution_pot_confirmed, class: 'checkbox-inline' do %>
+            <%= f.check_box :defined_contribution_pot_confirmed, class: 't-defined-contribution-pot-confirmed' %> Defined contribution pot confirmed?
+          <% end %>
+        </div>
+        <div class="form-group">
+          <%= f.label :accessibility_requirements, class: 'checkbox-inline' do %>
+            <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements' %> Accessibility requirements?
+          <% end %>
+        </div>
+      </div>
+
+      <div class="col-md-6">
+        <h2 class="h3" style="margin-top: 0;">Appointment details</h2>
+
         <div class="form-group">
           <%= f.label :guider_id %>
           <%= f.select(
@@ -140,11 +146,7 @@
 
         <div class="form-group">
           <%= f.label :date %>
-          <%= f.date_field(
-            :date,
-            value: @appointment_form.date,
-            class: 't-date form-control'
-          ) %>
+          <%= f.text_field :date, class: 'js-date-time-picker t-date form-control', value: @appointment_form.date.to_date.to_s(:govuk_date) %>
         </div>
 
         <div class="form-group">
@@ -157,13 +159,14 @@
             ) %>
           </div>
         </div>
+      </div>
+    </div>
 
-        <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
-          Make appointment and notify<br><%= @appointment_form.name %>
-        <% end %>
-
-        <%= toggle_activation_link(@appointment_form.location_aware_booking_request) %>
+    <div class="col-md-12">
+      <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
+        Make appointment and notify <%= @appointment_form.name %>
       <% end %>
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -1,0 +1,67 @@
+<%
+  form_element_day_id = "#{form.object_name}_date_of_birth_3i"
+  form_element_month_id = "#{form.object_name}_date_of_birth_2i"
+  form_element_year_id = "#{form.object_name}_date_of_birth_1i"
+%>
+
+<div class="form-dob clearfix" data-module="customer-age" data-output-id="customer-age">
+  <%= field_with_errors_wrapper(form, :date_of_birth, 'form-dob__inputs-container') do %>
+    <label for="<%= form_element_day_id %>">
+      <span class="sr-only">Date of birth</span> <%= required_label(:day) %>
+      <%=
+        form.text_field(
+          'date_of_birth(3i)',
+          id: form_element_day_id,
+          use_label: false,
+          value: form.object.date_of_birth.try(:day),
+          placeholder: 'DD',
+          class: 'form-dob__input js-dob-day t-date-of-birth-day form-control',
+          pattern: '[0-9]+',
+          maxlength: 2,
+          required: true,
+          title: 'Must be numeric eg 01',
+          'aria-describedby': 'dob-hint'
+        )
+      %>
+    </label>
+    <label for="<%= form_element_month_id %>">
+      <span class="sr-only">Date of birth</span> <%= required_label(:month) %>
+      <%=
+        form.text_field(
+          'date_of_birth(2i)',
+          id: form_element_month_id,
+          use_label: false,
+          value: form.object.date_of_birth.try(:month),
+          placeholder: 'MM',
+          class: 'form-dob__input js-dob-month t-date-of-birth-month form-control',
+          pattern: '[0-9]+',
+          maxlength: 2,
+          title: 'Must be numeric eg 01',
+          required: true
+        )
+      %>
+    </label>
+    <label for="<%= form_element_year_id %>">
+      <span class="sr-only">Date of birth</span> <%= required_label(:year) %>
+      <%=
+        form.text_field(
+          'date_of_birth(1i)',
+          id: form_element_year_id,
+          use_label: false,
+          value: form.object.date_of_birth.try(:year),
+          placeholder: 'YYYY',
+          class: 'form-dob__input form-dob__input--year js-dob-year t-date-of-birth-year form-control',
+          pattern: '[0-9]+',
+          maxlength: 4,
+          title: 'Must be numeric eg 1955',
+          required: true
+        )
+      %>
+    </label>
+    <% form.object.errors[:date_of_birth].each do |message| %>
+      <div class="text-danger"><%= message %></div>
+    <% end %>
+  <% end %>
+  <span class="bg-info form-dob__age" id="customer-age"></span>
+</div>
+<div class="help-block" id="dob-hint">For example, 31 3 1950</div>

--- a/db/migrate/20170301160815_add_missing_appointment_attributes.rb
+++ b/db/migrate/20170301160815_add_missing_appointment_attributes.rb
@@ -1,0 +1,8 @@
+class AddMissingAppointmentAttributes < ActiveRecord::Migration[5.0]
+  def change
+    add_column :appointments, :memorable_word, :string, default: '', null: false
+    add_column :appointments, :date_of_birth, :date, null: true
+    add_column :appointments, :defined_contribution_pot_confirmed, :boolean, default: true, null: false
+    add_column :appointments, :accessibility_requirements, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20170301180007_add_missing_values_to_appointments.rb
+++ b/db/migrate/20170301180007_add_missing_values_to_appointments.rb
@@ -1,0 +1,16 @@
+class AddMissingValuesToAppointments < ActiveRecord::Migration[5.0]
+  def up
+    Appointment.find_each do |appointment|
+      appointment.update_attributes(
+        memorable_word: appointment.booking_request.memorable_word,
+        date_of_birth: appointment.booking_request.date_of_birth,
+        defined_contribution_pot_confirmed: appointment.booking_request.defined_contribution_pot_confirmed,
+        accessibility_requirements: appointment.booking_request.accessibility_requirements
+      )
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170201135525) do
+ActiveRecord::Schema.define(version: 20170301180007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,18 +26,22 @@ ActiveRecord::Schema.define(version: 20170201135525) do
   end
 
   create_table "appointments", force: :cascade do |t|
-    t.integer  "booking_request_id",                    null: false
-    t.string   "name",                                  null: false
-    t.string   "email",                                 null: false
-    t.string   "phone",                                 null: false
-    t.integer  "guider_id",                             null: false
-    t.string   "location_id",                           null: false
-    t.datetime "proceeded_at",                          null: false
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
-    t.integer  "status",                    default: 0, null: false
-    t.integer  "fulfilment_time_seconds",   default: 0, null: false
-    t.integer  "fulfilment_window_seconds", default: 0, null: false
+    t.integer  "booking_request_id",                                 null: false
+    t.string   "name",                                               null: false
+    t.string   "email",                                              null: false
+    t.string   "phone",                                              null: false
+    t.integer  "guider_id",                                          null: false
+    t.string   "location_id",                                        null: false
+    t.datetime "proceeded_at",                                       null: false
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
+    t.integer  "status",                             default: 0,     null: false
+    t.integer  "fulfilment_time_seconds",            default: 0,     null: false
+    t.integer  "fulfilment_window_seconds",          default: 0,     null: false
+    t.string   "memorable_word",                     default: "",    null: false
+    t.date     "date_of_birth"
+    t.boolean  "defined_contribution_pot_confirmed", default: true,  null: false
+    t.boolean  "accessibility_requirements",         default: false, null: false
     t.index ["booking_request_id"], name: "index_appointments_on_booking_request_id", using: :btree
     t.index ["location_id"], name: "index_appointments_on_location_id", using: :btree
   end

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -5,6 +5,10 @@ FactoryGirl.define do
     name 'Mortimer Smith'
     email 'morty@example.com'
     phone '07719 334 5678'
+    memorable_word 'spaceships'
+    defined_contribution_pot_confirmed true
+    accessibility_requirements false
+    date_of_birth '1950-01-01'
     guider_id 1
     proceeded_at Time.zone.parse('2016-06-20 14:00')
   end

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     memorable_word 'spaceship'
     age_range '50-54'
     date_of_birth '1950-01-01'
-    accessibility_requirements false
+    accessibility_requirements true
     marketing_opt_in false
     defined_contribution_pot_confirmed true
 

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -21,7 +21,14 @@ RSpec.describe AppointmentForm do
         'location_id' => 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
         'date'        => '2016-06-21',
         'time(4i)'    => '13',
-        'time(5i)'    => '00'
+        'time(5i)'    => '00',
+        'name'        => 'Mick Smith',
+        'email'       => 'mick@example.com',
+        'phone'       => '01189 889 889',
+        'memorable_word' => 'snoopy',
+        'date_of_birth'  => '1950-01-01',
+        'accessibility_requirements' => '1',
+        'defined_contribution_pot_confirmed' => '1'
       }
     end
 
@@ -34,6 +41,30 @@ RSpec.describe AppointmentForm do
 
     it 'must not be associated with an existing appointment' do
       booking_request.appointment = build(:appointment)
+
+      expect(subject).to_not be_valid
+    end
+
+    it 'requires a name' do
+      params[:name] = ''
+
+      expect(subject).to_not be_valid
+    end
+
+    it 'requires an email' do
+      params[:email] = ''
+
+      expect(subject).to_not be_valid
+    end
+
+    it 'requires a phone' do
+      params[:phone] = ''
+
+      expect(subject).to_not be_valid
+    end
+
+    it 'requires a memorable word' do
+      params[:memorable_word] = ''
 
       expect(subject).to_not be_valid
     end
@@ -71,7 +102,6 @@ RSpec.describe AppointmentForm do
     expect(subject.name).to eq(booking_request.name)
     expect(subject.email).to eq(booking_request.email)
     expect(subject.phone).to eq(booking_request.phone)
-    expect(subject.age_range).to eq(booking_request.age_range)
     expect(subject.date_of_birth).to eq(booking_request.date_of_birth)
     expect(subject.reference).to eq(booking_request.reference)
     expect(subject.memorable_word).to eq(booking_request.memorable_word)

--- a/spec/mappers/appointment_mapper_spec.rb
+++ b/spec/mappers/appointment_mapper_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe AppointmentMapper, '.map' do
       'location_id' => 'deadbeef-e3cf-45cd-a8ff-9ba827b8e7ef',
       'date'        => '2016-01-01',
       'time(4i)'    => '13',
-      'time(5i)'    => '00'
+      'time(5i)'    => '00',
+      'date_of_birth' => '1950-01-01',
+      'memorable_word' => 'spaceship',
+      'accessibility_requirements' => '1',
+      'defined_contribution_pot_confirmed' => '1'
     }
   end
   let(:appointment_form) do
@@ -27,7 +31,11 @@ RSpec.describe AppointmentMapper, '.map' do
       proceeded_at: Time.zone.parse('2016-01-01 13:00'),
       guider_id: '1',
       location_id: 'deadbeef-e3cf-45cd-a8ff-9ba827b8e7ef',
-      booking_request_id: appointment_form.reference
+      booking_request_id: appointment_form.reference,
+      date_of_birth: appointment_form.date_of_birth,
+      memorable_word: appointment_form.memorable_word,
+      defined_contribution_pot_confirmed: appointment_form.defined_contribution_pot_confirmed,
+      accessibility_requirements: appointment_form.accessibility_requirements
     )
   end
 end

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -7,12 +7,15 @@ module Pages
 
     element :name, '.t-name'
     element :reference, '.t-reference'
+    element :phone, '.t-phone'
     element :email, '.t-email'
     element :location_name, '.t-location-name'
     element :memorable_word, '.t-memorable-word'
     element :age_range, '.t-age-range'
-    element :date_of_birth, '.t-date-of-birth'
-    element :accessibility_requirements, '.t-accessibility'
+    element :day_of_birth, '.t-date-of-birth-day'
+    element :month_of_birth, '.t-date-of-birth-month'
+    element :year_of_birth, '.t-date-of-birth-year'
+    element :accessibility_requirements, '.t-accessibility-requirements'
     element :defined_contribution_pot_confirmed, '.t-defined-contribution-pot-confirmed'
 
     element :slot_one_date,     '.t-slot-1-date'


### PR DESCRIPTION
We now allow the booking managers to modify the booking request in
place before transitioning to the appointment. The booking request
itself is still considered immutable, so this required a 1:1 mirroring
of booking request attributes to appointment attributes.

This also required some duplication of validation rules between the
resultant appointment and the form object. Once we add the further,
editable attributes on the appointment edit screen I can consolidate
these rules into once place.

![screen shot 2017-03-02 at 10 00 54](https://cloud.githubusercontent.com/assets/41963/23502598/4591b8c6-ff30-11e6-95ef-6a28025475eb.png)
