### PR TITLE
Expose schedule summary to screen readers

### DIFF
--- a/app/helpers/schedule_helper.rb
+++ b/app/helpers/schedule_helper.rb
@@ -3,7 +3,8 @@ module ScheduleHelper
     open = schedule.public_send(period)
     day, slot = period.to_s.split('_')
 
-    content_tag(:div, '', class: classes(day, slot, open), title: title(day, slot, open))
+    content_tag(:div, '', class: classes(day, slot, open), title: title(day, slot, open)) +
+      content_tag(:span, title(day, slot, open), class: 'sr-only')
   end
 
   def classes(day, slot, open)

--- a/app/views/schedules/_schedule_summary.html.erb
+++ b/app/views/schedules/_schedule_summary.html.erb
@@ -1,5 +1,5 @@
 <% cache location.schedule do %>
-<div class="schedule-summary" aria-hidden="true">
+<div class="schedule-summary">
   <div class="schedule-summary__day">
     <%= summary(:monday_am, location.schedule) %>
     <%= summary(:monday_pm, location.schedule) %>


### PR DESCRIPTION
This improves the accessibility of the schedule index page
by allowing screen readers to read out which days are open
and closed for each booking location.