### PR TITLE
Permit appointments on the same day

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -98,7 +98,7 @@ class AppointmentForm
     return unless date
 
     parsed_date = Date.parse(date.to_s)
-    errors.add(:date, 'must be in the future') unless parsed_date > Date.current
+    errors.add(:date, 'must be in the future') unless parsed_date >= Date.current
   rescue ArgumentError
     errors.add(:date, 'must be formatted correctly')
   end

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AppointmentForm do
       }
     end
 
-    before { travel_to '2016-06-20' }
+    before { travel_to '2016-06-20 13:00' }
     after  { travel_back }
 
     it 'is valid with valid attributes' do
@@ -88,12 +88,16 @@ RSpec.describe AppointmentForm do
         expect(subject).to_not be_valid
       end
 
-      it 'must be past the current date' do
-        %w(2016-06-19 2016-06-20).each do |date|
-          params[:date] = date
+      it 'can fall on the same day' do
+        params[:date] = '2016-06-20'
 
-          expect(subject).to_not be_valid
-        end
+        expect(subject).to be_valid
+      end
+
+      it 'must be no sooner than the current date' do
+        params[:date] = '2016-06-19'
+
+        expect(subject).to_not be_valid
       end
     end
   end


### PR DESCRIPTION
As requested by the CABs. The occassionally have capacity to offer
same-day appointments but we were validating against this scenario.
This change permits same-day appointments to be made from existing
bookings.