### PR TITLE
Expose a public bookable slots API

### DIFF
--- a/app/controllers/api/v1/bookable_slots_controller.rb
+++ b/app/controllers/api/v1/bookable_slots_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class BookableSlotsController < ActionController::Base
+      def index
+        render json: DefaultBookableSlots.new.call
+      end
+    end
+  end
+end

--- a/app/lib/default_bookable_slots.rb
+++ b/app/lib/default_bookable_slots.rb
@@ -1,0 +1,38 @@
+class DefaultBookableSlots
+  Instance = Struct.new(:date, :start, :end)
+
+  attr_reader :from
+  attr_reader :to
+
+  def initialize(from = Date.current, to = from.advance(weeks: 6))
+    @from = from
+    @to = to
+  end
+
+  def call
+    available_days.map do |date|
+      [
+        Instance.new(date.iso8601, '0900', '1300'),
+        Instance.new(date.iso8601, '1300', '1700')
+      ]
+    end.flatten
+  end
+
+  private
+
+  def available_days
+    (grace_period_end..to).reject { |day| day.on_weekend? || bank_holiday?(day) }
+  end
+
+  def bank_holiday?(date)
+    BANK_HOLIDAYS.include?(date)
+  end
+
+  def grace_period_end
+    if from.monday? || from.tuesday?
+      from.advance(days: 3)
+    else
+      from.next_week(GRACE_PERIODS[from.wday])
+    end
+  end
+end

--- a/config/initializers/bookable_slots.rb
+++ b/config/initializers/bookable_slots.rb
@@ -1,0 +1,16 @@
+# Days to advance when covering grace period
+GRACE_PERIODS = {
+  3 => :monday,
+  4 => :tuesday,
+  5 => :wednesday,
+  6 => :thursday,
+  0 => :thursday
+}.freeze
+
+# Days that are always excluded from availability
+BANK_HOLIDAYS = [
+  Date.parse('29/05/2017'),
+  Date.parse('28/08/2017'),
+  Date.parse('25/12/2017'),
+  Date.parse('26/12/2017')
+].freeze

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,10 @@ Rails.application.routes.draw do
 
   namespace :api, constraints: { format: :json } do
     namespace :v1 do
+      get '/locations/:location_id/bookable_slots',
+          to: 'bookable_slots#index',
+          as: :bookable_slots
+
       resources :booking_requests, only: :create do
         patch :batch_reassign, on: :collection
       end

--- a/spec/lib/default_bookable_slots_spec.rb
+++ b/spec/lib/default_bookable_slots_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe DefaultBookableSlots do
+  before(:all) do
+    travel_to('2017-05-25 13:00') { @slots = described_class.new.call }
+  end
+
+  it 'defaults the booking window to 6 weeks' do
+    expect(subject.from).to eq(Date.current)
+    expect(subject.to).to eq(6.weeks.from_now.to_date)
+  end
+
+  it 'returns slots in the booking window' do
+    # advanced to the grace period and exclude the bank holiday
+    expect(@slots.first.date).to eq('2017-05-30')
+    # the end of the booking window
+    expect(@slots.last.date).to eq('2017-07-06')
+  end
+
+  it 'doesn’t include weekends' do
+    weekends = @slots.select { |slot| slot.date.to_date.on_weekend? }
+
+    expect(weekends).to be_empty
+  end
+end

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/locations/{location_id}/bookable_slots' do
+  scenario 'returns default availability' do
+    when_a_request_is_made
+    then_the_service_responds_ok
+    and_slots_are_serialized_as_json
+  end
+
+  def when_a_request_is_made
+    get api_v1_bookable_slots_path(location_id: 'deadbeef'), as: :json
+  end
+
+  def then_the_service_responds_ok
+    expect(response).to be_ok
+  end
+
+  def and_slots_are_serialized_as_json
+    JSON.parse(response.body).tap do |json|
+      expect(json.first.keys).to match_array(%w(date start end))
+    end
+  end
+end


### PR DESCRIPTION
Exposes the slots API at:
`/api/v1/locations/{location}/bookable_slots.json`

For now, the `{location}` parameter is ignored but will eventually be
used to determine whether the location has an associated schedule.

Example payload:

```javascript
[
  {
    "date": "2017-05-30",
    "start": "0900",
    "end": "1300"
  },
  {
    "date": "2017-05-30",
    "start": "1300",
    "end": "1700"
  }
]

// and so on
```