### PR TITLE
Reassign requests by booking location

### DIFF
--- a/app/lib/batch_booking_request_reassignment.rb
+++ b/app/lib/batch_booking_request_reassignment.rb
@@ -22,6 +22,14 @@ class BatchBookingRequestReassignment
   end
 
   def affected_bookings
-    @affected_bookings ||= BookingRequest.where(location_id: location_id)
+    @affected_bookings ||= begin
+      key = if BookingRequest.exists?(booking_location_id: location_id)
+              :booking_location_id
+            else
+              :location_id
+            end
+
+      BookingRequest.where(key => location_id)
+    end
   end
 end

--- a/spec/requests/reassign_bookings_to_new_booking_locations_api_spec.rb
+++ b/spec/requests/reassign_bookings_to_new_booking_locations_api_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'PATCH /api/v1/booking_requests' do
+  scenario 'reassign a booking location to another booking location' do
+    given_the_client_identifies_as_pension_wise
+    and_a_booking_request_belonging_to_a_child_of_hackney_exists
+    and_a_booking_request_belonging_to_a_child_of_taunton_exists
+    when_the_client_reassigns_the_booking_to_a_different_booking_location
+    then_the_booking_requests_are_correctly_reassigned
+  end
+
   scenario 'reassign child bookings to the specified booking location' do
     with_real_cache do
       perform_enqueued_jobs do
@@ -23,6 +31,15 @@ RSpec.describe 'PATCH /api/v1/booking_requests' do
 
   def and_a_booking_request_belonging_to_a_child_of_hackney_exists
     @newham_booking_request = create(:hackney_child_booking_request)
+  end
+
+  def when_the_client_reassigns_the_booking_to_a_different_booking_location
+    valid_payload = {
+      'location_id' => @newham_booking_request.booking_location_id,
+      'booking_location_id' => @north_somerset_booking_request.booking_location_id
+    }
+
+    patch batch_reassign_api_v1_booking_requests_path, params: valid_payload, as: :json
   end
 
   def and_a_booking_request_belonging_to_a_child_of_taunton_exists

--- a/spec/requests/reassign_bookings_to_new_booking_locations_api_spec.rb
+++ b/spec/requests/reassign_bookings_to_new_booking_locations_api_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe 'PATCH /api/v1/booking_requests' do
 
   def when_the_client_reassigns_the_booking_to_a_different_booking_location
     valid_payload = {
-      'location_id' => @newham_booking_request.booking_location_id,
-      'booking_location_id' => @north_somerset_booking_request.booking_location_id
+      location_id: @newham_booking_request.booking_location_id,
+      booking_location_id: @north_somerset_booking_request.booking_location_id
     }
 
     patch batch_reassign_api_v1_booking_requests_path, params: valid_payload, as: :json
@@ -63,8 +63,8 @@ RSpec.describe 'PATCH /api/v1/booking_requests' do
 
   def when_the_client_makes_a_valid_reassignment_request
     valid_payload = {
-      'location_id' => @newham_booking_request.location_id,
-      'booking_location_id' => @north_somerset_booking_request.booking_location_id
+      location_id: @newham_booking_request.location_id,
+      booking_location_id: @north_somerset_booking_request.booking_location_id
     }
 
     patch batch_reassign_api_v1_booking_requests_path, params: valid_payload, as: :json


### PR DESCRIPTION
When a booking location is assigned to another, the logic around
reassignment is slightly different. First we need to check if the given
location ID refers to a booking location - if it does we can assume the
booking location is being reassigned - so we only update bookings matching
their booking location ID with the given location ID.

Otherwise we fallback to the previous logic and update the booking location
ID of bookings matching the given location ID. This can be confusing since
bookings can take place at their booking location - in which case the
booking location ID and location ID are the same.