### PR TITLE
Configure bootsnap for snappy boots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'uglifier', '>= 1.3.0'
 
   group :development, :test do
+    gem 'bootsnap'
     gem 'capybara'
     gem 'factory_girl_rails'
     gem 'phantomjs-binaries'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
     booking_locations (0.15.0)
       activesupport (>= 4, <= 6)
       globalid
+    bootsnap (0.2.14)
+      msgpack (~> 1.0)
     bootstrap-kaminari-views (0.0.5)
       kaminari (>= 0.13)
       rails (>= 3.1)
@@ -162,6 +164,7 @@ GEM
     minitest (5.10.2)
     momentjs-rails (2.17.1)
       railties (>= 3.1)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -363,6 +366,7 @@ PLATFORMS
 DEPENDENCIES
   audited!
   booking_locations!
+  bootsnap!
   bootstrap-kaminari-views!
   bugsnag!
   capybara!

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,20 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
+if %w(development test).include?(ENV.fetch('RAILS_ENV'))
+  require 'bootsnap'
+
+  # These features are Mac only for the timebeing
+  DARWIN = `uname`.chomp == 'Darwin'
+
+  Bootsnap.setup(
+    cache_dir: 'tmp/cache',
+    development_mode: true,
+    load_path_cache: true,
+    autoload_paths_cache: true,
+    disable_trace: false,
+    compile_cache_iseq: DARWIN,
+    compile_cache_yaml: DARWIN
+  )
+end


### PR DESCRIPTION
Yields at least a 50% reduction in boot times in both development and
test. See here for details: https://github.com/Shopify/bootsnap