### PR TITLE
Clear only cached locations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.10.0)
+    booking_locations (0.12.0)
       activesupport (>= 4, < 5.1)
       globalid
     bootstrap-kaminari-views (0.0.5)

--- a/app/lib/batch_booking_request_reassignment.rb
+++ b/app/lib/batch_booking_request_reassignment.rb
@@ -8,16 +8,12 @@ class BatchBookingRequestReassignment
     affected_bookings
       .update_all(booking_location_id: booking_location_id) # rubocop:disable Rails/SkipsModelValidations
 
-    expire_cached_locations
+    BookingLocations.clear_cache
   end
 
   private
 
   attr_reader :booking_location_id, :location_id
-
-  def expire_cached_locations
-    Rails.cache.clear
-  end
 
   def affected_bookings
     @affected_bookings ||= BookingRequest.where(location_id: location_id)

--- a/spec/requests/reassign_bookings_to_new_booking_locations_api_spec.rb
+++ b/spec/requests/reassign_bookings_to_new_booking_locations_api_spec.rb
@@ -30,7 +30,11 @@ RSpec.describe 'PATCH /api/v1/booking_requests' do
       @newham_booking_request.location_id,
       @north_somerset_booking_request.booking_location_id,
       @north_somerset_booking_request.location_id
-    ].each do |cache_key|
+    ].map do |cache_key|
+      BookingLocations::DEFAULT_PREFIX.concat(cache_key)
+    end
+
+    @cache_keys.each do |cache_key|
       Rails.cache.write(cache_key, 'stuff')
     end
   end


### PR DESCRIPTION
Due to recent changes to `booking_locations` we now prefix booking
locations when read-through cached by the gem, so in turn we can be more
specific about which cache entries we clear.