### PR TITLE
Increase DB pool size

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: 5
+  pool: <%= Integer(ENV.fetch('MAX_THREADS') { 3 }) * 2 %>
 
 development:
   <<: *default


### PR DESCRIPTION
We have seen one or two instances where the database connection pool
was exhausted. This change allows us to specify the exact pool size via
the `MAX_THREADS` environment variable. This is doubled to cater for
worker concurrency.