### PR TITLE
Order select boxes alphabetically

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -39,8 +39,6 @@ class AppointmentForm
 
   delegate(*BOOKING_REQUEST_ATTRIBUTES, to: :location_aware_booking_request)
 
-  delegate :guiders, to: :booking_location
-
   def initialize(location_aware_booking_request, params)
     @location_aware_booking_request = location_aware_booking_request
     normalise_time(params)
@@ -50,10 +48,6 @@ class AppointmentForm
 
   def appointment_params
     AppointmentMapper.map(self)
-  end
-
-  def flattened_locations
-    FlattenedLocationMapper.map(booking_location)
   end
 
   def name

--- a/app/forms/edit_appointment_form.rb
+++ b/app/forms/edit_appointment_form.rb
@@ -1,13 +1,7 @@
 class EditAppointmentForm < SimpleDelegator
-  delegate :guiders, to: :booking_location
-
   delegate :primary_slot, :secondary_slot, :tertiary_slot, to: :booking_request
 
   def initialize(location_aware_appointment)
     super
-  end
-
-  def flattened_locations
-    FlattenedLocationMapper.map(booking_location)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,6 @@ module ApplicationHelper
     location_ids.map do |id|
       location = BookingLocations.find(id)
       [location.name, location.id]
-    end
+    end.sort_by(&:first)
   end
 end

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -16,12 +16,12 @@ module AppointmentHelper
   end
 
   def location_options(booking_location)
-    FlattenedLocationMapper.map(booking_location)
+    FlattenedLocationMapper.map(booking_location).sort_by(&:first)
   end
 
   def guider_options(booking_location)
     booking_location.guiders.map do |guider|
       [guider['name'], guider['id']]
-    end
+    end.sort_by(&:first)
   end
 end

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -111,14 +111,18 @@
               <%= f.label :guider_id %>
               <%= f.select(
                 :guider_id,
-                options_from_collection_for_select(@appointment_form.guiders, 'id', 'name', selected: @appointment_form.guider_id),
+                guider_options(@appointment_form.booking_location),
                 options = {},
                 class: 'form-control t-guider'
               ) %>
             </div>
             <div class="form-group">
               <%= f.label :location_id %>
-              <%= f.select(:location_id, @appointment_form.flattened_locations, options = {}, { class: 'form-control t-location' }
+              <%= f.select(
+                :location_id,
+                location_options(@appointment_form.booking_location),
+                options = {},
+                class: 'form-control t-location'
               ) %>
             </div>
             <div class="form-group">

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -136,7 +136,7 @@
             <%= f.label :guider_id %>
             <%= f.select(
               :guider_id,
-              options_from_collection_for_select(@appointment_form.guiders, 'id', 'name', selected: @appointment_form.guider_id),
+              guider_options(@appointment_form.booking_location),
               { include_blank: true },
               { class: 'form-control t-guider' }
             ) %>
@@ -146,7 +146,7 @@
             <%= f.label :location_id %>
             <%= f.select(
               :location_id,
-              @appointment_form.flattened_locations,
+              location_options(@appointment_form.booking_location),
               options = {},
               { class: 'form-control t-location' }
             ) %>

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -112,20 +112,6 @@ RSpec.describe AppointmentForm do
     expect(subject.tertiary_slot).to eq(booking_request.tertiary_slot)
   end
 
-  describe '#guiders' do
-    it 'returns the guiders from the booking location' do
-      expect(subject.guiders).to eq(hackney.guiders)
-    end
-  end
-
-  describe '#flattened_locations' do
-    it 'flattens locations with a mapper' do
-      expect(FlattenedLocationMapper).to receive(:map).with(hackney)
-
-      subject.flattened_locations
-    end
-  end
-
   describe '#date' do
     it 'defaults to the primary slot date' do
       expect(subject.date).to eq(booking_request.primary_slot.date)

--- a/spec/forms/edit_appointment_form_spec.rb
+++ b/spec/forms/edit_appointment_form_spec.rb
@@ -17,18 +17,4 @@ RSpec.describe EditAppointmentForm do
     expect(subject.secondary_slot).to eq(appointment.booking_request.secondary_slot)
     expect(subject.tertiary_slot).to eq(appointment.booking_request.tertiary_slot)
   end
-
-  describe '#guiders' do
-    it 'returns the guiders from the booking location' do
-      expect(subject.guiders).to eq(hackney.guiders)
-    end
-  end
-
-  describe '#flattened_locations' do
-    it 'flattens locations with a mapper' do
-      expect(FlattenedLocationMapper).to receive(:map).with(hackney)
-
-      subject.flattened_locations
-    end
-  end
 end


### PR DESCRIPTION
Some of these lists are quite long and it's becoming increasingly
difficult to find the correct option. Ordering the lists helps find the
correct option quickly.