### PR TITLE
Display time zone information in customer emails

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -44,6 +44,10 @@ class Appointment < ActiveRecord::Base
     super || Time.zone.now
   end
 
+  def timezone
+    proceeded_at.in_time_zone('London').utc_offset.zero? ? 'GMT' : 'BST'
+  end
+
   def self.needing_reminder
     pending
       .where(proceeded_at: Time.zone.now..48.hours.from_now)

--- a/app/views/booking_requests/customer.html.erb
+++ b/app/views/booking_requests/customer.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%= p do %>
-  Your requested dates:
+  Your requested dates (UK local time):
   <br><br>
   <strong class="emphasize">
     <%= @booking_request.primary_slot %>

--- a/app/views/booking_requests/customer.text.erb
+++ b/app/views/booking_requests/customer.text.erb
@@ -2,7 +2,7 @@ Dear <%= @booking_request.name %>,
 
 Thank you for requesting a Pension Wise appointment. We'll confirm your appointment in the next 2 working days.
 
-Your requested dates:
+Your requested dates (UK local time):
 
 <%= @booking_request.primary_slot %>
 

--- a/app/views/shared/email/_appointment_details.html.erb
+++ b/app/views/shared/email/_appointment_details.html.erb
@@ -10,7 +10,7 @@
   Time:
   <br>
   <strong class="emphasize">
-    <%= @appointment.proceeded_at.to_s(:govuk_time) %>
+    <%= "#{@appointment.proceeded_at.to_s(:govuk_time)} (#{@appointment.timezone})" %>
   </strong>
 <% end %>
 

--- a/app/views/shared/email/_appointment_details.text.erb
+++ b/app/views/shared/email/_appointment_details.text.erb
@@ -2,7 +2,7 @@ Date:
 <%= @appointment.proceeded_at.to_date.to_s(:govuk_date) %>
 
 Time:
-<%= @appointment.proceeded_at.to_s(:govuk_time) %>
+<%= "#{@appointment.proceeded_at.to_s(:govuk_time)} (#{@appointment.timezone})" %>
 
 Appointment lasts:
 45 to 60 minutes

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe Appointment do
     expect(described_class.new.created_at).to be_present
   end
 
+  describe '#timezone' do
+    it 'returns "GMT" when the appointment is in winter time' do
+      appointment = described_class.new(proceeded_at: Time.zone.parse('1 January 2017 12:00'))
+      expect(appointment.timezone).to eq 'GMT'
+    end
+
+    it 'returns "BST" when the appointment is in summer time' do
+      appointment = described_class.new(proceeded_at: Time.zone.parse('1 June 2017 12:00'))
+      expect(appointment.timezone).to eq 'BST'
+    end
+  end
+
   describe '#fulfilment_time_seconds' do
     subject { build(:appointment) }
 


### PR DESCRIPTION
# Booking request confirmation

<img width="605" alt="screen shot 2017-06-16 at 13 51 32" src="https://user-images.githubusercontent.com/9943/27227462-79271a50-529b-11e7-8f5d-174f6ff2e147.png">

# Appointment confirmation / updated / reminder

<img width="594" alt="screen shot 2017-06-16 at 13 51 05" src="https://user-images.githubusercontent.com/9943/27227444-62ea5d74-529b-11e7-9a8f-291b501fac43.png">

