### PR TITLE
Unpin `govuk_admin_template` to latest release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'faraday_middleware'
   gem 'foreman'
   gem 'gds-sso'
-  gem 'govuk_admin_template',
-      github: 'guidance-guarantee-programme/govuk_admin_template',
-      branch: 'rails-deprecations'
+  gem 'govuk_admin_template'
   gem 'kaminari'
   gem 'momentjs-rails'
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: git://github.com/guidance-guarantee-programme/govuk_admin_template.git
-  revision: e22dba715524a2b05d15071059febc96162e249b
-  branch: rails-deprecations
-  specs:
-    govuk_admin_template (6.0.0)
-      bootstrap-sass (= 3.3.5.1)
-      jquery-rails (~> 4.1.1)
-      rails (>= 3.2.0)
-
-GIT
   remote: git://github.com/rails/rails-observers.git
   revision: 206cb17bc14f4f5ac6f83da4204013a69549b9dc
   branch: master
@@ -131,10 +121,14 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    govuk_admin_template (6.1.0)
+      bootstrap-sass (= 3.3.5.1)
+      jquery-rails (~> 4.3.1)
+      rails (>= 3.2.0)
     hashdiff (0.3.4)
     hashie (3.5.5)
     i18n (0.8.1)
-    jquery-rails (4.1.1)
+    jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)


### PR DESCRIPTION
My stuff was merged and released in `6.1.0`.