### PR TITLE
Add page titles across the app

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: "Manage appointment for #{@appointment_form.name}")) %>
 <div class="page-header">
   <ol class="breadcrumb">
     <li><a href="<%= root_path %>">Appointment planner</a></li>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Appointments')) %>
 <div class="page-header">
   <ol class="breadcrumb">
     <li><a href="<%= root_path %>">Appointment planner</a></li>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: "Make appointment for #{@appointment_form.name}")) %>
 <div class="page-header">
   <ol class="breadcrumb">
     <li><a href="<%= root_path %>">Appointment planner</a></li>

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:page_title, t('service.title', page_title: 'Booking requests')) %>
 <div class="page-header">
   <ol class="breadcrumb">
     <li><%= link_to 'Appointment planner', root_path %></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,5 @@ en:
     accessibility_requirements:
       is_true: "Requested, please discuss with customer"
       is_false: "Not requested"
+  service:
+    title: '%{page_title} - Appointment Planner'


### PR DESCRIPTION
Each page should have it's own tailored title to
aid bookmarking pages, and helping users know
which page they are on in the tab of a browser