### PR TITLE
Ensure locations are cached correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.12.0)
+    booking_locations (0.13.0)
       activesupport (>= 4, < 5.1)
       globalid
     bootstrap-kaminari-views (0.0.5)


### PR DESCRIPTION
This addresses the bug with prefixing in `booking_locations`.

We have to use the memory store since the null store doesn't reflect
what actually happens when working with a 'real' cache store.