### PR TITLE
Log in single line format with lograge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   end
 
   group :staging, :production do
+    gem 'lograge'
     gem 'rails_12factor'
     gem 'redis-rails', require: false
   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,10 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
+    lograge (0.4.1)
+      actionpack (>= 4, < 5.1)
+      activesupport (>= 4, < 5.1)
+      railties (>= 4, < 5.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -373,6 +377,7 @@ DEPENDENCIES
   gds-sso!
   govuk_admin_template!
   kaminari!
+  lograge!
   momentjs-rails!
   newrelic_rpm!
   pg!

--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class BookingRequestsController < ActionController::Base
       include GDS::SSO::ControllerMethods
+      include LogrageFilterer
 
       before_action :authorise_api_user!
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,12 +4,11 @@ class ApplicationController < ActionController::Base
   add_flash_types :success
 
   include GDS::SSO::ControllerMethods
+  include LogrageFilterer
 
   before_action do
     authorise_user!(User::BOOKING_MANAGER_PERMISSION)
   end
-
-  protected
 
   def poll_interval_milliseconds
     Integer(ENV.fetch(Activity::POLLING_KEY, 5000))

--- a/app/controllers/lograge_filterer.rb
+++ b/app/controllers/lograge_filterer.rb
@@ -1,0 +1,8 @@
+module LogrageFilterer
+  protected
+
+  def append_info_to_payload(payload)
+    super
+    payload[:params] = request.filtered_parameters
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,17 @@
 require 'redis-rails'
 
+EXCEPTIONS = %w(controller action format id).freeze
+
 Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Settings specified here will take precedence over those in config/application.rb.
+
+  # use lograge and log in single-line heroku router style
+  config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    {
+      params: event.payload[:params].except(*EXCEPTIONS)
+    }
+  end
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
Logs in the heroku style of a single line instead of verbosely dumping
(and interleaving) requests over multiple lines.