### PR TITLE
Guard against missing locations

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  def guard_missing_location(object, attribute)
+    object.public_send(attribute)
+  rescue
+    content_tag(:span, 'Missing', title: object.try(:location_id))
+  end
+
   def paginate(objects, options = {})
     options.reverse_merge!(theme: 'twitter-bootstrap-3')
     super(objects, options)

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -72,10 +72,10 @@
                 <%= appointment.name %>
               </td>
               <td>
-                <%= appointment.guider_name %>
+                <%= guard_missing_location(appointment, :guider_name) %>
               </td>
               <td>
-                <%= appointment.location_name %>
+                <%= guard_missing_location(appointment, :location_name) %>
               </td>
               <td>
                 <%= appointment.reference %>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -67,7 +67,7 @@
     <p class="lead">
       <strong>
         <a href="https://www.pensionwise.gov.uk/locations/<%= @appointment_form.location_aware_booking_request.location_id %>" class="t-location-name">
-          <%= @appointment_form.location_aware_booking_request.location_name %>
+          <%= guard_missing_location(@appointment_form.location_aware_booking_request, :location_name) %>
         </a>
       </strong>
     </p>

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -41,7 +41,7 @@
                 <%= booking_request.name %>
               </td>
               <td>
-                <a href="https://www.pensionwise.gov.uk/locations/<%= booking_request.location_id %>"><%= booking_request.location_name %></a>
+                <a href="https://www.pensionwise.gov.uk/locations/<%= booking_request.location_id %>"><%= guard_missing_location(booking_request, :location_name) %></a>
               </td>
               <td>
                 <%= booking_request.primary_slot %><br>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '.guard_missing_location' do
+    context 'when the location is missing' do
+      it 'responds with a message' do
+        wrapped_entity = double(location_id: 'bleh')
+        allow(wrapped_entity).to receive(:whoops).and_raise(ArgumentError)
+
+        expect(
+          helper.guard_missing_location(wrapped_entity, :whoops)
+        ).to eq('<span title="bleh">Missing</span>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the location isn't bound we blow up in interesting ways and it is
difficult to figure out which location is causing the problem. This
change guards against that and in the case of missing locations
helpfully outputs the location ID for instrumentation.