### PR TITLE
Ensure cached entries are evicted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.7.0)
+    booking_locations (0.9.1)
       activesupport (>= 4, < 5.1)
       globalid
     bootstrap-kaminari-views (0.0.5)
@@ -81,7 +81,7 @@ GEM
       xpath (~> 2.0)
     cliver (0.3.2)
     coderay (1.1.1)
-    concurrent-ruby (1.0.4)
+    concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     coveralls (0.8.19)
       json (>= 1.8, < 3)
@@ -128,7 +128,7 @@ GEM
       rails (>= 3.2.0)
     hashdiff (0.3.2)
     hashie (3.4.6)
-    i18n (0.8.0)
+    i18n (0.8.1)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -322,7 +322,7 @@ GEM
     term-ansicolor (1.4.0)
       tins (~> 1.0)
     thor (0.19.4)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tilt (2.0.5)
     tins (1.13.2)
     tzinfo (1.2.2)
@@ -391,4 +391,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/spec/features/booking_manager_views_booking_requests_spec.rb
+++ b/spec/features/booking_manager_views_booking_requests_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature 'Viewing Booking Requests' do
-  scenario 'Administrator changes their location', js: true do
+  scenario 'Administrators can change their location' do
     given_the_user_identifies_as_hackneys_administrator do
       and_there_are_booking_requests_for_their_location
       when_they_visit_the_site
       then_they_are_shown_booking_requests_for_their_locations
-      when_they_change_their_location
-      then_they_are_shown_booking_requests_for_their_new_location
+      then_they_see_the_administrative_location_choices
     end
   end
 
@@ -40,15 +39,8 @@ RSpec.feature 'Viewing Booking Requests' do
     expect(@page).to have_no_location
   end
 
-  def when_they_change_their_location
-    @page.location.select 'Taunton'
-  end
-
-  def then_they_are_shown_booking_requests_for_their_new_location
-    # this will wait for the JS triggered reload
-    expect(@page.booking_requests.first).to have_content('Taunton')
-
-    expect(@page).to have_booking_requests(count: 1)
+  def then_they_see_the_administrative_location_choices
+    expect(@page.location).to be_visible
   end
 
   def and_there_are_booking_requests_for_their_location
@@ -56,9 +48,6 @@ RSpec.feature 'Viewing Booking Requests' do
 
     # this won't be listed as it's not `active`
     create(:hackney_booking_request, active: false)
-
-    # this won't be listed as it's not under Hackney
-    create(:taunton_booking_request)
 
     # this won't be listed as it's fulfilled
     create(:appointment)

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Appointments do
         expect(body).to include('2:00pm')
         expect(body).to include('20 June 2016')
         expect(body).to include('Hackney')
-        expect(body).to include('+443344556677')
+        expect(body).to include('+442086291134')
         expect(body).to include(appointment.reference)
       end
 
@@ -33,7 +33,7 @@ RSpec.describe Appointments do
       it 'includes the address' do
         expect(body).to include(
           '300 Mare St',
-          'HACKNEY',
+          'Hackney',
           'London',
           'E8 1HE'
         )
@@ -59,7 +59,7 @@ RSpec.describe Appointments do
         expect(body).to include('2:00pm')
         expect(body).to include('20 June 2016')
         expect(body).to include('Hackney')
-        expect(body).to include('+443344556677')
+        expect(body).to include('+442086291134')
         expect(body).to include(appointment.reference)
       end
 
@@ -70,7 +70,7 @@ RSpec.describe Appointments do
       it 'includes the address' do
         expect(body).to include(
           '300 Mare St',
-          'HACKNEY',
+          'Hackney',
           'London',
           'E8 1HE'
         )

--- a/spec/mappers/flattened_location_mapper_spec.rb
+++ b/spec/mappers/flattened_location_mapper_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe FlattenedLocationMapper, '.map' do
         ['Dalston', '183080c6-642b-4b8f-96fd-891f5cd9f9c7'],
         ['Tower Hamlets', '1a1ad00f-d967-448a-a4a6-772369fa5087'],
         ['Haringey', 'c165d25e-f27b-4ce9-b3d3-e7415ebaa93c'],
-        ['Waltham Forest', 'a77a031a-8037-4510-b1f7-63d4aab7b103']
+        ['Enfield', '1cc67bbb-b879-4def-8713-99255a0bce03'],
+        ['Newham', '89821b79-b132-4893-bc9f-c247dd9009fd']
       ]
     )
   end


### PR DESCRIPTION
The booking locations API gem now ensures the cache TTL is respected.
Since we had to bump several major versions there were a few changes we
had to accomodate in our tests, due mostly to changes in the stubbed
response JSON provided by the gem for testing purposes.