### PR TITLE
Bump sinatra to latest released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'rails-observers', github: 'rails/rails-observers', branch: 'master'
   gem 'sassc-rails'
   gem 'sidekiq'
-  gem 'sinatra', '2.0.0.beta2', require: false
+  gem 'sinatra', require: false
   gem 'sprockets-es6'
   gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mustermann (1.0.0.beta2)
+    mustermann (1.0.0)
     newrelic_rpm (4.0.0.332)
     nio4r (2.0.0)
     nokogiri (1.7.1)
@@ -207,7 +207,7 @@ GEM
     public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.1)
-    rack-protection (2.0.0.beta2)
+    rack-protection (2.0.0)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -310,10 +310,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sinatra (2.0.0.beta2)
-      mustermann (= 1.0.0.beta2)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0.beta2)
+      rack-protection (= 2.0.0)
       tilt (~> 2.0)
     site_prism (2.9)
       addressable (>= 2.3.3, < 3.0)
@@ -395,7 +395,7 @@ DEPENDENCIES
   rubocop!
   sassc-rails!
   sidekiq!
-  sinatra (= 2.0.0.beta2)!
+  sinatra!
   site_prism!
   sprockets-es6!
   uglifier (>= 1.3.0)!


### PR DESCRIPTION
This is used by the sidekiq web control panel and was previously pinned
at a beta release.