### PR TITLE
Supplementary appointment fields are editable

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -19,7 +19,7 @@ class AppointmentsController < ApplicationController
     if @appointment_form.update(edit_appointment_params)
       notify_customer(@appointment_form.entity)
 
-      redirect_to appointments_path
+      redirect_to appointments_path, success: 'Appointment was updated'
     else
       render :edit
     end
@@ -100,6 +100,10 @@ class AppointmentsController < ApplicationController
         :name,
         :email,
         :phone,
+        :defined_contribution_pot_confirmed,
+        :accessibility_requirements,
+        :memorable_word,
+        :date_of_birth,
         :guider_id,
         :location_id,
         :proceeded_at,

--- a/app/forms/edit_appointment_form.rb
+++ b/app/forms/edit_appointment_form.rb
@@ -10,8 +10,4 @@ class EditAppointmentForm < SimpleDelegator
   def flattened_locations
     FlattenedLocationMapper.map(booking_location)
   end
-
-  def defined_contribution_pot_confirmed
-    booking_request.defined_contribution_pot_confirmed ? 'Yes' : 'Not sure'
-  end
 end

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -6,7 +6,7 @@
   </ol>
 
   <h1>
-    Modify/cancel appointment for <%= @appointment_form.name %><br>
+    Manage appointment for <%= @appointment_form.name %><br>
     <small>Booking reference: <%= @appointment_form.reference %></small>
   </h1>
 </div>
@@ -16,137 +16,128 @@
   booking_request: @appointment_form.booking_request
 } %>
 
-<div class="row">
-  <div class="col-md-4">
-    <h2 class="h3">Change appointment details</h2>
-    <p class="lead">Use the form below to change the details of the appointment.</p>
+<%= form_for @appointment_form do |f| %>
+  <div class="row">
+    <div class="col-md-4">
+      <h2 class="h3">Requested appointment</h2>
+      <p>The customer has requested the following time slots, in order of preference.</p>
 
-    <% if @appointment_form.errors.any? %>
-      <div class="alert alert-danger t-errors" role="alert">
-        <h3 class="alert__heading h4">There's a problem</h3>
-        <ul>
-          <% @appointment_form.errors.full_messages.each do |msg| %>
-            <li><%= msg %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-
-    <%= form_for @appointment_form do |f| %>
-      <div class="form-group">
-        <%= f.label :name %>
-        <%= f.text_field :name, class: 'form-control t-name' %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :email %>
-        <%= f.text_field :email, class: 'form-control t-email' %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :phone %>
-        <%= f.text_field :phone, class: 'form-control t-phone' %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :defined_contribution_pot_confirmed, 'Defined contribution pot confirmed?' %>
-        <%= f.text_field :defined_contribution_pot_confirmed, class: 'form-control t-defined-contribution-pot-confirmed', readonly: true %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :memorable_word %>
-        <%= f.text_field :memorable_word, class: 'form-control t-memorable-word', readonly: true %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :date_of_birth %>
-        <%= f.date_field :date_of_birth, class: 't-date-of-birth form-control', readonly: true %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :guider_id %>
-        <%= f.select(
-          :guider_id,
-          options_from_collection_for_select(@appointment_form.guiders, 'id', 'name', selected: @appointment_form.guider_id),
-          options = {},
-          class: 'form-control t-guider'
-        ) %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :location_id %>
-        <%= f.select(:location_id, @appointment_form.flattened_locations, options = {}, { class: 'form-control t-location' }
-        ) %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :proceeded_at, 'Date of appointment' %>
-        <%= f.date_field(:proceeded_at, class: 't-date form-control') %>
-      </div>
-
-      <div class="form-group">
-        <%= f.label :proceeded_at, 'Time of appointment' %>
-        <div class="form-control">
-          <%= f.time_select(:proceeded_at, ignore_date: true, minute_step: 15) %>
-        </div>
-      </div>
-
-      <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
-        Update appointment and notify<br><%= @appointment_form.name %>
-      <% end %>
-    <% end %>
-  </div>
-
-  <div class="col-md-4">
-    <h2 class="h3">After the appointment</h2>
-    <p class="lead">Appointment finished? Update the status below.</p>
-
-    <%= form_for @appointment_form do |f| %>
-      <div class="form-group">
-        <%= f.label :status, 'Appointment status' %>
-        <%= f.select :status, friendly_options(Appointment.statuses), options = {}, { class: 'form-control t-status' } %>
-      </div>
-
-      <%= f.button class: 'btn btn-primary btn-block t-submit-status' do %>
-        Update status
-      <% end %>
-    <% end %>
-  </div>
-
-  <div class="col-md-4">
-    <h2 class="h3">Original slots requested</h2>
-    <p class="lead">For reference, the slots originally requested by the customer are:</p>
-
-    <div class="SlotPicker-choices is-chosen SlotPicker--selected">
-      <div class="SlotPicker-choice is-chosen">
-        <div class="SlotPicker-choiceInner">
-          <div class="SlotPicker-position"><span>1</span></div>
-          <div class="SlotPicker-choiceContent">
-            <p class="SlotPicker-date t-slot-1-date"><%= @appointment_form.primary_slot.formatted_date %></p>
-            <p class="SlotPicker-time t-slot-1-period"><%= @appointment_form.primary_slot.period %></p>
+      <div class="SlotPicker-choices is-chosen SlotPicker--selected">
+        <div class="SlotPicker-choice is-chosen">
+          <div class="SlotPicker-choiceInner">
+            <div class="SlotPicker-position"><span>1</span></div>
+            <div class="SlotPicker-choiceContent">
+              <p class="SlotPicker-date t-slot-1-date"><%= @appointment_form.primary_slot.formatted_date %></p>
+              <p class="SlotPicker-time t-slot-1-period"><%= @appointment_form.primary_slot.period %></p>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="SlotPicker-choice is-chosen">
-        <div class="SlotPicker-choiceInner">
-          <div class="SlotPicker-position"><span>2</span></div>
-          <div class="SlotPicker-choiceContent">
-            <p class="SlotPicker-date t-slot-2-date"><%= @appointment_form.secondary_slot.formatted_date %></p>
-            <p class="SlotPicker-time t-slot-2-period"><%= @appointment_form.secondary_slot.period %></p>
+        <div class="SlotPicker-choice is-chosen">
+          <div class="SlotPicker-choiceInner">
+            <div class="SlotPicker-position"><span>2</span></div>
+            <div class="SlotPicker-choiceContent">
+              <p class="SlotPicker-date t-slot-2-date"><%= @appointment_form.secondary_slot.formatted_date %></p>
+              <p class="SlotPicker-time t-slot-2-period"><%= @appointment_form.secondary_slot.period %></p>
+            </div>
           </div>
         </div>
-      </div>
 
-      <div class="SlotPicker-choice is-chosen">
-        <div class="SlotPicker-choiceInner">
-          <div class="SlotPicker-position"><span>3</span></div>
-          <div class="SlotPicker-choiceContent">
-            <p class="SlotPicker-date t-slot-3-date"><%= @appointment_form.tertiary_slot.formatted_date %></p>
-            <p class="SlotPicker-time t-slot-3-period"><%= @appointment_form.tertiary_slot.period %></p>
+        <div class="SlotPicker-choice is-chosen">
+          <div class="SlotPicker-choiceInner">
+            <div class="SlotPicker-position"><span>3</span></div>
+            <div class="SlotPicker-choiceContent">
+              <p class="SlotPicker-date t-slot-3-date"><%= @appointment_form.tertiary_slot.formatted_date %></p>
+              <p class="SlotPicker-time t-slot-3-period"><%= @appointment_form.tertiary_slot.period %></p>
+            </div>
           </div>
         </div>
       </div>
     </div>
+    <div class="col-md-8">
+      <div class="well" style="overflow: hidden;">
+        <% if @appointment_form.errors.any? %>
+          <div class="alert alert-danger t-errors" role="alert">
+            <h3 class="alert__heading h4">There's a problem</h3>
+            <ul>
+              <% @appointment_form.errors.full_messages.each do |msg| %>
+                <li><%= msg %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div class="row">
+          <div class="col-md-6">
+            <h2 class="h3" style="margin-top: 0;">Customer details</h2>
+            <div class="form-group">
+              <%= f.label :name %>
+              <%= f.text_field :name, class: 'form-control t-name' %>
+            </div>
+            <div class="form-group">
+              <%= f.label :email %>
+              <%= f.text_field :email, class: 'form-control t-email' %>
+            </div>
+            <div class="form-group">
+              <%= f.label :phone %>
+              <%= f.text_field :phone, class: 'form-control t-phone' %>
+            </div>
+            <div class="form-group">
+              <%= f.label :memorable_word %>
+              <%= f.text_field :memorable_word, class: 'form-control t-memorable-word' %>
+            </div>
+            <%= render partial: 'shared/date_of_birth_form_field', locals: { form: f } %>
+            <div class="form-group">
+              <%= f.label :defined_contribution_pot_confirmed, class: 'checkbox-inline' do %>
+                <%= f.check_box :defined_contribution_pot_confirmed, class: 't-defined-contribution-pot-confirmed' %> Defined contribution pot confirmed?
+              <% end %>
+            </div>
+            <div class="form-group">
+              <%= f.label :accessibility_requirements, class: 'checkbox-inline' do %>
+                <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements' %> Accessibility requirements?
+              <% end %>
+            </div>
+          </div>
+          <div class="col-md-6">
+            <h2 class="h3" style="margin-top: 0;">Appointment details</h2>
+            <div class="form-group">
+              <%= f.label :guider_id %>
+              <%= f.select(
+                :guider_id,
+                options_from_collection_for_select(@appointment_form.guiders, 'id', 'name', selected: @appointment_form.guider_id),
+                options = {},
+                class: 'form-control t-guider'
+              ) %>
+            </div>
+            <div class="form-group">
+              <%= f.label :location_id %>
+              <%= f.select(:location_id, @appointment_form.flattened_locations, options = {}, { class: 'form-control t-location' }
+              ) %>
+            </div>
+            <div class="form-group">
+              <%= f.label :proceeded_at, 'Date of appointment' %>
+              <%= f.text_field(:proceeded_at, class: 'js-date-time-picker t-date form-control', value: @appointment_form.proceeded_at.to_date.to_s(:govuk_date)) %>
+            </div>
+            <div class="form-group">
+              <%= f.label :proceeded_at, 'Time of appointment' %>
+              <div class="form-control">
+                <%= f.time_select(:proceeded_at, ignore_date: true, minute_step: 15) %>
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="well" style="background: #CCC">
+                <%= f.label :status, 'Appointment status' %>
+                <%= f.select :status, friendly_options(Appointment.statuses), options = {}, { class: 'form-control t-status' } %>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-12">
+          <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
+            Update appointment details for <%= @appointment_form.name %>
+          <% end %>
+        </div>
+      </div>
+    </div>
   </div>
-</div>
+<% end %>

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -56,13 +56,16 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     expect(@page.email.value).to eq(@appointment.email)
     expect(@page.phone.value).to eq(@appointment.phone)
     expect(@page.memorable_word.value).to eq(@appointment.memorable_word)
-    expect(@page.date_of_birth.value).to eq(@appointment.date_of_birth.iso8601)
-    expect(@page.defined_contribution_pot_confirmed.value).to eq('Yes')
+    expect(@page.day_of_birth.value).to eq(@appointment.date_of_birth.day.to_s)
+    expect(@page.month_of_birth.value).to eq(@appointment.date_of_birth.month.to_s)
+    expect(@page.year_of_birth.value).to eq(@appointment.date_of_birth.year.to_s)
+    expect(@page.defined_contribution_pot_confirmed.value).to eq('1')
+    expect(@page.accessibility_requirements.value).to eq('1')
 
     # ensure Hackney is pre-selected
     expect(@page.location.value).to eq('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
 
-    expect(@page.date.value).to eq('2016-06-20')
+    expect(@page.date.value).to eq('20 June 2016')
     expect(@page.time_hour.value).to eq('14')
     expect(@page.time_minute.value).to eq('00')
   end
@@ -80,8 +83,16 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     expect(@page.slot_three_period.text).to eq(@booking_request.tertiary_slot.period)
   end
 
-  def when_they_modify_the_appointment_details
+  def when_they_modify_the_appointment_details # rubocop:disable Metrics/MethodLength
     @page.name.set('Bob Jones')
+    @page.email.set('bob@example.com')
+    @page.phone.set('01189 888 888')
+    @page.memorable_word.set('snarf')
+    @page.day_of_birth.set('02')
+    @page.month_of_birth.set('02')
+    @page.year_of_birth.set('1945')
+    @page.defined_contribution_pot_confirmed.set(false)
+    @page.accessibility_requirements.set(false)
     @page.date.set('2016-06-21')
     @page.time_hour.set('15')
     @page.time_minute.set('15')
@@ -119,7 +130,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
 
   def when_they_modify_the_status
     @page.status.select('Completed')
-    @page.submit_status.click
+    @page.submit.click
   end
 
   def then_the_status_is_updated

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -9,9 +9,12 @@ module Pages
     element :email, '.t-email'
     element :phone, '.t-phone'
     element :memorable_word, '.t-memorable-word'
-    element :date_of_birth, '.t-date-of-birth'
     element :location, '.t-location'
     element :guider, '.t-guider'
+    element :day_of_birth, '.t-date-of-birth-day'
+    element :month_of_birth, '.t-date-of-birth-month'
+    element :year_of_birth, '.t-date-of-birth-year'
+    element :accessibility_requirements, '.t-accessibility-requirements'
     element :defined_contribution_pot_confirmed, '.t-defined-contribution-pot-confirmed'
 
     element :date, '.t-date'
@@ -28,7 +31,6 @@ module Pages
     element :submit, '.t-submit'
 
     element :status, '.t-status'
-    element :submit_status, '.t-submit-status'
 
     elements :errors, '.field_with_errors'
     element :error_summary, '.t-errors'


### PR DESCRIPTION
Makes all appointment fields editable and collapses the previously
separate status form into the main edit form.

![screen shot 2017-03-02 at 13 37 40](https://cloud.githubusercontent.com/assets/41963/23509394/8bac8bca-ff4d-11e6-9817-430921f934d4.png)
