### PR TITLE
Expose API to reassign child locations

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -16,6 +16,15 @@ module Api
         end
       end
 
+      def batch_reassign
+        BatchBookingRequestReassignment.new(
+          booking_location_id: params[:booking_location_id],
+          location_id:         params[:location_id]
+        ).call
+
+        head :no_content
+      end
+
       private
 
       def send_notifications(booking_request)

--- a/app/lib/batch_booking_request_reassignment.rb
+++ b/app/lib/batch_booking_request_reassignment.rb
@@ -1,0 +1,25 @@
+class BatchBookingRequestReassignment
+  def initialize(booking_location_id:, location_id:)
+    @booking_location_id = booking_location_id
+    @location_id = location_id
+  end
+
+  def call
+    affected_bookings
+      .update_all(booking_location_id: booking_location_id) # rubocop:disable Rails/SkipsModelValidations
+
+    expire_cached_locations
+  end
+
+  private
+
+  attr_reader :booking_location_id, :location_id
+
+  def expire_cached_locations
+    Rails.cache.clear
+  end
+
+  def affected_bookings
+    @affected_bookings ||= BookingRequest.where(location_id: location_id)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,9 @@ Rails.application.routes.draw do
 
   namespace :api, constraints: { format: :json } do
     namespace :v1 do
-      resources :booking_requests, only: :create
+      resources :booking_requests, only: :create do
+        patch :batch_reassign, on: :collection
+      end
     end
   end
 

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -25,6 +25,16 @@ FactoryGirl.define do
       location_id 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
     end
 
+    factory :hackney_child_booking_request do
+      booking_location_id 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
+      location_id '89821b79-b132-4893-bc9f-c247dd9009fd'
+    end
+
+    factory :taunton_child_booking_request do
+      booking_location_id '7f916cf6-d2bd-4bcc-90dc-594207c8b1f4'
+      location_id '13e12f95-f709-4536-b6ee-8d7a735ddf9f'
+    end
+
     factory :taunton_booking_request do
       booking_location_id '7f916cf6-d2bd-4bcc-90dc-594207c8b1f4'
       location_id '7f916cf6-d2bd-4bcc-90dc-594207c8b1f4'

--- a/spec/requests/reassign_bookings_to_new_booking_locations_api_spec.rb
+++ b/spec/requests/reassign_bookings_to_new_booking_locations_api_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'PATCH /api/v1/booking_requests' do
+  scenario 'reassign child bookings to the specified booking location' do
+    given_the_client_identifies_as_pension_wise
+    and_a_booking_request_belonging_to_a_child_of_hackney_exists
+    and_a_booking_request_belonging_to_a_child_of_taunton_exists
+    and_the_locations_are_cached
+    when_the_client_makes_a_valid_reassignment_request
+    then_the_booking_requests_are_correctly_reassigned
+    and_the_required_cache_entries_are_expired
+    and_the_service_responds_with_a_204
+  end
+
+  def given_the_client_identifies_as_pension_wise
+    create(:pension_wise_api_user)
+  end
+
+  def and_a_booking_request_belonging_to_a_child_of_hackney_exists
+    @newham_booking_request = create(:hackney_child_booking_request)
+  end
+
+  def and_a_booking_request_belonging_to_a_child_of_taunton_exists
+    @north_somerset_booking_request = create(:taunton_child_booking_request)
+  end
+
+  def and_the_locations_are_cached
+    @cache_keys = [
+      @newham_booking_request.booking_location_id,
+      @newham_booking_request.location_id,
+      @north_somerset_booking_request.booking_location_id,
+      @north_somerset_booking_request.location_id
+    ].each do |cache_key|
+      Rails.cache.write(cache_key, 'stuff')
+    end
+  end
+
+  def when_the_client_makes_a_valid_reassignment_request
+    valid_payload = {
+      'location_id' => @newham_booking_request.location_id,
+      'booking_location_id' => @north_somerset_booking_request.booking_location_id
+    }
+
+    patch batch_reassign_api_v1_booking_requests_path, params: valid_payload, as: :json
+  end
+
+  def then_the_booking_requests_are_correctly_reassigned
+    expect(@newham_booking_request.reload.booking_location_id).to eq(
+      @north_somerset_booking_request.booking_location_id
+    )
+  end
+
+  def and_the_required_cache_entries_are_expired
+    @cache_keys.each do |cache_key|
+      expect(Rails.cache.fetch(cache_key)).to be_nil
+    end
+  end
+
+  def and_the_service_responds_with_a_204
+    expect(response).to be_no_content
+  end
+end


### PR DESCRIPTION
We need to expose an API that is called in response to a child
location being reassigned to a new booking location in the locations
registry. Since we maintain referential integrity with both the booking
location and the child location here we need to be sure to keep them in
sync with the canonical source of locations.

Once the change is made here we simply flush our whole cache rather
than trying to determine which exact locations need flushing. This is
an API call that will happen very infrequently and only while the
location mergers and closures are happening.

Clients can call the API as below:

`PATCH /api/v1/booking_requests/batch_reassign` with the following
payload:

```javascript
  {
    "booking_location_id": "...", // new booking location
    "location_id": "..." // the location being reassigned
  }
```