### PR TITLE
Ensuring layout of edit appointment page is similar to booking request

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,4 +2,5 @@
 @import 'bootstrap-daterangepicker';
 
 @import 'helpers/**/*';
+@import 'layout/**/*';
 @import 'components/**/*';

--- a/app/assets/stylesheets/components/_appointment-status-well.scss
+++ b/app/assets/stylesheets/components/_appointment-status-well.scss
@@ -1,0 +1,3 @@
+.appointment-status-well {
+  background: $appointment-status-well-background-color;
+}

--- a/app/assets/stylesheets/components/_appointments.scss
+++ b/app/assets/stylesheets/components/_appointments.scss
@@ -1,7 +1,3 @@
 .appointments tbody tr td { // scss-lint:disable SelectorDepth
   vertical-align: middle;
 }
-
-.panel-default .panel-heading {
-  background-color: transparent;
-}

--- a/app/assets/stylesheets/components/_booking-requests.scss
+++ b/app/assets/stylesheets/components/_booking-requests.scss
@@ -2,14 +2,6 @@
   margin-bottom: 16px;
 }
 
-.booking-request-details {
-  overflow: hidden;
-
-  .h3 {
-    margin-top: 0;
-  }
-}
-
 .booking-request-show-hide-btn {
   margin-bottom: 20px;
 }

--- a/app/assets/stylesheets/components/_filters.scss
+++ b/app/assets/stylesheets/components/_filters.scss
@@ -15,7 +15,7 @@
   }
 
   &[readonly] {
-    background: $color-white;
+    background: $read-only-background;
   }
 }
 

--- a/app/assets/stylesheets/helpers/_colours.scss
+++ b/app/assets/stylesheets/helpers/_colours.scss
@@ -1,1 +1,5 @@
 $color-white: #fff;
+$color-silver: #ccc;
+
+$appointment-status-well-background-color: $color-silver;
+$read-only-background: $color-white;

--- a/app/assets/stylesheets/layout/_appointment-details.scss
+++ b/app/assets/stylesheets/layout/_appointment-details.scss
@@ -1,0 +1,7 @@
+.l-appointment-details {
+  overflow: hidden;
+
+  .h3 {
+    margin-top: 0;
+  }
+}

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -54,8 +54,8 @@
         </div>
       </div>
     </div>
-    <div class="col-md-8">
-      <div class="well" style="overflow: hidden;">
+    <div class="col-md-8 l-appointment-details">
+      <div class="well">
         <% if @appointment_form.errors.any? %>
           <div class="alert alert-danger t-errors" role="alert">
             <h3 class="alert__heading h4">There's a problem</h3>
@@ -66,10 +66,9 @@
             </ul>
           </div>
         <% end %>
-
         <div class="row">
           <div class="col-md-6">
-            <h2 class="h3" style="margin-top: 0;">Customer details</h2>
+            <h2 class="h3">Customer details</h2>
             <div class="form-group">
               <%= f.label :name %>
               <%= f.text_field :name, class: 'form-control t-name' %>
@@ -99,7 +98,7 @@
             </div>
           </div>
           <div class="col-md-6">
-            <h2 class="h3" style="margin-top: 0;">Appointment details</h2>
+            <h2 class="h3">Appointment details</h2>
             <div class="form-group">
               <%= f.label :guider_id %>
               <%= f.select(
@@ -125,17 +124,19 @@
               </div>
             </div>
             <div class="form-group">
-              <div class="well" style="background: #CCC">
+              <div class="well appointment-status-well">
                 <%= f.label :status, 'Appointment status' %>
                 <%= f.select :status, friendly_options(Appointment.statuses), options = {}, { class: 'form-control t-status' } %>
               </div>
             </div>
           </div>
         </div>
-        <div class="col-md-12">
-          <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
-            Update appointment details for <%= @appointment_form.name %>
-          <% end %>
+        <div class="row">
+          <div class="col-md-12">
+            <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
+              Update appointment details for <%= @appointment_form.name %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -77,8 +77,8 @@
     <% end %>
   </div>
 
-  <div class="col-md-8">
-    <div class="well booking-request-details">
+  <div class="col-md-8 l-appointment-details">
+    <div class="well">
       <% if @appointment_form.errors.any? %>
         <div class="alert alert-danger t-errors" role="alert">
           <h3 class="alert__heading h4">There's a problem</h3>


### PR DESCRIPTION
This tidies up some of the markup to get rid of inline styles
and makes the update button the full width of the 'well'

<img width="1164" alt="screen shot 2017-03-02 at 16 25 18" src="https://cloud.githubusercontent.com/assets/6049076/23516329/da0a7996-ff64-11e6-85bd-ea2686b83e4c.png">
