### PR TITLE
Use SSL for `github` references

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 ruby IO.read('.ruby-version').strip
 
+# force Bundler to use SSL
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-daterangepicker'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/rails/rails-observers.git
+  remote: https://github.com/rails/rails-observers.git
   revision: 206cb17bc14f4f5ac6f83da4204013a69549b9dc
   branch: master
   specs:


### PR DESCRIPTION
Hopefully for obvious reasons.