### PR TITLE
Use curly apostrophe instead of straight one on Don't know

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -95,7 +95,7 @@
 
               <%= f.label :defined_contribution_pot_confirmed, value: false, class: 'radio-inline' do %>
                 <%= f.radio_button :defined_contribution_pot_confirmed, false, class: 't-defined-contribution-pot-confirmed-dont-know' %>
-                Don't know
+                Don’t know
               <% end %>
             </div>
             <div class="form-group">

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -119,7 +119,7 @@
 
             <%= f.label :defined_contribution_pot_confirmed, value: false, class: 'radio-inline' do %>
               <%= f.radio_button :defined_contribution_pot_confirmed, false, class: 't-defined-contribution-pot-confirmed-dont-know' %>
-              Don't know
+              Don’t know
             <% end %>
           </div>
           <div class="form-group">


### PR DESCRIPTION
Pension Wise standard is to use smart quotes/apostrophes where
possible

<img width="120" alt="screen shot 2017-03-03 at 12 26 28" src="https://cloud.githubusercontent.com/assets/6049076/23551115/a5d7cdc4-000c-11e7-8e6e-9966e60fa76c.png">
