### PR TITLE
Move the accessibility question closer to the phone number

### DIFF
--- a/app/assets/stylesheets/components/_checkbox-inline.scss
+++ b/app/assets/stylesheets/components/_checkbox-inline.scss
@@ -1,0 +1,3 @@
+.checkbox-inline--accessibility {
+  margin-top: 10px;
+}

--- a/app/assets/stylesheets/components/_form-group.scss
+++ b/app/assets/stylesheets/components/_form-group.scss
@@ -1,0 +1,5 @@
+.form-group--time {
+  @media(min-width: $screen-md-min) {
+    margin-top: 43px;
+  }
+}

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -138,29 +138,16 @@
             <div class="form-group">
               <%= f.label :phone %>
               <%= f.text_field :phone, class: 'form-control t-phone' %>
+
+              <%= f.label :accessibility_requirements, class: 'checkbox-inline checkbox-inline--accessibility' do %>
+                <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements' %> Accessibility requirements?
+              <% end %>
             </div>
             <div class="form-group">
               <%= f.label :memorable_word %>
               <%= f.text_field :memorable_word, class: 'form-control t-memorable-word' %>
             </div>
             <%= render partial: 'shared/date_of_birth_form_field', locals: { form: f } %>
-            <div class="form-group">
-              <p>Defined contribution pot confirmed?</p>
-              <%= f.label :defined_contribution_pot_confirmed, value: true, class: 'radio-inline' do %>
-                  <%= f.radio_button :defined_contribution_pot_confirmed, true, class: 't-defined-contribution-pot-confirmed-yes' %>
-                  Yes
-              <% end %>
-
-              <%= f.label :defined_contribution_pot_confirmed, value: false, class: 'radio-inline' do %>
-                <%= f.radio_button :defined_contribution_pot_confirmed, false, class: 't-defined-contribution-pot-confirmed-dont-know' %>
-                Don’t know
-              <% end %>
-            </div>
-            <div class="form-group">
-              <%= f.label :accessibility_requirements, class: 'checkbox-inline' do %>
-                <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements' %> Accessibility requirements?
-              <% end %>
-            </div>
           </div>
           <div class="col-md-6">
             <h2 class="h3">Appointment details</h2>
@@ -190,7 +177,7 @@
               <%= f.text_field :date, class: 'js-date-time-picker t-date form-control', value: @appointment_form.date.to_date.to_s(:govuk_date) %>
             </div>
 
-            <div class="form-group">
+            <div class="form-group form-group--time">
               <%= f.label :time %>
               <div class="form-control">
                 <%= f.time_select(
@@ -199,6 +186,19 @@
                   minute_step: 15
                 ) %>
               </div>
+            </div>
+
+            <div class="form-group">
+              <p><b>Defined contribution pot confirmed?</b></p>
+              <%= f.label :defined_contribution_pot_confirmed, value: true, class: 'radio-inline' do %>
+                  <%= f.radio_button :defined_contribution_pot_confirmed, true, class: 't-defined-contribution-pot-confirmed-yes' %>
+                  Yes
+              <% end %>
+
+              <%= f.label :defined_contribution_pot_confirmed, value: false, class: 'radio-inline' do %>
+                <%= f.radio_button :defined_contribution_pot_confirmed, false, class: 't-defined-contribution-pot-confirmed-dont-know' %>
+                Don’t know
+              <% end %>
             </div>
         </div>
       </div>

--- a/app/views/shared/_date_of_birth_form_field.html.erb
+++ b/app/views/shared/_date_of_birth_form_field.html.erb
@@ -5,6 +5,7 @@
 %>
 
 <div class="form-dob clearfix" data-module="customer-age" data-output-id="customer-age">
+  <p><b>Date of birth</b></p>
   <%= field_with_errors_wrapper(form, :date_of_birth, 'form-dob__inputs-container') do %>
     <label for="<%= form_element_day_id %>">
       <span class="sr-only">Date of birth</span> <%= required_label(:day) %>


### PR DESCRIPTION
Feedback from booking managers has indicated that
sometimes customers are not asked about their accessibility
requirements when a booking is made because the manager has
missed that the accessibility question is checked.

This brings the accessibility question closer to the phone
number field, so it's more noticeable.

<img width="734" alt="screen shot 2017-05-30 at 10 04 52" src="https://cloud.githubusercontent.com/assets/6049076/26576062/745dbd00-451f-11e7-8056-dce1e9a2ab6b.png">
