### PR TITLE
Default to `development` unless in `test`

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['RAILS_ENV'] ||= 'development'
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,5 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?


### PR DESCRIPTION
The `fetch` for `RAILS_ENV` performed in boot was a little over-zealous
since other binaries (ie rake, rails) don't set this variable so early
on, in particular circumstances.

We default to `development` and `test` where it makes sense to resolve
this.