### PR TITLE
Add an additional info field to booking request and appointments

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -51,6 +51,7 @@ module Api
           :accessibility_requirements,
           :marketing_opt_in,
           :defined_contribution_pot_confirmed,
+          :additional_info,
           slots: %i(date from to priority)
         ).tap { |p| p[:slots_attributes] = p.delete(:slots) }
       end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -106,6 +106,7 @@ class AppointmentsController < ApplicationController
         :date_of_birth,
         :guider_id,
         :location_id,
+        :additional_info,
         :proceeded_at,
         :status
       )
@@ -134,7 +135,8 @@ class AppointmentsController < ApplicationController
         :guider_id,
         :location_id,
         :date,
-        :time
+        :time,
+        :additional_info
       )
   end
 end

--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -8,6 +8,7 @@ class AppointmentForm
     secondary_slot
     tertiary_slot
     booking_location
+    additional_info
   ).freeze
 
   validates :name, presence: true
@@ -36,6 +37,7 @@ class AppointmentForm
   attr_accessor :guider_id
   attr_accessor :location_id
   attr_accessor :date
+  attr_accessor :additional_info
 
   delegate(*BOOKING_REQUEST_ATTRIBUTES, to: :location_aware_booking_request)
 
@@ -78,6 +80,10 @@ class AppointmentForm
     @time ||= location_aware_booking_request.primary_slot.delimited_from
 
     Time.zone.parse(@time)
+  end
+
+  def additional_info
+    @additional_info ||= location_aware_booking_request.additional_info
   end
 
   def defined_contribution_pot_confirmed

--- a/app/mappers/appointment_mapper.rb
+++ b/app/mappers/appointment_mapper.rb
@@ -1,5 +1,5 @@
 class AppointmentMapper
-  def self.map(appointment_form) # rubocop:disable Metrics/MethodLength
+  def self.map(appointment_form) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     {
       name: appointment_form.name,
       email: appointment_form.email,
@@ -11,7 +11,8 @@ class AppointmentMapper
       guider_id: appointment_form.guider_id,
       location_id: appointment_form.location_id,
       proceeded_at: Time.zone.parse("#{appointment_form.date} #{appointment_form.time.strftime('%H:%M')}"),
-      booking_request_id: appointment_form.reference
+      booking_request_id: appointment_form.reference,
+      additional_info: appointment_form.additional_info
     }
   end
 end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -25,6 +25,7 @@ class BookingRequest < ActiveRecord::Base
   validates :accessibility_requirements, inclusion: { in: [true, false] }
   validates :marketing_opt_in, inclusion: { in: [true, false] }
   validates :defined_contribution_pot_confirmed, inclusion: { in: [true, false] }
+  validates :additional_info, length: { maximum: 160 }, allow_blank: true
   validate :validate_slots
 
   alias reference to_param

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -136,6 +136,10 @@
               </div>
             </div>
             <div class="form-group">
+              <%= f.label :additional_info %>
+              <%= f.text_area :additional_info, class: 'form-control t-additional-info', rows: 5, maxlength: 160, readonly: true %>
+            </div>
+            <div class="form-group">
               <div class="well appointment-status-well">
                 <%= f.label :status, 'Appointment status' %>
                 <%= f.select :status, friendly_options(Appointment.statuses), options = {}, { class: 'form-control t-status' } %>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -189,6 +189,11 @@
             </div>
 
             <div class="form-group">
+              <%= f.label :additional_info %>
+              <%= f.text_area :additional_info, class: 'form-control t-additional-info', rows: 5, maxlength: 160, readonly: true %>
+            </div>
+
+            <div class="form-group">
               <p><b>Defined contribution pot confirmed?</b></p>
               <%= f.label :defined_contribution_pot_confirmed, value: true, class: 'radio-inline' do %>
                 <%= f.radio_button :defined_contribution_pot_confirmed, true, class: 't-defined-contribution-pot-confirmed-yes' %>

--- a/db/migrate/20170605122227_add_additional_info_fields.rb
+++ b/db/migrate/20170605122227_add_additional_info_fields.rb
@@ -1,0 +1,8 @@
+class AddAdditionalInfoFields < ActiveRecord::Migration[5.1]
+  def change
+    with_options default: '', null: false, limit: 160 do |options|
+      options.add_column :booking_requests, :additional_info, :string
+      options.add_column :appointments, :additional_info, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170525135108) do
+ActiveRecord::Schema.define(version: 20170605122227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20170525135108) do
     t.date "date_of_birth"
     t.boolean "defined_contribution_pot_confirmed", default: true, null: false
     t.boolean "accessibility_requirements", default: false, null: false
+    t.string "additional_info", limit: 160, default: "", null: false
     t.index ["booking_request_id"], name: "index_appointments_on_booking_request_id"
     t.index ["location_id"], name: "index_appointments_on_location_id"
   end
@@ -93,6 +94,7 @@ ActiveRecord::Schema.define(version: 20170525135108) do
     t.string "booking_location_id", null: false
     t.date "date_of_birth"
     t.integer "status", default: 0, null: false
+    t.string "additional_info", limit: 160, default: "", null: false
   end
 
   create_table "schedules", force: :cascade do |t|

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     memorable_word 'spaceship'
     age_range '50-54'
     date_of_birth '1950-01-01'
+    additional_info ''
     accessibility_requirements true
     marketing_opt_in false
     defined_contribution_pot_confirmed true

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -93,6 +93,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
     expect(@page.year_of_birth.value).to eq(@booking_request.date_of_birth.year.to_s)
     expect(@page.defined_contribution_pot_confirmed_yes).to be_checked
     expect(@page.accessibility_requirements.value).to eq('1')
+    expect(@page.additional_info.value).to eq('')
   end
 
   def and_they_see_the_requested_slots

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe AppointmentForm do
     expect(subject.reference).to eq(booking_request.reference)
     expect(subject.memorable_word).to eq(booking_request.memorable_word)
     expect(subject.accessibility_requirements).to eq(booking_request.accessibility_requirements)
-
+    expect(subject.additional_info).to eq(booking_request.additional_info)
     expect(subject.primary_slot).to eq(booking_request.primary_slot)
     expect(subject.secondary_slot).to eq(booking_request.secondary_slot)
     expect(subject.tertiary_slot).to eq(booking_request.tertiary_slot)

--- a/spec/mappers/appointment_mapper_spec.rb
+++ b/spec/mappers/appointment_mapper_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe AppointmentMapper, '.map' do
       'date_of_birth' => '1950-01-01',
       'memorable_word' => 'spaceship',
       'accessibility_requirements' => '1',
-      'defined_contribution_pot_confirmed' => '1'
+      'defined_contribution_pot_confirmed' => '1',
+      'additional_info' => 'Additional Info'
     }
   end
   let(:appointment_form) do
@@ -35,7 +36,8 @@ RSpec.describe AppointmentMapper, '.map' do
       date_of_birth: appointment_form.date_of_birth,
       memorable_word: appointment_form.memorable_word,
       defined_contribution_pot_confirmed: appointment_form.defined_contribution_pot_confirmed,
-      accessibility_requirements: appointment_form.accessibility_requirements
+      accessibility_requirements: appointment_form.accessibility_requirements,
+      additional_info: appointment_form.additional_info
     )
   end
 end

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe BookingRequest do
       expect(build(:booking_request)).to be_valid
     end
 
+    it 'validates maximum length of `additional_info`' do
+      expect(build(:booking_request, additional_info: '*' * 161)).to_not be_valid
+    end
+
     it 'requires a booking_location_id' do
       expect(build(:booking_request, booking_location_id: '')).to_not be_valid
     end

--- a/spec/requests/create_a_booking_request_spec.rb
+++ b/spec/requests/create_a_booking_request_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
         'memorable_word' => 'science',
         'age_range' => '50-54',
         'date_of_birth' => '1950-01-01',
+        'additional_info' => 'Additional Info',
         'accessibility_requirements' => false,
         'marketing_opt_in' => true,
         'defined_contribution_pot_confirmed' => true,
@@ -77,6 +78,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
       memorable_word: 'science',
       age_range: '50-54',
       date_of_birth: Date.parse('1950-01-01'),
+      additional_info: 'Additional Info',
       accessibility_requirements: false,
       marketing_opt_in: true,
       defined_contribution_pot_confirmed: true

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -13,6 +13,7 @@ module Pages
     element :memorable_word, '.t-memorable-word'
     element :age_range, '.t-age-range'
     element :day_of_birth, '.t-date-of-birth-day'
+    element :additional_info, '.t-additional-info'
     element :month_of_birth, '.t-date-of-birth-month'
     element :year_of_birth, '.t-date-of-birth-year'
     element :accessibility_requirements, '.t-accessibility-requirements'


### PR DESCRIPTION
This allows the API to accept an additional info field which
is then displayed as readonly on the booking request and
appointment edit forms.

<img width="482" alt="screen shot 2017-06-02 at 16 34 27" src="https://cloud.githubusercontent.com/assets/6049076/26732974/5d3d3a30-47b1-11e7-83a9-cd2866d59e77.png">
