### PR TITLE
Don't audit when copying attributes

### DIFF
--- a/db/migrate/20170301180007_add_missing_values_to_appointments.rb
+++ b/db/migrate/20170301180007_add_missing_values_to_appointments.rb
@@ -1,12 +1,14 @@
 class AddMissingValuesToAppointments < ActiveRecord::Migration[5.0]
   def up
     Appointment.find_each do |appointment|
-      appointment.update_attributes(
-        memorable_word: appointment.booking_request.memorable_word,
-        date_of_birth: appointment.booking_request.date_of_birth,
-        defined_contribution_pot_confirmed: appointment.booking_request.defined_contribution_pot_confirmed,
-        accessibility_requirements: appointment.booking_request.accessibility_requirements
-      )
+      appointment.without_auditing do
+        appointment.update_attributes(
+          memorable_word: appointment.booking_request.memorable_word,
+          date_of_birth: appointment.booking_request.date_of_birth,
+          defined_contribution_pot_confirmed: appointment.booking_request.defined_contribution_pot_confirmed,
+          accessibility_requirements: appointment.booking_request.accessibility_requirements
+        )
+      end
     end
   end
 


### PR DESCRIPTION
This makes no sense to log and shouldn't be pointed out to the customer
by way of an appointment or booking request activity entry.

Amendments to migrations are usually a bad idea but we're fine here
since this has yet to run and in those environments where it has it can
be deemed idempotent.