### PR TITLE
Log at the info level

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
Log at the info level so we get single-line event logs from lograge.
Debug gives us more verbosity around SQL queries being executed but we
can trace these elsewhere so they're redundant here and noising up the
logs.