### PR TITLE
Use redis for a centralised API cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,5 +52,6 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
 
   group :staging, :production do
     gem 'rails_12factor'
+    gem 'redis-rails', require: false
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,22 @@ GEM
     rainbow (2.2.1)
     rake (12.0.0)
     redis (3.3.2)
+    redis-actionpack (5.0.1)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 1.4.0)
+    redis-activesupport (5.0.1)
+      activesupport (>= 3, < 6)
+      redis-store (~> 1.2.0)
+    redis-rack (2.0.0)
+      rack (~> 2.0)
+      redis-store (~> 1.2.0)
+    redis-rails (5.0.1)
+      redis-actionpack (~> 5.0.0)
+      redis-activesupport (~> 5.0.0)
+      redis-store (~> 1.2.0)
+    redis-store (1.2.0)
+      redis (>= 2.2)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -360,6 +376,7 @@ DEPENDENCIES
   rails-assets-bootstrap-daterangepicker!
   rails-observers!
   rails_12factor!
+  redis-rails!
   rspec-rails!
   rubocop!
   sassc-rails!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require 'redis-rails'
+
 Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -60,7 +62,7 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  config.cache_store = :memory_store
+  config.cache_store = :redis_store
 
   # Log cache hits / misses
   ActiveSupport::Cache::Store.logger = Rails.logger


### PR DESCRIPTION
Cache locations using the centralised (shared) redis cache in the
staging and production environments. Keys are still expired respective
of their configured TTL.

Before now we relied on the memory store for cache backing, this
doesn't survive restarts so deploys were causing multiple cache misses
until the caches were warmed through.