### PR TITLE
Remove references to the `schedule_manager` permission

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,6 @@
 class User < ActiveRecord::Base
   PENSION_WISE_API_PERMISSION = 'pension_wise_api_user'
   BOOKING_MANAGER_PERMISSION  = 'booking_manager'
-  SCHEDULE_MANAGER_PERMISSION = 'schedule_manager'
   ADMINISTRATOR_PERMISSION    = 'administrator'
 
   include GDS::SSO::User
@@ -30,9 +29,5 @@ class User < ActiveRecord::Base
 
   def administrator?
     has_permission?(ADMINISTRATOR_PERMISSION)
-  end
-
-  def schedule_manager?
-    has_permission?(SCHEDULE_MANAGER_PERMISSION)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,11 +29,9 @@
   <li>
     <%= link_to 'Appointments', appointments_path %>
   </li>
-  <% if current_user.schedule_manager? %>
   <li>
     <%= link_to 'Schedules', schedules_path %>
   </li>
-  <% end %>
   <% if current_user.administrator? %>
     <%= form_for current_user, html: { class: 'navbar-form navbar-right js-location-form' } do |f| %>
       <div class="form-group">


### PR DESCRIPTION
In effect the `schedule_manager` permission was doing no more than `booking_manager`, so was surplus to needs.

Additionally, it wasn't actually being used to authorise any access so it was decided that we'd just show the link to the schedules for all users and be done with it.