### PR TITLE
Alter the DC Pot question to a radio button selection

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -15,7 +15,7 @@ class AppointmentForm
   validates :phone, presence: true
   validates :memorable_word, presence: true
   validates :accessibility_requirements, inclusion: { in: [true, false, '1', '0'] }
-  validates :defined_contribution_pot_confirmed, inclusion: { in: [true, false, '1', '0'] }
+  validates :defined_contribution_pot_confirmed, inclusion: { in: %w(true false) }
 
   validates :guider_id, presence: true
   validates :location_id, presence: true

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -87,8 +87,15 @@
             </div>
             <%= render partial: 'shared/date_of_birth_form_field', locals: { form: f } %>
             <div class="form-group">
-              <%= f.label :defined_contribution_pot_confirmed, class: 'checkbox-inline' do %>
-                <%= f.check_box :defined_contribution_pot_confirmed, class: 't-defined-contribution-pot-confirmed' %> Defined contribution pot confirmed?
+              <p>Defined contribution pot confirmed?</p>
+              <%= f.label :defined_contribution_pot_confirmed, value: true, class: 'radio-inline' do %>
+                  <%= f.radio_button :defined_contribution_pot_confirmed, true, class: 't-defined-contribution-pot-confirmed-yes' %>
+                  Yes
+              <% end %>
+
+              <%= f.label :defined_contribution_pot_confirmed, value: false, class: 'radio-inline' do %>
+                <%= f.radio_button :defined_contribution_pot_confirmed, false, class: 't-defined-contribution-pot-confirmed-dont-know' %>
+                Don't know
               <% end %>
             </div>
             <div class="form-group">

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -111,8 +111,15 @@
           </div>
           <%= render partial: 'shared/date_of_birth_form_field', locals: { form: f } %>
           <div class="form-group">
-            <%= f.label :defined_contribution_pot_confirmed, class: 'checkbox-inline' do %>
-              <%= f.check_box :defined_contribution_pot_confirmed, class: 't-defined-contribution-pot-confirmed' %> Defined contribution pot confirmed?
+            <p>Defined contribution pot confirmed?</p>
+            <%= f.label :defined_contribution_pot_confirmed, value: true, class: 'radio-inline' do %>
+                <%= f.radio_button :defined_contribution_pot_confirmed, true, class: 't-defined-contribution-pot-confirmed-yes' %>
+                Yes
+            <% end %>
+
+            <%= f.label :defined_contribution_pot_confirmed, value: false, class: 'radio-inline' do %>
+              <%= f.radio_button :defined_contribution_pot_confirmed, false, class: 't-defined-contribution-pot-confirmed-dont-know' %>
+              Don't know
             <% end %>
           </div>
           <div class="form-group">

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     expect(@page.day_of_birth.value).to eq(@appointment.date_of_birth.day.to_s)
     expect(@page.month_of_birth.value).to eq(@appointment.date_of_birth.month.to_s)
     expect(@page.year_of_birth.value).to eq(@appointment.date_of_birth.year.to_s)
-    expect(@page.defined_contribution_pot_confirmed.value).to eq('1')
+    expect(@page.defined_contribution_pot_confirmed_yes).to be_checked
     expect(@page.accessibility_requirements.value).to eq('1')
 
     # ensure Hackney is pre-selected
@@ -91,7 +91,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     @page.day_of_birth.set('02')
     @page.month_of_birth.set('02')
     @page.year_of_birth.set('1945')
-    @page.defined_contribution_pot_confirmed.set(false)
+    @page.defined_contribution_pot_confirmed_dont_know.set true
     @page.accessibility_requirements.set(false)
     @page.date.set('21 June 2016')
     @page.time_hour.select('15')

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
     expect(@page.day_of_birth.value).to eq(@booking_request.date_of_birth.day.to_s)
     expect(@page.month_of_birth.value).to eq(@booking_request.date_of_birth.month.to_s)
     expect(@page.year_of_birth.value).to eq(@booking_request.date_of_birth.year.to_s)
-    expect(@page.defined_contribution_pot_confirmed.value).to eq('1')
+    expect(@page.defined_contribution_pot_confirmed_yes).to be_checked
     expect(@page.accessibility_requirements.value).to eq('1')
   end
 
@@ -100,7 +100,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
     @page.day_of_birth.set '02'
     @page.month_of_birth.set '02'
     @page.year_of_birth.set '1945'
-    @page.defined_contribution_pot_confirmed.set false
+    @page.defined_contribution_pot_confirmed_dont_know.set true
     @page.accessibility_requirements.set false
   end
 

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AppointmentForm do
         'memorable_word' => 'snoopy',
         'date_of_birth'  => '1950-01-01',
         'accessibility_requirements' => '1',
-        'defined_contribution_pot_confirmed' => '1'
+        'defined_contribution_pot_confirmed' => 'true'
       }
     end
 

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -15,7 +15,8 @@ module Pages
     element :month_of_birth, '.t-date-of-birth-month'
     element :year_of_birth, '.t-date-of-birth-year'
     element :accessibility_requirements, '.t-accessibility-requirements'
-    element :defined_contribution_pot_confirmed, '.t-defined-contribution-pot-confirmed'
+    element :defined_contribution_pot_confirmed_yes, '.t-defined-contribution-pot-confirmed-yes'
+    element :defined_contribution_pot_confirmed_dont_know, '.t-defined-contribution-pot-confirmed-dont-know'
 
     element :date, '.t-date'
     element :time_hour, '#appointment_proceeded_at_4i'

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -16,7 +16,8 @@ module Pages
     element :month_of_birth, '.t-date-of-birth-month'
     element :year_of_birth, '.t-date-of-birth-year'
     element :accessibility_requirements, '.t-accessibility-requirements'
-    element :defined_contribution_pot_confirmed, '.t-defined-contribution-pot-confirmed'
+    element :defined_contribution_pot_confirmed_yes, '.t-defined-contribution-pot-confirmed-yes'
+    element :defined_contribution_pot_confirmed_dont_know, '.t-defined-contribution-pot-confirmed-dont-know'
 
     element :slot_one_date,     '.t-slot-1-date'
     element :slot_one_period,   '.t-slot-1-period'


### PR DESCRIPTION
Users were getting confused over a checkbox for 'DC Pot confirmed?'
This changes the question in the booking request and edit
appointment pages to two radio buttons

"Yes" and "Don't know"

<img width="412" alt="screen shot 2017-03-03 at 11 51 40" src="https://cloud.githubusercontent.com/assets/6049076/23550202/ca3e1042-0007-11e7-86db-78973ddc4c96.png">
