### PR TITLE
Fixing issue where search filter inputs wrap onto new line

### DIFF
--- a/app/assets/stylesheets/components/_filters.scss
+++ b/app/assets/stylesheets/components/_filters.scss
@@ -11,11 +11,17 @@
 
 .filters__form-control {
   .form-inline & {
-    width: 220px;
+    width: 190px;
   }
 
   &[readonly] {
     background: $read-only-background;
+  }
+}
+
+.filters__form-control--status {
+  .form-inline & {
+    width: 220px;
   }
 }
 

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -23,7 +23,7 @@
           </li>
           <li class="filters__item">
             <%= f.label :status, class: 'filters__label' %>
-            <%= f.select :status, friendly_options(BookingRequest.statuses), { include_blank: 'All Statuses' }, { class: 't-status form-control filters__form-control' } %>
+            <%= f.select :status, friendly_options(BookingRequest.statuses), { include_blank: 'All Statuses' }, { class: 't-status form-control filters__form-control filters__form-control--status' } %>
           </li>
           <li class="filters__item">
             <%= f.label :location, class: 'filters__label' %>


### PR DESCRIPTION
Increasing the size of all filter inputs to cater for the
long 'awaiting customer feedback' status value, caused the
search form on the appointments page to wrap onto a new
line even at large viewport widths.

This targets just the status dropdown to make it longer
instead.

<img width="1170" alt="screen shot 2017-05-23 at 19 10 57" src="https://cloud.githubusercontent.com/assets/6049076/26369108/952b7fa6-3feb-11e7-983f-be5726edf2e6.png">
