### PR TITLE
Display full changesets from audits

### DIFF
--- a/app/controllers/changes_controller.rb
+++ b/app/controllers/changes_controller.rb
@@ -1,0 +1,18 @@
+class ChangesController < ApplicationController
+  def index
+    @audits = AuditPresenter.wrap(
+      appointment.audits.reverse,
+      booking_location
+    )
+  end
+
+  private
+
+  def appointment
+    @appointment ||= begin
+      current_user
+        .appointments
+        .find_by(booking_request_id: params[:appointment_id])
+    end
+  end
+end

--- a/app/presenters/audit_presenter.rb
+++ b/app/presenters/audit_presenter.rb
@@ -1,0 +1,54 @@
+class AuditPresenter < SimpleDelegator
+  def initialize(object, booking_location)
+    super(object)
+
+    @booking_location = booking_location
+  end
+
+  def changed_fields
+    audited_changes.keys.map(&:humanize).to_sentence.downcase
+  end
+
+  def timestamp
+    created_at.to_s(:govuk_date_short)
+  end
+
+  def username
+    user ? user.name : 'Someone'
+  end
+
+  def changes
+    audited_changes.each_with_object({}) do |(key, value), memo|
+      field = key.humanize
+      before, after = value.map(&:to_s)
+
+      memo[field] = {
+        before: format(key, before),
+        after:  format(key, after)
+      }
+    end
+  end
+
+  def self.wrap(objects, booking_location)
+    Array(objects).map { |object| new(object, booking_location) }
+  end
+
+  private
+
+  attr_reader :booking_location
+
+  def format(key, value) # rubocop:disable Metrics/MethodLength
+    case key
+    when 'guider_id'
+      booking_location.guider_name_for(value.to_i)
+    when 'location_id'
+      booking_location.name_for(value)
+    when 'status'
+      value.humanize
+    when 'proceeded_at'
+      Time.zone.parse(value).to_s(:govuk_date)
+    else
+      value
+    end
+  end
+end

--- a/app/views/activities/_audit_activity.html.erb
+++ b/app/views/activities/_audit_activity.html.erb
@@ -1,4 +1,4 @@
 <li class="activity-feed__item t-activity" id="activity-<%= audit_activity.id %>">
   <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-  <b><%= audit_activity.owner_name %></b> changed the <%= audit_activity.message %> <em class="badge"><%= time_ago_in_words(audit_activity.created_at) %> ago</em>
+  <b><%= audit_activity.owner_name %></b> <%= link_to "changed the #{audit_activity.message}", appointment_changes_path(audit_activity.booking_request), class: 't-changes' %> <em class="badge"><%= time_ago_in_words(audit_activity.created_at) %> ago</em>
 </li>

--- a/app/views/changes/index.html.erb
+++ b/app/views/changes/index.html.erb
@@ -1,0 +1,39 @@
+<% content_for(:page_title, t('service.title', page_title: "Changes for appointment #{@appointment.name}")) %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= appointments_path %>">Appointments</a></li>
+    <li><%= link_to @appointment.name, edit_appointment_path(@appointment) %></li>
+    <li class="active">Changes</li>
+  </ol>
+
+  <h1>
+    Changes for <%= @appointment.name %><br>
+    <small>Booking reference: <%= @appointment.reference %></small>
+  </h1>
+</div>
+
+<% @audits.each do |audit| %>
+  <table class="table table-striped table-bordered t-changes-table">
+  <col width="20%" />
+  <col width="40%" />
+  <col width="40%" />
+  <caption><%= audit.username %> changed the <%= audit.changed_fields %> on <%= audit.timestamp %></caption>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Before</th>
+      <th>After</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% audit.changes.each do |field, change| %>
+    <tr class="t-change-row">
+      <td class="t-label"><%= field %></td>
+      <td class="t-before"><%= change[:before] %></td>
+      <td class="t-after"><%= change[:after] %></td>
+    </tr>
+    <% end %>
+  </tbody>
+  </table>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
 
   resources :users, only: :update
 
-  resources :appointments, only: %i(index edit update)
+  resources :appointments, only: %i(index edit update) do
+    resources :changes, only: :index
+  end
 
   resources :booking_requests, only: %i(index update) do
     resources :activities, only: %i(index create)

--- a/spec/support/pages/changes.rb
+++ b/spec/support/pages/changes.rb
@@ -1,0 +1,11 @@
+module Pages
+  class Changes < SitePrism::Page
+    set_url '/appointments/{id}/changes'
+
+    sections :rows, '.t-change-row' do
+      element :label, '.t-label'
+      element :before, '.t-before'
+      element :after, '.t-after'
+    end
+  end
+end

--- a/spec/support/sections/activity.rb
+++ b/spec/support/sections/activity.rb
@@ -1,4 +1,5 @@
 module Sections
   class Activity < SitePrism::Section
+    element :changes, '.t-changes'
   end
 end


### PR DESCRIPTION
Displays the before and after values from a changeset so the booking
managers can better understand the changes made to an appointment
during its lifecycle.

![screen shot 2017-05-03 at 13 43 37](https://cloud.githubusercontent.com/assets/41963/25660982/941c22c2-3006-11e7-9886-bc865e85a8ca.png)

![screen shot 2017-05-03 at 13 43 42](https://cloud.githubusercontent.com/assets/41963/25660991/9ea1fce4-3006-11e7-909f-fdbb3dffb188.png)
