### PR TITLE
Create activities to audit reassignments

### DIFF
--- a/app/jobs/create_reassignment_activities_job.rb
+++ b/app/jobs/create_reassignment_activities_job.rb
@@ -1,0 +1,12 @@
+class CreateReassignmentActivitiesJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(booking_request_ids)
+    booking_request_ids.each do |booking_request_id|
+      ReassignmentActivity.create!(
+        booking_request_id: booking_request_id,
+        message: ''
+      )
+    end
+  end
+end

--- a/app/lib/batch_booking_request_reassignment.rb
+++ b/app/lib/batch_booking_request_reassignment.rb
@@ -8,12 +8,18 @@ class BatchBookingRequestReassignment
     affected_bookings
       .update_all(booking_location_id: booking_location_id) # rubocop:disable Rails/SkipsModelValidations
 
+    create_reassignment_activities
+
     BookingLocations.clear_cache
   end
 
   private
 
   attr_reader :booking_location_id, :location_id
+
+  def create_reassignment_activities
+    CreateReassignmentActivitiesJob.perform_later(affected_bookings.ids)
+  end
 
   def affected_bookings
     @affected_bookings ||= BookingRequest.where(location_id: location_id)

--- a/app/models/reassignment_activity.rb
+++ b/app/models/reassignment_activity.rb
@@ -1,0 +1,2 @@
+class ReassignmentActivity < Activity
+end

--- a/app/views/activities/_reassignment_activity.html.erb
+++ b/app/views/activities/_reassignment_activity.html.erb
@@ -1,0 +1,5 @@
+<li class="activity-feed__item t-activity" id="activity-<%= reassignment_activity.id %>">
+  <span class="glyphicon glyphicon-pushpin" aria-hidden="true"></span>
+  <b>Booking location reassignment: </b>
+  <em>the booking was reassigned.</em> <em class="badge"><%= time_ago_in_words(reassignment_activity.created_at) %> ago</em>
+</li>


### PR DESCRIPTION
It's helpful for booking managers to see when a booking was reassigned
to a new booking location.

![screen shot 2017-03-22 at 17 51 32](https://cloud.githubusercontent.com/assets/41963/24212964/ded8adca-0f28-11e7-83e4-6d2f0f1880a7.png)
