### PR TITLE
Customised availability per location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rails-assets.org' do
 end
 
 source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
+  gem 'active_model_serializers'
   gem 'audited'
   gem 'booking_locations'
   gem 'bootstrap-kaminari-views'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.6)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.2)
     activejob (5.1.1)
       activesupport (= 5.1.1)
       globalid (>= 0.3.6)
@@ -80,6 +85,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    case_transform (0.2)
+      activesupport
     cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
@@ -135,6 +142,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
+    jsonapi-renderer (0.1.2)
     jwt (1.5.6)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
@@ -364,6 +372,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers!
   audited!
   booking_locations!
   bootsnap!
@@ -409,4 +418,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/app/assets/stylesheets/components/_centred-table.scss
+++ b/app/assets/stylesheets/components/_centred-table.scss
@@ -1,0 +1,3 @@
+.centered-table tbody tr td { // scss-lint:disable SelectorDepth
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/components/_schedule-summary.scss
+++ b/app/assets/stylesheets/components/_schedule-summary.scss
@@ -10,8 +10,8 @@
 
 .schedule-summary__period {
   background: $color-silver;
-  border-right: 1px solid $color-silver;
-  border-bottom: 1px solid $color-silver;
+  border-right: 1px solid $color-white;
+  border-bottom: 1px solid $color-white;
   height: 10px;
 }
 

--- a/app/assets/stylesheets/components/_schedule-summary.scss
+++ b/app/assets/stylesheets/components/_schedule-summary.scss
@@ -1,0 +1,20 @@
+.schedule-summary {
+  width: 100%;
+  display: flex;
+}
+
+.schedule-summary__day {
+  flex-basis: 20%;
+  height: 20px;
+}
+
+.schedule-summary__period {
+  background: $color-silver;
+  border-right: 1px solid $color-silver;
+  border-bottom: 1px solid $color-silver;
+  height: 10px;
+}
+
+.schedule-summary__period--on {
+  background: $brand-success;
+}

--- a/app/assets/stylesheets/components/_weekly-schedule.scss
+++ b/app/assets/stylesheets/components/_weekly-schedule.scss
@@ -1,0 +1,97 @@
+.weekly-schedule {
+  width: 100%;
+
+  @media (min-width: 600px) {
+    display: flex;
+  }
+
+  & + & {
+    border-top: 0;
+  }
+}
+
+.weekly-schedule__day {
+  @media (min-width: 600px) {
+    flex-basis: 20%;
+    border-right: 1px solid $color-white;
+  }
+}
+
+.weekly-schedule__day-name {
+  @media (min-width: 600px) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+  }
+}
+
+.weekly-schedule__day-label {
+  text-align: center;
+  padding: 10px;
+  font-weight: bold;
+  background: $color-silver;
+
+  @media (min-width: 600px) {
+    flex-basis: 20%;
+    border-right: 1px solid $color-white;
+  }
+}
+
+.weekly-schedule--day-labels {
+  display: none;
+
+  @media (min-width: 600px) {
+    display: flex;
+  }
+}
+
+.weekly-schedule__label {
+  border-bottom: 1px solid $color-white;
+  color: $color-white;
+  display: block;
+  font-size: 100%;
+  margin: 0;
+  padding: 30px;
+  text-align: center;
+  transition: background .2s;
+  width: 100%;
+
+  @media (min-width: 600px) {
+    font-size: 150%;
+  }
+}
+
+.weekly-schedule__switch {
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  display: inherit;
+  margin: 0 !important;
+
+  + .weekly-schedule__label {
+    background: $color-silver;
+    color: $color-black;
+    border: 4px solid transparent;
+
+    &:hover {
+      border: 4px solid darken($color-silver, 20%);
+    }
+  }
+
+  &:checked {
+    + .weekly-schedule__label {
+      background: $brand-success;
+      color: $color-white;
+      border: 4px solid transparent;
+
+      &:hover {
+        border: 4px solid darken($brand-success, 20%);
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/helpers/_colours.scss
+++ b/app/assets/stylesheets/helpers/_colours.scss
@@ -1,5 +1,6 @@
 $color-white: #fff;
 $color-silver: #ccc;
+$color-black: #000;
 
 $appointment-status-well-background-color: $color-silver;
 $read-only-background: $color-white;

--- a/app/assets/stylesheets/helpers/_striped.scss
+++ b/app/assets/stylesheets/helpers/_striped.scss
@@ -1,0 +1,12 @@
+@mixin striped($foreground, $background) {
+  // scss-lint:disable DuplicateProperty
+  background: $foreground; // IE9 fallback
+  background: $background repeating-linear-gradient(
+    -45deg,
+    $foreground,
+    $foreground 1px,
+    $background 1px,
+    $background 6px
+  );
+  // scss-lint:enable DuplicateProperty
+}

--- a/app/controllers/api/v1/bookable_slots_controller.rb
+++ b/app/controllers/api/v1/bookable_slots_controller.rb
@@ -2,7 +2,19 @@ module Api
   module V1
     class BookableSlotsController < ActionController::Base
       def index
-        render json: DefaultBookableSlots.new.call
+        render json: slots
+      end
+
+      private
+
+      def slots
+        schedule = Schedule.current(params[:location_id])
+
+        if schedule.default?
+          DefaultBookableSlots.new.call
+        else
+          schedule.bookable_slots_in_window
+        end
       end
     end
   end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -21,7 +21,7 @@ class SchedulesController < ApplicationController
     params
       .require(:schedule)
       .permit(
-        *Schedule.slot_attributes,
+        *Schedule::SLOT_ATTRIBUTES,
         :location_id
       )
   end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -2,4 +2,27 @@ class SchedulesController < ApplicationController
   def index
     @booking_location = booking_location
   end
+
+  def new
+    @location = booking_location.location_for(params[:location_id])
+    @schedule = Schedule.new(location_id: params[:location_id])
+  end
+
+  def create
+    @schedule = Schedule.create!(schedule_params)
+    SlotGenerationJob.perform_later(@schedule)
+
+    redirect_to schedules_path, notice: 'Schedule was created'
+  end
+
+  private
+
+  def schedule_params
+    params
+      .require(:schedule)
+      .permit(
+        *Schedule.slot_attributes,
+        :location_id
+      )
+  end
 end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,0 +1,5 @@
+class SchedulesController < ApplicationController
+  def index
+    @booking_location = booking_location
+  end
+end

--- a/app/helpers/schedule_helper.rb
+++ b/app/helpers/schedule_helper.rb
@@ -1,0 +1,18 @@
+module ScheduleHelper
+  def summary(period, schedule)
+    open = schedule.public_send(period)
+    day, slot = period.to_s.split('_')
+
+    content_tag(:div, '', class: classes(day, slot, open), title: title(day, slot, open))
+  end
+
+  def classes(day, slot, open)
+    "schedule-summary__period t-#{day}-#{slot}".tap do |classes|
+      classes.concat(' schedule-summary__period--on') if open
+    end
+  end
+
+  def title(day, slot, open)
+    "#{open ? 'Open' : 'Closed'} #{day.humanize} #{slot.upcase}"
+  end
+end

--- a/app/jobs/slot_generation_job.rb
+++ b/app/jobs/slot_generation_job.rb
@@ -2,5 +2,6 @@ class SlotGenerationJob < ActiveJob::Base
   queue_as :default
 
   def perform(schedule)
+    schedule.generate_bookable_slots!
   end
 end

--- a/app/jobs/slot_generation_job.rb
+++ b/app/jobs/slot_generation_job.rb
@@ -1,0 +1,6 @@
+class SlotGenerationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(schedule)
+  end
+end

--- a/app/lib/bookable_slot_generator.rb
+++ b/app/lib/bookable_slot_generator.rb
@@ -1,0 +1,46 @@
+class BookableSlotGenerator
+  def initialize(schedule)
+    @schedule = schedule
+  end
+
+  def call
+    Schedule.transaction do
+      delete_existing_slots!
+      create_scheduled_slots!
+    end
+  end
+
+  private
+
+  def create_scheduled_slots!
+    slots_to_create.map do |slot|
+      schedule.bookable_slots.create!(
+        date: slot.date,
+        start: slot.start,
+        end: slot.end
+      )
+    end
+  end
+
+  def scheduled_slots
+    @scheduled_slots ||= schedule.attributes.slice(
+      *Schedule.slot_attributes.map(&:to_s)
+    ).select { |_, v| v }
+  end
+
+  def slots_to_create
+    return [] if scheduled_slots.empty?
+
+    DefaultBookableSlots.new(to: 4.months.from_now).call.select do |slot|
+      scheduled_slots.key?(slot.label)
+    end
+  end
+
+  def delete_existing_slots!
+    schedule_ids = Schedule.where(location_id: schedule.location_id).pluck(:id)
+
+    BookableSlot.for_deletion(schedule_ids).delete_all
+  end
+
+  attr_reader :schedule
+end

--- a/app/lib/bookable_slot_generator.rb
+++ b/app/lib/bookable_slot_generator.rb
@@ -24,7 +24,7 @@ class BookableSlotGenerator
 
   def scheduled_slots
     @scheduled_slots ||= schedule.attributes.slice(
-      *Schedule.slot_attributes.map(&:to_s)
+      *Schedule::SLOT_ATTRIBUTES.map(&:to_s)
     ).select { |_, v| v }
   end
 

--- a/app/lib/default_bookable_slots.rb
+++ b/app/lib/default_bookable_slots.rb
@@ -1,12 +1,20 @@
 class DefaultBookableSlots
-  Instance = Struct.new(:date, :start, :end)
+  Instance = Struct.new(:date, :start, :end) do
+    def label
+      "#{date.to_date.strftime('%A').downcase}_#{period}"
+    end
+
+    def period
+      start == '0900' ? 'am' : 'pm'
+    end
+  end
 
   attr_reader :from
   attr_reader :to
 
-  def initialize(from = Date.current, to = from.advance(weeks: 6))
+  def initialize(from: Date.current, to: from.advance(weeks: 6))
     @from = from
-    @to = to
+    @to   = to
   end
 
   def call

--- a/app/lib/default_bookable_slots.rb
+++ b/app/lib/default_bookable_slots.rb
@@ -37,10 +37,6 @@ class DefaultBookableSlots
   end
 
   def grace_period_end
-    if from.monday? || from.tuesday?
-      from.advance(days: 3)
-    else
-      from.next_week(GRACE_PERIODS[from.wday])
-    end
+    GracePeriod.new(from).call
   end
 end

--- a/app/lib/default_bookable_slots.rb
+++ b/app/lib/default_bookable_slots.rb
@@ -5,7 +5,7 @@ class DefaultBookableSlots
     end
 
     def period
-      start == '0900' ? 'am' : 'pm'
+      BookableSlot::AM.period(start)
     end
   end
 
@@ -20,8 +20,8 @@ class DefaultBookableSlots
   def call
     available_days.map do |date|
       [
-        Instance.new(date.iso8601, '0900', '1300'),
-        Instance.new(date.iso8601, '1300', '1700')
+        Instance.new(date.iso8601, *BookableSlot::AM.pair),
+        Instance.new(date.iso8601, *BookableSlot::PM.pair)
       ]
     end.flatten
   end

--- a/app/lib/grace_period.rb
+++ b/app/lib/grace_period.rb
@@ -1,0 +1,25 @@
+class GracePeriod
+  GRACE_PERIODS = {
+    3 => :monday,
+    4 => :tuesday,
+    5 => :wednesday,
+    6 => :thursday,
+    0 => :thursday
+  }.freeze
+
+  def initialize(from = Date.current)
+    @from = from
+  end
+
+  def call
+    if from.monday? || from.tuesday?
+      from.advance(days: 3)
+    else
+      from.next_week(GRACE_PERIODS[from.wday])
+    end
+  end
+
+  private
+
+  attr_reader :from
+end

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -1,0 +1,16 @@
+class BookableSlot < ActiveRecord::Base
+  belongs_to :schedule
+
+  def am?
+    start == '0900'
+  end
+
+  def pm?
+    !am?
+  end
+
+  def self.for_deletion(schedule_ids)
+    where(schedule_id: schedule_ids)
+      .where(arel_table[:date].gteq(Time.zone.now))
+  end
+end

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -12,6 +12,10 @@ class BookableSlot < ActiveRecord::Base
     PM.pm?(start)
   end
 
+  def self.windowed
+    where(date: GracePeriod.new.call..6.weeks.from_now)
+  end
+
   def self.for_deletion(schedule_ids)
     where(schedule_id: schedule_ids)
       .where(arel_table[:date].gteq(Time.zone.now))

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -1,12 +1,15 @@
 class BookableSlot < ActiveRecord::Base
+  AM = Period.new('0900', '1300')
+  PM = Period.new('1300', '1700')
+
   belongs_to :schedule
 
   def am?
-    start == '0900'
+    AM.am?(start)
   end
 
   def pm?
-    !am?
+    PM.pm?(start)
   end
 
   def self.for_deletion(schedule_ids)

--- a/app/models/booking_location_decorator.rb
+++ b/app/models/booking_location_decorator.rb
@@ -11,5 +11,9 @@ class BookingLocationDecorator < SimpleDelegator
     super.map { |l| BookingLocationDecorator.new(l) }
   end
 
+  def schedule
+    @schedule ||= Schedule.current(id)
+  end
+
   alias object __getobj__
 end

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -1,0 +1,17 @@
+Period = Struct.new(:start, :end) do
+  def am?(time)
+    time == start
+  end
+
+  def pm?(time)
+    time == self.end
+  end
+
+  def period(start)
+    am?(start) ? 'am' : 'pm'
+  end
+
+  def pair
+    [start, self.end]
+  end
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,10 @@
 class Schedule < ActiveRecord::Base
+  has_many :bookable_slots
+
+  def generate_bookable_slots!
+    BookableSlotGenerator.new(self).call
+  end
+
   def self.current(location_id)
     where(location_id: location_id)
       .order(created_at: :desc)

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,0 +1,14 @@
+class Schedule < ActiveRecord::Base
+  def self.current(location_id)
+    where(location_id: location_id)
+      .order(created_at: :desc)
+      .first_or_initialize(location_id: location_id)
+  end
+
+  def self.slot_attributes
+    columns_hash
+      .keys
+      .select { |k| /_[a|p]m\z/ === k } # rubocop:disable Style/CaseEquality
+      .map(&:to_sym)
+  end
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,8 +1,14 @@
 class Schedule < ActiveRecord::Base
-  has_many :bookable_slots
+  has_many :bookable_slots, -> { order(:date) }
+
+  alias default? new_record?
 
   def generate_bookable_slots!
     BookableSlotGenerator.new(self).call
+  end
+
+  def bookable_slots_in_window
+    bookable_slots.windowed
   end
 
   def self.current(location_id)

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,4 +1,17 @@
 class Schedule < ActiveRecord::Base
+  SLOT_ATTRIBUTES = %i(
+    monday_am
+    monday_pm
+    tuesday_am
+    tuesday_pm
+    wednesday_am
+    wednesday_pm
+    thursday_am
+    thursday_pm
+    friday_am
+    friday_pm
+  ).freeze
+
   has_many :bookable_slots, -> { order(:date) }
 
   alias default? new_record?
@@ -15,12 +28,5 @@ class Schedule < ActiveRecord::Base
     where(location_id: location_id)
       .order(created_at: :desc)
       .first_or_initialize(location_id: location_id)
-  end
-
-  def self.slot_attributes
-    columns_hash
-      .keys
-      .select { |k| /_[a|p]m\z/ === k } # rubocop:disable Style/CaseEquality
-      .map(&:to_sym)
   end
 end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -11,7 +11,7 @@ class Slot < ActiveRecord::Base
   validate :validate_from_before_to
 
   def morning?
-    from < '1300'
+    BookableSlot::AM.am?(from)
   end
 
   def to_s

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 class User < ActiveRecord::Base
   PENSION_WISE_API_PERMISSION = 'pension_wise_api_user'
   BOOKING_MANAGER_PERMISSION  = 'booking_manager'
+  SCHEDULE_MANAGER_PERMISSION = 'schedule_manager'
   ADMINISTRATOR_PERMISSION    = 'administrator'
 
   include GDS::SSO::User
@@ -28,6 +29,10 @@ class User < ActiveRecord::Base
   end
 
   def administrator?
-    permissions.include?(ADMINISTRATOR_PERMISSION)
+    has_permission?(ADMINISTRATOR_PERMISSION)
+  end
+
+  def schedule_manager?
+    has_permission?(SCHEDULE_MANAGER_PERMISSION)
   end
 end

--- a/app/serializers/bookable_slot_serializer.rb
+++ b/app/serializers/bookable_slot_serializer.rb
@@ -1,0 +1,5 @@
+class BookableSlotSerializer < ActiveModel::Serializer
+  attribute :date
+  attribute :start
+  attribute :end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,11 @@
   <li>
     <%= link_to 'Appointments', appointments_path %>
   </li>
+  <% if current_user.schedule_manager? %>
+  <li>
+    <%= link_to 'Schedules', schedules_path %>
+  </li>
+  <% end %>
   <% if current_user.administrator? %>
     <%= form_for current_user, html: { class: 'navbar-form navbar-right js-location-form' } do |f| %>
       <div class="form-group">

--- a/app/views/schedules/_schedule_summary.html.erb
+++ b/app/views/schedules/_schedule_summary.html.erb
@@ -1,3 +1,4 @@
+<% cache location.schedule do %>
 <div class="schedule-summary" aria-hidden="true">
   <div class="schedule-summary__day">
     <%= summary(:monday_am, location.schedule) %>
@@ -20,3 +21,4 @@
     <%= summary(:friday_pm, location.schedule) %>
   </div>
 </div>
+<% end %>

--- a/app/views/schedules/_schedule_summary.html.erb
+++ b/app/views/schedules/_schedule_summary.html.erb
@@ -1,0 +1,23 @@
+<span class="sr-only">Mondays, Tuesdays AM, Wednesdays, Thursday AM, Fridays</span>
+<div class="schedule-summary" aria-hidden="true">
+  <div class="schedule-summary__day">
+    <div class="schedule-summary__period schedule-summary__period--on" title="Open Monday AM"></div>
+    <div class="schedule-summary__period schedule-summary__period--on" title="Open Monday PM"></div>
+  </div>
+  <div class="schedule-summary__day">
+    <div class="schedule-summary__period schedule-summary__period--on" title="Open Tuesday AM"></div>
+    <div class="schedule-summary__period" title="Closed Tuesday PM"></div>
+  </div>
+  <div class="schedule-summary__day">
+    <div class="schedule-summary__period schedule-summary__period--on" title="Open Wednesday AM"></div>
+    <div class="schedule-summary__period schedule-summary__period--on" title="Open Wednesday PM"></div>
+  </div>
+  <div class="schedule-summary__day">
+    <div class="schedule-summary__period schedule-summary__period--on" title="Open Thursday AM"></div>
+    <div class="schedule-summary__period" title="Closed Thursday PM"></div>
+  </div>
+  <div class="schedule-summary__day">
+    <div class="schedule-summary__period schedule-summary__period--on" title="Open Friday AM"></div>
+    <div class="schedule-summary__period schedule-summary__period--on" title="Open Friday PM"></div>
+  </div>
+</div>

--- a/app/views/schedules/_schedule_summary.html.erb
+++ b/app/views/schedules/_schedule_summary.html.erb
@@ -1,23 +1,22 @@
-<span class="sr-only">Mondays, Tuesdays AM, Wednesdays, Thursday AM, Fridays</span>
 <div class="schedule-summary" aria-hidden="true">
   <div class="schedule-summary__day">
-    <div class="schedule-summary__period schedule-summary__period--on" title="Open Monday AM"></div>
-    <div class="schedule-summary__period schedule-summary__period--on" title="Open Monday PM"></div>
+    <%= summary(:monday_am, location.schedule) %>
+    <%= summary(:monday_pm, location.schedule) %>
   </div>
   <div class="schedule-summary__day">
-    <div class="schedule-summary__period schedule-summary__period--on" title="Open Tuesday AM"></div>
-    <div class="schedule-summary__period" title="Closed Tuesday PM"></div>
+    <%= summary(:tuesday_am, location.schedule) %>
+    <%= summary(:tuesday_pm, location.schedule) %>
   </div>
   <div class="schedule-summary__day">
-    <div class="schedule-summary__period schedule-summary__period--on" title="Open Wednesday AM"></div>
-    <div class="schedule-summary__period schedule-summary__period--on" title="Open Wednesday PM"></div>
+    <%= summary(:wednesday_am, location.schedule) %>
+    <%= summary(:wednesday_pm, location.schedule) %>
   </div>
   <div class="schedule-summary__day">
-    <div class="schedule-summary__period schedule-summary__period--on" title="Open Thursday AM"></div>
-    <div class="schedule-summary__period" title="Closed Thursday PM"></div>
+    <%= summary(:thursday_am, location.schedule) %>
+    <%= summary(:thursday_pm, location.schedule) %>
   </div>
   <div class="schedule-summary__day">
-    <div class="schedule-summary__period schedule-summary__period--on" title="Open Friday AM"></div>
-    <div class="schedule-summary__period schedule-summary__period--on" title="Open Friday PM"></div>
+    <%= summary(:friday_am, location.schedule) %>
+    <%= summary(:friday_pm, location.schedule) %>
   </div>
 </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -29,10 +29,10 @@
             <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span> <%= @booking_location.name %>
           </td>
           <td class="t-summary">
-            <%= render 'schedule_summary' %>
+            <%= render 'schedule_summary', location: @booking_location %>
           </td>
           <td>
-            <%= link_to 'Modify', new_schedule_path(location_id: @booking_location.id), class: 'btn btn-info' %>
+            <%= link_to 'Modify', new_schedule_path(location_id: @booking_location.id), class: 'btn btn-info t-manage' %>
           </td>
         </tr>
         <% @booking_location.locations.each do |location| %>
@@ -41,10 +41,10 @@
               <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span> <%= location.name %>
             </td>
             <td class="t-summary">
-              <%= render 'schedule_summary' %>
+              <%= render 'schedule_summary', location: location %>
             </td>
             <td>
-              <%= link_to 'Modify', new_schedule_path(location_id: location.id), class: 'btn btn-info' %>
+              <%= link_to 'Modify', new_schedule_path(location_id: location.id), class: 'btn btn-info t-manage' %>
             </td>
           </tr>
         <% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,0 +1,54 @@
+<% content_for(:page_title, t('service.title', page_title: 'Schedules')) %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li class="active">Schedules</li>
+  </ol>
+
+  <h1>Schedules</h1>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <table class="centered-table table table-bordered table-striped">
+      <colgroup>
+        <col width="75%" />
+        <col width="20%" />
+        <col width="5%" />
+      </colgroup>
+      <thead>
+        <tr class="table-header">
+          <th>Location</th>
+          <th>Schedule</th>
+          <th><span class="sr-only">Actions</span></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="t-schedule">
+          <td class="t-location">
+            <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span> <%= @booking_location.name %>
+          </td>
+          <td class="t-summary">
+            <%= render 'schedule_summary' %>
+          </td>
+          <td>
+            <%= link_to 'Modify', new_schedule_path(location_id: @booking_location.id), class: 'btn btn-info' %>
+          </td>
+        </tr>
+        <% @booking_location.locations.each do |location| %>
+          <tr class="t-schedule">
+            <td class="t-location">
+              <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span> <%= location.name %>
+            </td>
+            <td class="t-summary">
+              <%= render 'schedule_summary' %>
+            </td>
+            <td>
+              <%= link_to 'Modify', new_schedule_path(location_id: location.id), class: 'btn btn-info' %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,0 +1,92 @@
+<% content_for(:page_title, t('service.title', page_title: "Edit schedule for #{@location.name}")) %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= schedules_path %>">Schedules</a></li>
+    <li class="active">Edit schedule for <%= @location.name %></li>
+  </ol>
+
+  <h1>Edit schedule for <%= @location.name %></h1>
+</div>
+
+<%= form_for @schedule do |f| %>
+  <%= f.hidden_field :location_id %>
+  <div class="weekly-schedule weekly-schedule--day-labels" aria-hidden="true">
+    <div class="weekly-schedule__day-label">
+      Monday
+    </div>
+    <div class="weekly-schedule__day-label">
+      Tuesday
+    </div>
+    <div class="weekly-schedule__day-label">
+      Wednesday
+    </div>
+    <div class="weekly-schedule__day-label">
+      Thursday
+    </div>
+    <div class="weekly-schedule__day-label">
+      Friday
+    </div>
+  </div>
+  <div class="weekly-schedule form-group">
+    <div class="weekly-schedule__day">
+      <%= f.check_box :monday_am, class: 'weekly-schedule__switch t-monday-am', id: 'monday-am' %>
+      <label class="weekly-schedule__label" for="monday-am">
+        <span class="weekly-schedule__day-name">Monday</span> AM
+      </label>
+
+      <%= f.check_box :monday_pm, class: 'weekly-schedule__switch t-monday-pm', id: 'monday-pm' %>
+      <label class="weekly-schedule__label" for="monday-pm">
+        <span class="weekly-schedule__day-name">Monday</span> PM
+      </label>
+    </div>
+    <div class="weekly-schedule__day">
+      <%= f.check_box :tuesday_am, class: 'weekly-schedule__switch t-tuesday-am', id: 'tuesday-am' %>
+      <label class="weekly-schedule__label" for="tuesday-am">
+        <span class="weekly-schedule__day-name">Tuesday</span> AM
+      </label>
+
+      <%= f.check_box :tuesday_pm, class: 'weekly-schedule__switch t-tuesday-pm', id: 'tuesday-pm' %>
+      <label class="weekly-schedule__label" for="tuesday-pm">
+        <span class="weekly-schedule__day-name">Tuesday</span> PM
+      </label>
+    </div>
+    <div class="weekly-schedule__day">
+      <%= f.check_box :wednesday_am, class: 'weekly-schedule__switch t-wednesday-am', id: 'wednesday-am' %>
+      <label class="weekly-schedule__label" for="wednesday-am">
+        <span class="weekly-schedule__day-name">Wednesday</span> AM
+      </label>
+
+      <%= f.check_box :wednesday_pm, class: 'weekly-schedule__switch t-wednesday-pm', id: 'wednesday-pm' %>
+      <label class="weekly-schedule__label" for="wednesday-pm">
+        <span class="weekly-schedule__day-name">Wednesday</span> PM
+      </label>
+    </div>
+    <div class="weekly-schedule__day">
+      <%= f.check_box :thursday_am, class: 'weekly-schedule__switch t-thursday-am', id: 'thursday-am' %>
+      <label class="weekly-schedule__label" for="thursday-am">
+        <span class="weekly-schedule__day-name">Thursday</span> AM
+      </label>
+
+      <%= f.check_box :thursday_pm, class: 'weekly-schedule__switch t-thursday-pm', id: 'thursday-pm' %>
+      <label class="weekly-schedule__label" for="thursday-pm">
+        <span class="weekly-schedule__day-name">Thursday</span> PM
+      </label>
+    </div>
+    <div class="weekly-schedule__day">
+      <%= f.check_box :friday_am, class: 'weekly-schedule__switch t-friday-am', id: 'friday-am' %>
+      <label class="weekly-schedule__label" for="friday-am">
+        <span class="weekly-schedule__day-name">Friday</span> AM
+      </label>
+
+      <%= f.check_box :friday_pm, class: 'weekly-schedule__switch t-friday-pm', id: 'friday-pm' %>
+      <label class="weekly-schedule__label" for="friday-pm">
+        <span class="weekly-schedule__day-name">Friday</span> PM
+      </label>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.button 'Save', class: 'btn btn-primary t-submit' %>
+  </div>
+<% end %>

--- a/config/initializers/bookable_slots.rb
+++ b/config/initializers/bookable_slots.rb
@@ -1,12 +1,3 @@
-# Days to advance when covering grace period
-GRACE_PERIODS = {
-  3 => :monday,
-  4 => :tuesday,
-  5 => :wednesday,
-  6 => :thursday,
-  0 => :thursday
-}.freeze
-
 # Days that are always excluded from availability
 BANK_HOLIDAYS = [
   Date.parse('29/05/2017'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
     resources :appointments, only: %i(new create)
   end
 
-  resources :schedules, only: %i(index new)
+  resources :schedules, only: %i(index new create)
 
   root 'booking_requests#index'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
     resources :appointments, only: %i(new create)
   end
 
+  resources :schedules, only: %i(index new)
+
   root 'booking_requests#index'
 
   namespace :api, constraints: { format: :json } do

--- a/db/migrate/20170522140310_create_schedules.rb
+++ b/db/migrate/20170522140310_create_schedules.rb
@@ -1,0 +1,20 @@
+class CreateSchedules < ActiveRecord::Migration[5.1]
+  def change
+    create_table :schedules do |t|
+      t.string :location_id, null: false, index: true
+
+      t.boolean :monday_am, default: true, null: false
+      t.boolean :monday_pm, default: true, null: false
+      t.boolean :tuesday_am, default: true, null: false
+      t.boolean :tuesday_pm, default: true, null: false
+      t.boolean :wednesday_am, default: true, null: false
+      t.boolean :wednesday_pm, default: true, null: false
+      t.boolean :thursday_am, default: true, null: false
+      t.boolean :thursday_pm, default: true, null: false
+      t.boolean :friday_am, default: true, null: false
+      t.boolean :friday_pm, default: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170522140310_create_schedules.rb
+++ b/db/migrate/20170522140310_create_schedules.rb
@@ -3,16 +3,9 @@ class CreateSchedules < ActiveRecord::Migration[5.1]
     create_table :schedules do |t|
       t.string :location_id, null: false, index: true
 
-      t.boolean :monday_am, default: true, null: false
-      t.boolean :monday_pm, default: true, null: false
-      t.boolean :tuesday_am, default: true, null: false
-      t.boolean :tuesday_pm, default: true, null: false
-      t.boolean :wednesday_am, default: true, null: false
-      t.boolean :wednesday_pm, default: true, null: false
-      t.boolean :thursday_am, default: true, null: false
-      t.boolean :thursday_pm, default: true, null: false
-      t.boolean :friday_am, default: true, null: false
-      t.boolean :friday_pm, default: true, null: false
+      Schedule::SLOT_ATTRIBUTES.each do |attribute|
+        t.boolean attribute, default: true, null: false
+      end
 
       t.timestamps
     end

--- a/db/migrate/20170525135108_create_bookable_slots.rb
+++ b/db/migrate/20170525135108_create_bookable_slots.rb
@@ -1,0 +1,12 @@
+class CreateBookableSlots < ActiveRecord::Migration[5.1]
+  def change
+    create_table :bookable_slots do |t|
+      t.belongs_to :schedule, null: false, foreign_key: true, index: true
+      t.date :date, null: false
+      t.string :start, null: false
+      t.string :end, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170522140310) do
+ActiveRecord::Schema.define(version: 20170525135108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,16 @@ ActiveRecord::Schema.define(version: 20170522140310) do
     t.index ["created_at"], name: "index_audits_on_created_at"
     t.index ["request_uuid"], name: "index_audits_on_request_uuid"
     t.index ["user_id", "user_type"], name: "user_index"
+  end
+
+  create_table "bookable_slots", force: :cascade do |t|
+    t.bigint "schedule_id", null: false
+    t.date "date", null: false
+    t.string "start", null: false
+    t.string "end", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["schedule_id"], name: "index_bookable_slots_on_schedule_id"
   end
 
   create_table "booking_requests", id: :serial, force: :cascade do |t|
@@ -126,5 +136,6 @@ ActiveRecord::Schema.define(version: 20170522140310) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "bookable_slots", "schedules"
   add_foreign_key "slots", "booking_requests"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170518162225) do
+ActiveRecord::Schema.define(version: 20170522140310) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,23 @@ ActiveRecord::Schema.define(version: 20170518162225) do
     t.string "booking_location_id", null: false
     t.date "date_of_birth"
     t.integer "status", default: 0, null: false
+  end
+
+  create_table "schedules", force: :cascade do |t|
+    t.string "location_id", null: false
+    t.boolean "monday_am", default: true, null: false
+    t.boolean "monday_pm", default: true, null: false
+    t.boolean "tuesday_am", default: true, null: false
+    t.boolean "tuesday_pm", default: true, null: false
+    t.boolean "wednesday_am", default: true, null: false
+    t.boolean "wednesday_pm", default: true, null: false
+    t.boolean "thursday_am", default: true, null: false
+    t.boolean "thursday_pm", default: true, null: false
+    t.boolean "friday_am", default: true, null: false
+    t.boolean "friday_pm", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_schedules_on_location_id"
   end
 
   create_table "slots", id: :serial, force: :cascade do |t|

--- a/spec/factories/bookable_slots.rb
+++ b/spec/factories/bookable_slots.rb
@@ -4,13 +4,13 @@ FactoryGirl.define do
     date { Time.zone.now }
 
     trait :am do
-      start '0900'
-      add_attribute(:end, '1300')
+      start BookableSlot::AM.start
+      add_attribute(:end, BookableSlot::PM.end)
     end
 
     trait :pm do
-      start '1300'
-      add_attribute(:end, '1700')
+      start BookableSlot::PM.start
+      add_attribute(:end, BookableSlot::PM.end)
     end
   end
 end

--- a/spec/factories/bookable_slots.rb
+++ b/spec/factories/bookable_slots.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :bookable_slot do
+    schedule
+    date { Time.zone.now }
+
+    trait :am do
+      start '0900'
+      add_attribute(:end, '1300')
+    end
+
+    trait :pm do
+      start '1300'
+      add_attribute(:end, '1700')
+    end
+  end
+end

--- a/spec/factories/bookable_slots.rb
+++ b/spec/factories/bookable_slots.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
 
     trait :am do
       start BookableSlot::AM.start
-      add_attribute(:end, BookableSlot::PM.end)
+      add_attribute(:end, BookableSlot::AM.end)
     end
 
     trait :pm do

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :schedule do
+    # Hackney
+    location_id 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
+  end
+end

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -4,14 +4,8 @@ FactoryGirl.define do
     location_id 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
 
     trait :blank do
-      begin
-        Schedule.slot_attributes.each do |attribute|
-          add_attribute(attribute, false)
-        end
-      rescue ActiveRecord::StatementInvalid => e
-        # this occurs during migrations since `Schedule#slot_attributes`
-        # requires `Schedule` to be migrated
-        Rails.logger.error(e)
+      Schedule::SLOT_ATTRIBUTES.each do |attribute|
+        add_attribute(attribute, false)
       end
     end
   end

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -2,5 +2,17 @@ FactoryGirl.define do
   factory :schedule do
     # Hackney
     location_id 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef'
+
+    trait :blank do
+      begin
+        Schedule.slot_attributes.each do |attribute|
+          add_attribute(attribute, false)
+        end
+      rescue ActiveRecord::StatementInvalid => e
+        # this occurs during migrations since `Schedule#slot_attributes`
+        # requires `Schedule` to be migrated
+        Rails.logger.error(e)
+      end
+    end
   end
 end

--- a/spec/factories/slots.rb
+++ b/spec/factories/slots.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :slot do
     date { "2016-06-#{Array(20..24).sample}" }
-    from '0900'
-    to '1300'
+    from BookableSlot::AM.start
+    to   BookableSlot::AM.end
     priority 1
   end
 end

--- a/spec/features/booking_manager_manages_schedules_spec.rb
+++ b/spec/features/booking_manager_manages_schedules_spec.rb
@@ -1,10 +1,15 @@
 require 'rails_helper'
 
 RSpec.feature 'Booking manager manages schedules' do
-  scenario 'Viewing locations with default schedules' do
+  scenario 'Modifying a booking location’s schedules' do
     given_the_user_identifies_as_hackneys_booking_manager do
       when_they_view_their_schedules
       then_they_see_default_schedules_across_their_locations
+      when_they_manage_the_booking_location_schedule
+      and_they_mark_some_days_unavailable
+      when_they_save_the_schedule
+      then_slot_generation_is_scheduled
+      and_they_see_the_schedule_summarised_accurately
     end
   end
 
@@ -15,8 +20,41 @@ RSpec.feature 'Booking manager manages schedules' do
 
   def then_they_see_default_schedules_across_their_locations
     expect(@page).to be_loaded
-
     expect(@page).to have_schedules(count: 6)
     expect(@page.schedules.first.location.text).to eq('Hackney')
+  end
+
+  def when_they_manage_the_booking_location_schedule
+    @page.schedules.first.manage.click
+  end
+
+  def and_they_mark_some_days_unavailable
+    @page = Pages::Schedule.new
+    @page.load(location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+    expect(@page).to be_loaded
+
+    @page.monday_am.click
+    @page.wednesday_pm.click
+    @page.friday_am.click
+  end
+
+  def when_they_save_the_schedule
+    @page.submit.click
+  end
+
+  def then_slot_generation_is_scheduled
+    assert_enqueued_jobs(1, only: SlotGenerationJob)
+  end
+
+  def and_they_see_the_schedule_summarised_accurately # rubocop:disable Metrics/AbcSize
+    @page = Pages::Schedules.new
+
+    @page.schedules.first.summary.tap do |summary|
+      expect(summary.monday_am).to be_closed
+      expect(summary.wednesday_pm).to be_closed
+      expect(summary.friday_am).to be_closed
+      # just a single example of an open slot
+      expect(summary.monday_pm).to be_open
+    end
   end
 end

--- a/spec/features/booking_manager_manages_schedules_spec.rb
+++ b/spec/features/booking_manager_manages_schedules_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.feature 'Booking manager manages schedules' do
+  scenario 'Viewing locations with default schedules' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      when_they_view_their_schedules
+      then_they_see_default_schedules_across_their_locations
+    end
+  end
+
+  def when_they_view_their_schedules
+    @page = Pages::Schedules.new
+    @page.load
+  end
+
+  def then_they_see_default_schedules_across_their_locations
+    expect(@page).to be_loaded
+
+    expect(@page).to have_schedules(count: 6)
+    expect(@page.schedules.first.location.text).to eq('Hackney')
+  end
+end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Schedule do
+  let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
+
+  describe '.current' do
+    context 'when multiple schedules exist for a single location' do
+      it 'returns the latest one' do
+        # first, default schedule
+        create(:schedule)
+        # the current schedule
+        create(:schedule, monday_am: false)
+
+        expect(described_class.current(hackney.id)).to_not be_monday_am
+      end
+    end
+
+    context 'when no schedules exist' do
+      it 'returns a default schedule' do
+        expect(described_class.current(hackney.id)).to_not be_persisted
+      end
+    end
+  end
+end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -3,6 +3,36 @@ require 'rails_helper'
 RSpec.describe Schedule do
   let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
 
+  describe '#generate_bookable_slots!' do
+    before do
+      @previous_schedule = create(:schedule) do |schedule|
+        create(:bookable_slot, :am, schedule: schedule)
+      end
+
+      @other_schedule = create(:schedule, location_id: 'deadbeef') do |schedule|
+        create(:bookable_slot, :am, schedule: schedule)
+      end
+
+      @current_schedule = create(:schedule, :blank, monday_am: true, friday_pm: true)
+    end
+
+    it 'performs the requisite steps to generate bookable slots' do
+      @current_schedule.generate_bookable_slots!
+      # deleted slots from the schedule start date, for the same location
+      expect(@previous_schedule.bookable_slots).to be_empty
+      # other location's slots are left intact
+      expect(@other_schedule.bookable_slots).to_not be_empty
+
+      # created slots based on the scheduled availability
+      mondays, fridays = @current_schedule.bookable_slots.partition do |slot|
+        slot.date.strftime('%A') == 'Monday'
+      end
+
+      expect(mondays.all?(&:am?))
+      expect(fridays.all?(&:pm?))
+    end
+  end
+
   describe '.current' do
     context 'when multiple schedules exist for a single location' do
       it 'returns the latest one' do

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -1,13 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe 'GET /api/v1/locations/{location_id}/bookable_slots' do
-  scenario 'returns default availability' do
-    when_a_request_is_made
+  scenario 'Returns real availability for locations with schedules' do
+    travel_to '2017-05-26 13:00' do
+      given_a_location_with_a_schedule_exists
+      when_a_request_for_the_location_is_made
+      then_the_service_responds_ok
+      and_slots_are_serialized_as_json
+      and_the_correct_slots_are_returned
+    end
+  end
+
+  scenario 'Returns default availability for locations without schedules' do
+    when_a_request_for_a_location_without_a_schedule_is_made
     then_the_service_responds_ok
     and_slots_are_serialized_as_json
   end
 
-  def when_a_request_is_made
+  def given_a_location_with_a_schedule_exists
+    @schedule = create(:schedule).tap do |schedule|
+      # excluded due to falling within the grace period
+      create(:bookable_slot, :am, schedule: schedule)
+      # excluded as after booking window
+      create(:bookable_slot, :am, schedule: schedule, date: 7.weeks.from_now)
+      # will be returned
+      create(:bookable_slot, :am, schedule: schedule, date: GracePeriod.new.call)
+    end
+  end
+
+  def when_a_request_for_the_location_is_made
+    get api_v1_bookable_slots_path(location_id: @schedule.location_id), as: :json
+  end
+
+  def and_the_correct_slots_are_returned
+    expect(@json.count).to eq(1)
+
+    expect(@json.first).to eq(
+      'date'  => '2017-05-31',
+      'start' => BookableSlot::AM.start,
+      'end'   => BookableSlot::AM.end
+    )
+  end
+
+  def when_a_request_for_a_location_without_a_schedule_is_made
     get api_v1_bookable_slots_path(location_id: 'deadbeef'), as: :json
   end
 
@@ -16,7 +51,7 @@ RSpec.describe 'GET /api/v1/locations/{location_id}/bookable_slots' do
   end
 
   def and_slots_are_serialized_as_json
-    JSON.parse(response.body).tap do |json|
+    @json = JSON.parse(response.body).tap do |json|
       expect(json.first.keys).to match_array(%w(date start end))
     end
   end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -1,0 +1,20 @@
+# rubocop:disable Style/CaseEquality
+RSpec::Matchers.define :be_open do
+  match do |actual|
+    /\Aopen/i === actual[:title]
+  end
+
+  failure_message do |actual|
+    "expected '#{actual[:title]}' to be 'Open'"
+  end
+end
+
+RSpec::Matchers.define :be_closed do
+  match do |actual|
+    /\Aclosed/i === actual[:title]
+  end
+
+  failure_message do |actual|
+    "expected '#{actual[:title]}' to be 'Closed'"
+  end
+end

--- a/spec/support/pages/schedule.rb
+++ b/spec/support/pages/schedule.rb
@@ -1,0 +1,12 @@
+module Pages
+  class Schedule < SitePrism::Page
+    set_url '/schedules/new?location_id={location_id}'
+
+    %i(monday tuesday wednesday thursday friday).each do |day|
+      element "#{day}_am", ".t-#{day}-am"
+      element "#{day}_pm", ".t-#{day}-pm"
+    end
+
+    element :submit, '.t-submit'
+  end
+end

--- a/spec/support/pages/schedules.rb
+++ b/spec/support/pages/schedules.rb
@@ -4,7 +4,14 @@ module Pages
 
     sections :schedules, '.t-schedule' do
       element :location, '.t-location'
-      element :summary, '.t-summary'
+      element :manage, '.t-manage'
+
+      section :summary, '.t-summary' do
+        %i(monday tuesday wednesday thursday friday).each do |day|
+          element "#{day}_am", ".t-#{day}-am"
+          element "#{day}_pm", ".t-#{day}-pm"
+        end
+      end
     end
   end
 end

--- a/spec/support/pages/schedules.rb
+++ b/spec/support/pages/schedules.rb
@@ -1,0 +1,10 @@
+module Pages
+  class Schedules < SitePrism::Page
+    set_url '/schedules'
+
+    sections :schedules, '.t-schedule' do
+      element :location, '.t-location'
+      element :summary, '.t-summary'
+    end
+  end
+end


### PR DESCRIPTION
Grants booking managers the ability to manage their location's availability by
way of templated schedules. Locations without schedules will return the same,
default availability currently returned by the booking locations API from the
location registry.

A single schedule runs at any given time, and serves up slots based on the
grace period to the end of the current booking window (6 weeks) and upon
creation of a schedule, bookable slots are generated and persisted to be served
via the publicly available bookable slots API, exposed in this application.
When an existing schedule is in play and another is created that would overlap,
the prior schedule's slots are destroyed and replaced by those generated by the
new schedule.

Some things to note/question:

1. 'Modify' is probably the wrong language for schedules now
2. We need a solution for 'regenerating' slots when they are approaching the
end of the generation window (currently hard-coded at 4 months from the date of
generation)
3. The slots are cacheable and we should investigate this
4. The `booking_locations` gem needs rework once this is deployed - in order to
correctly derive slots - now this application serves those slots via its API

Review commit-by-commit. I'll squash this down after review.