### PR TITLE
Manage custom availability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-daterangepicker'
+  gem 'rails-assets-fullcalendar'
 end
 
 source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,9 @@ GEM
     rails-assets-bootstrap-daterangepicker (2.1.25)
       rails-assets-jquery (>= 1.9.1, < 4)
       rails-assets-moment (>= 2.9.0)
+    rails-assets-fullcalendar (3.4.0)
+      rails-assets-jquery (>= 2, < 4)
+      rails-assets-moment (>= 2.9.0, < 3)
     rails-assets-jquery (3.2.1)
     rails-assets-moment (2.18.1)
     rails-dom-testing (2.0.3)
@@ -403,6 +406,7 @@ DEPENDENCIES
   puma!
   rails (= 5.1.1)!
   rails-assets-bootstrap-daterangepicker!
+  rails-assets-fullcalendar!
   rails-observers!
   rails_12factor!
   redis-rails!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require jquery
 //= require moment
+//= require fullcalendar
 //= require bootstrap-daterangepicker
 //= require_tree .
 

--- a/app/assets/javascripts/modules/availability-calendar.es6
+++ b/app/assets/javascripts/modules/availability-calendar.es6
@@ -1,0 +1,62 @@
+/* global moment */
+{
+  'use strict';
+
+  class AvailabilityCalendar {
+    start(el) {
+      this.$el = el;
+      this.$modal = this.$el.find('.js-availability-modal');
+      this.$editUri = this.$el.data('edit-slots-uri');
+
+      $(this.$el).fullCalendar({
+        header: {
+          right: 'month today prev,next'
+        },
+        allDaySlot: false,
+        buttonText: {
+          agendaDay: 'Day',
+          today: 'Jump to today',
+          month: 'Month'
+        },
+        displayEventTime: false,
+        columnFormat: 'ddd D/M',
+        height: 'auto',
+        weekends: false,
+        defaultView: 'month',
+        slotDuration: '12:00:00',
+        slotLabelFormat: 'A',
+        showNonCurrentDates: false,
+        defaultDate: moment(el.data('default-date')),
+        firstDay: 1,
+        events: el.data('slots-uri'),
+        eventRender: (event, element) => {
+          $(element).attr('id', event.id);
+
+          element.find('.fc-content').addClass('availability-calendar__event--on t-event');
+        },
+        eventClick: (event) => {
+          this.availabilityModal(event.start);
+        },
+        dayClick: (date) => {
+          this.availabilityModal(date);
+        },
+        eventAfterAllRender: () => {
+          // mark the calendar as reloaded
+          let $rendered = $("<div class='t-calendar-rendered' style='display:hidden;'></div>")
+          $('body').append($rendered);
+        }
+      });
+    }
+
+    availabilityModal(date) {
+      var editUri = `${this.$editUri}?date=${date.format()}`;
+
+      // mark the calendar for reloading
+      $('.t-calendar-rendered').remove();
+
+      this.$modal.modal().find('.modal-content').load(editUri);
+    }
+  }
+
+  window.GOVUKAdmin.Modules.AvailabilityCalendar = AvailabilityCalendar;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import 'govuk_admin_template';
 @import 'bootstrap-daterangepicker';
+@import 'fullcalendar';
 
 @import 'helpers/**/*';
 @import 'layout/**/*';

--- a/app/assets/stylesheets/components/_availability-calendar.scss
+++ b/app/assets/stylesheets/components/_availability-calendar.scss
@@ -1,0 +1,117 @@
+@mixin bank-holiday-bg {
+  @include striped(#999, $color-silver);
+}
+
+.availability-calendar {
+  .fc-time-grid .fc-event-container {
+    margin: 0;
+  }
+
+  .fc-event {
+    border-radius: 0;
+    display: flex;
+    box-shadow: 0 0 0 1px $color-white;
+  }
+
+  .fc-content {
+    align-self: center;
+    width: 100%;
+    text-align: center;
+    font-size: 180%;
+    font-weight: bold;
+  }
+
+  .fc-month-view {
+    .fc-content {
+      font-size: 120%;
+      font-weight: normal;
+      padding: 5px;
+    }
+  }
+
+  .fc-day-number {
+    font-weight: bold;
+  }
+
+  .fc-event .fc-bg {
+    opacity: 0;
+  }
+
+  .fc-row .fc-content-skeleton td {
+    padding: 5px;
+  }
+
+  .fc-bank-holiday {
+    @include bank-holiday-bg;
+  }
+
+  .fc-time-grid .fc-slats td {
+    height: 147px;
+  }
+}
+
+.availability-calendar__event {
+  background: $color-silver;
+  color: $color-black;
+  border: 0;
+  cursor: pointer;
+  border: 4px solid transparent;
+  transition: background .2s;
+
+  &:hover {
+    border-color: darken($color-silver, 20%);
+    color: $color-black;
+    z-index: 5;
+  }
+
+  .fc-month-view & {
+    border-width: 2px;
+  }
+}
+
+.availability-calendar__event--on {
+  background: $brand-success;
+  color: $color-white;
+
+  &:hover {
+    border-color: darken($brand-success, 20%);
+    color: $color-white;
+  }
+}
+
+.appointment-calendar__appointment-count {
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+
+  .fc-month-view & {
+    bottom: 20%;
+    left: 5px;
+  }
+}
+
+.availability-calendar-key__item {
+  width: 25px;
+  height: 25px;
+  display: inline-block;
+  border: 1px solid $color-black;
+  margin: 0 0 0 10px;
+  vertical-align: middle;
+
+  &:first-of-type {
+    margin-left: 0;
+  }
+}
+
+.availability-calendar-key__item--bank-holiday {
+  @include bank-holiday-bg;
+}
+
+.availability-calendar-key__item--on {
+  background: $brand-success;
+}
+
+.availability-calendar-key__item--off {
+  background: $color-silver;
+}

--- a/app/assets/stylesheets/components/_availability-calendar.scss
+++ b/app/assets/stylesheets/components/_availability-calendar.scss
@@ -37,6 +37,10 @@
     opacity: 0;
   }
 
+  .fc-body .fc-row {
+    height: 120px;
+  }
+
   .fc-row .fc-content-skeleton td {
     padding: 5px;
   }

--- a/app/assets/stylesheets/components/_weekly-schedule.scss
+++ b/app/assets/stylesheets/components/_weekly-schedule.scss
@@ -12,7 +12,7 @@
 
 .weekly-schedule__day {
   @media (min-width: 600px) {
-    flex-basis: 20%;
+    flex-basis: 100%;
     border-right: 1px solid $color-white;
   }
 }

--- a/app/controllers/bookable_slots_controller.rb
+++ b/app/controllers/bookable_slots_controller.rb
@@ -1,0 +1,39 @@
+class BookableSlotsController < ApplicationController
+  def index
+    @schedule = Schedule.current(params[:location_id])
+    @location = booking_location.location_for(params[:location_id])
+
+    respond_to do |format|
+      format.html
+      format.json { render_bookable_slots_json }
+    end
+  end
+
+  def edit
+    @form = AvailabilityForm.new(availability_params)
+
+    render :edit, layout: false
+  end
+
+  def update
+    AvailabilityForm.new(availability_params).upsert!
+  end
+
+  private
+
+  def render_bookable_slots_json
+    render json: @schedule.bookable_slots_in_window(date_range).all,
+           each_serializer: CalendarBookableSlotSerializer
+  end
+
+  def date_range
+    {
+      starting: params.fetch(:start) { Date.current.beginning_of_month }.to_date,
+      ending: params.fetch(:end) { Date.current.end_of_month }.to_date
+    }
+  end
+
+  def availability_params
+    params.permit(:date, :schedule_id, :am, :pm)
+  end
+end

--- a/app/forms/availability_form.rb
+++ b/app/forms/availability_form.rb
@@ -1,0 +1,41 @@
+class AvailabilityForm
+  include ActiveModel::Model
+
+  attr_accessor :date
+  attr_accessor :schedule_id
+  attr_accessor :am
+  attr_accessor :pm
+
+  def am?
+    slots.any?(&:am?)
+  end
+
+  def pm?
+    slots.any?(&:pm?)
+  end
+
+  def date
+    @date.to_date
+  end
+
+  def schedule
+    @schedule ||= Schedule.find(schedule_id)
+  end
+
+  def upsert!
+    ActiveRecord::Base.transaction do
+      slots.destroy_all
+
+      schedule.create_bookable_slots(date: date, am: am, pm: pm)
+    end
+  end
+
+  private
+
+  def slots
+    @slots ||= schedule.bookable_slots_in_window(
+      starting: date,
+      ending: date
+    )
+  end
+end

--- a/app/helpers/schedule_helper.rb
+++ b/app/helpers/schedule_helper.rb
@@ -16,4 +16,14 @@ module ScheduleHelper
   def title(day, slot, open)
     "#{open ? 'Open' : 'Closed'} #{day.humanize} #{slot.upcase}"
   end
+
+  def availability_button(location_id)
+    return unless Schedule.exists?(location_id: location_id)
+
+    link_to(
+      'Availability',
+      bookable_slots_path(location_id: location_id),
+      class: 'btn btn-info t-availability'
+    )
+  end
 end

--- a/app/helpers/schedule_helper.rb
+++ b/app/helpers/schedule_helper.rb
@@ -21,9 +21,12 @@ module ScheduleHelper
     return unless Schedule.exists?(location_id: location_id)
 
     link_to(
-      'Availability',
       bookable_slots_path(location_id: location_id),
+      title: 'Modify availability',
       class: 'btn btn-info t-availability'
-    )
+    ) do
+      content_tag(:span, '', class: 'glyphicon glyphicon-th', 'aria-hidden' => 'true') +
+        content_tag(:span, 'Modify availability', class: 'sr-only')
+    end
   end
 end

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -9,11 +9,11 @@ class BookableSlot < ActiveRecord::Base
   end
 
   def pm?
-    PM.pm?(start)
+    PM.pm?(self.end)
   end
 
-  def self.windowed
-    where(date: GracePeriod.new.call..6.weeks.from_now)
+  def self.windowed(date_range)
+    where(date: date_range)
   end
 
   def self.for_deletion(schedule_ids)

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -4,6 +4,8 @@ class BookableSlot < ActiveRecord::Base
 
   belongs_to :schedule
 
+  audited associated_with: :schedule
+
   def am?
     AM.am?(start)
   end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -12,7 +12,7 @@ class Schedule < ActiveRecord::Base
     friday_pm
   ).freeze
 
-  has_many :bookable_slots, -> { order(:date) }
+  has_many :bookable_slots, -> { order(:date, :start) }
 
   alias default? new_record?
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -20,13 +20,28 @@ class Schedule < ActiveRecord::Base
     BookableSlotGenerator.new(self).call
   end
 
-  def bookable_slots_in_window
-    bookable_slots.windowed
+  def create_bookable_slots(date:, am:, pm:)
+    create_bookable_slot(date: date, period: BookableSlot::AM) if am
+    create_bookable_slot(date: date, period: BookableSlot::PM) if pm
+  end
+
+  def bookable_slots_in_window(starting: GracePeriod.new.call, ending: 6.weeks.from_now)
+    bookable_slots.windowed(starting..ending)
   end
 
   def self.current(location_id)
     where(location_id: location_id)
       .order(created_at: :desc)
       .first_or_initialize(location_id: location_id)
+  end
+
+  private
+
+  def create_bookable_slot(date:, period:)
+    bookable_slots.create!(
+      date: date,
+      start: period.start,
+      end: period.end
+    )
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -16,6 +16,8 @@ class Schedule < ActiveRecord::Base
 
   alias default? new_record?
 
+  has_associated_audits
+
   def generate_bookable_slots!
     BookableSlotGenerator.new(self).call
   end

--- a/app/serializers/calendar_bookable_slot_serializer.rb
+++ b/app/serializers/calendar_bookable_slot_serializer.rb
@@ -1,0 +1,19 @@
+class CalendarBookableSlotSerializer < ActiveModel::Serializer
+  attribute :id
+
+  attribute :start do
+    Time.zone.parse("#{object.date} #{delimit(object.start)}")
+  end
+
+  attribute :end do
+    Time.zone.parse("#{object.date} #{delimit(object.end)}")
+  end
+
+  attribute :title do
+    BookableSlot::AM.period(object.start).upcase
+  end
+
+  def delimit(time)
+    time.dup.insert(2, ':')
+  end
+end

--- a/app/views/bookable_slots/edit.html.erb
+++ b/app/views/bookable_slots/edit.html.erb
@@ -1,0 +1,25 @@
+<%= form_with method: :put, url: schedule_bookable_slots_path(@form.schedule, date: @form.date), class: 't-availability-modal' do |f| %>
+<div class="modal-header">
+  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <h4 class="modal-title t-title">Availability for <%= @form.date.to_s(:gov_uk) %></h4>
+</div>
+
+<div class="modal-body">
+  <div class="weekly-schedule form-group">
+    <div class="weekly-schedule__day">
+      <input type="checkbox" id="am" class="weekly-schedule__switch" name="am" value="1" <%= 'checked' if @form.am? %>>
+      <label class="weekly-schedule__label t-am" for="am">AM</label>
+
+      <input type="checkbox" id="pm" class="weekly-schedule__switch" name="pm" value="1" <%= 'checked' if @form.pm? %>>
+      <label class="weekly-schedule__label t-pm" for="pm">PM</label>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+  <%= f.button "Save availability for #{@form.date.to_s(:gov_uk)}", class: 'btn btn-primary t-save' %>
+</div>
+<% end %>

--- a/app/views/bookable_slots/index.html.erb
+++ b/app/views/bookable_slots/index.html.erb
@@ -1,0 +1,34 @@
+<% content_for(:page_title, t('service.title', page_title: 'Availability')) %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><%= link_to 'Schedules', schedules_path %></li>
+    <li class="active">Availability for <%= @location.name %></li>
+  </ol>
+
+  <h1>Availability for <%= @location.name %></h1>
+
+  <div class="availability-calendar-key" aria-hidden="true">
+    <span class="availability-calendar-key__item availability-calendar-key__item--on"></span> Available
+    <span class="availability-calendar-key__item availability-calendar-key__item--off"></span> Unavailable
+  </div>
+</div>
+
+<div
+  id="AvailabilityCalendar"
+  class="js-calendar availability-calendar t-calendar"
+  data-module="availability-calendar"
+  data-default-date="<%= Time.zone.now.iso8601 %>"
+  data-slots-uri="<%= bookable_slots_path(location_id: @location.id) %>"
+  data-edit-slots-uri="<%= edit_schedule_bookable_slots_path(@schedule) %>">
+  <div
+    class="modal <%= 'fade' unless Rails.env.test? %> js-availability-modal"
+    tabindex="-1"
+    role="dialog"
+    aria-labelledby="availability">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/bookable_slots/index.html.erb
+++ b/app/views/bookable_slots/index.html.erb
@@ -10,7 +10,6 @@
 
   <div class="availability-calendar-key" aria-hidden="true">
     <span class="availability-calendar-key__item availability-calendar-key__item--on"></span> Available
-    <span class="availability-calendar-key__item availability-calendar-key__item--off"></span> Unavailable
   </div>
 </div>
 

--- a/app/views/bookable_slots/update.js.erb
+++ b/app/views/bookable_slots/update.js.erb
@@ -1,0 +1,2 @@
+$('.js-calendar').fullCalendar('refetchEvents');
+$('[data-dismiss=modal]').trigger({ type: 'click' });

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -12,9 +12,9 @@
   <div class="col-md-12">
     <table class="centered-table table table-bordered table-striped">
       <colgroup>
-        <col width="60%" />
+        <col width="65%" />
         <col width="20%" />
-        <col width="20%" />
+        <col width="15%" />
       </colgroup>
       <thead>
         <tr class="table-header">
@@ -32,7 +32,10 @@
             <%= render 'schedule_summary', location: @booking_location %>
           </td>
           <td>
-            <%= link_to 'Modify', new_schedule_path(location_id: @booking_location.id), class: 'btn btn-info t-manage' %>
+            <%= link_to new_schedule_path(location_id: @booking_location.id), title: 'Modify schedule', class: 'btn btn-info t-manage' do %>
+              <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+              <span class="sr-only">Modify schedule</span>
+            <% end %>
             <%= availability_button(@booking_location.id) %>
           </td>
         </tr>
@@ -45,7 +48,10 @@
               <%= render 'schedule_summary', location: location %>
             </td>
             <td>
-              <%= link_to 'Modify', new_schedule_path(location_id: location.id), class: 'btn btn-info t-manage' %>
+              <%= link_to new_schedule_path(location_id: location.id), title: 'Modify schedule', class: 'btn btn-info t-manage' do %>
+                <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span>
+                <span class="sr-only">Modify schedule</span>
+              <% end %>
               <%= availability_button(location.id) %>
             </td>
           </tr>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -12,9 +12,9 @@
   <div class="col-md-12">
     <table class="centered-table table table-bordered table-striped">
       <colgroup>
-        <col width="75%" />
+        <col width="60%" />
         <col width="20%" />
-        <col width="5%" />
+        <col width="20%" />
       </colgroup>
       <thead>
         <tr class="table-header">
@@ -33,6 +33,7 @@
           </td>
           <td>
             <%= link_to 'Modify', new_schedule_path(location_id: @booking_location.id), class: 'btn btn-info t-manage' %>
+            <%= link_to 'Availability', bookable_slots_path(location_id: @booking_location.id), class: 'btn btn-info t-availability' %>
           </td>
         </tr>
         <% @child_locations.each do |location| %>
@@ -45,6 +46,7 @@
             </td>
             <td>
               <%= link_to 'Modify', new_schedule_path(location_id: location.id), class: 'btn btn-info t-manage' %>
+              <%= link_to 'Availability', bookable_slots_path(location_id: location.id), class: 'btn btn-info t-availability' %>
             </td>
           </tr>
         <% end %>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -33,7 +33,7 @@
           </td>
           <td>
             <%= link_to 'Modify', new_schedule_path(location_id: @booking_location.id), class: 'btn btn-info t-manage' %>
-            <%= link_to 'Availability', bookable_slots_path(location_id: @booking_location.id), class: 'btn btn-info t-availability' %>
+            <%= availability_button(@booking_location.id) %>
           </td>
         </tr>
         <% @child_locations.each do |location| %>
@@ -46,7 +46,7 @@
             </td>
             <td>
               <%= link_to 'Modify', new_schedule_path(location_id: location.id), class: 'btn btn-info t-manage' %>
-              <%= link_to 'Availability', bookable_slots_path(location_id: location.id), class: 'btn btn-info t-availability' %>
+              <%= availability_button(location.id) %>
             </td>
           </tr>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 require 'sidekiq/web'
 
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   namespace :mail_gun do
     resources :drops, only: :create
@@ -17,7 +18,18 @@ Rails.application.routes.draw do
     resources :appointments, only: %i(new create)
   end
 
-  resources :schedules, only: %i(index new create)
+  resources :schedules, only: %i(index new create) do
+    resources :bookable_slots, only: [] do
+      collection do
+        get 'edit'
+        put 'update'
+      end
+    end
+  end
+
+  scope '/locations/:location_id' do
+    resources :bookable_slots, only: :index
+  end
 
   root 'booking_requests#index'
 

--- a/spec/features/booking_manager_manages_availability_spec.rb
+++ b/spec/features/booking_manager_manages_availability_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature 'Booking manager manages availability' do
+  scenario 'Modifying a booking location’s availability', js: true do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      travel_to '2017-06-12 13:00' do
+        and_a_schedule_exists
+        when_they_view_their_schedules
+        and_choose_to_edit_the_availability
+        then_they_are_shown_the_existing_availability
+        when_they_remove_a_slot
+        and_they_add_another
+        then_the_availability_is_affected
+      end
+    end
+  end
+
+  def and_a_schedule_exists
+    @schedule = create(:schedule, :blank, monday_am: true, &:generate_bookable_slots!)
+  end
+
+  def when_they_view_their_schedules
+    @page = Pages::Schedules.new.tap(&:load)
+    expect(@page).to be_loaded
+  end
+
+  def and_choose_to_edit_the_availability
+    @page.schedules.first.availability.click
+  end
+
+  def then_they_are_shown_the_existing_availability
+    @page = Pages::Availability.new
+    expect(@page).to be_displayed
+
+    # two Monday AM slots will be present
+    @page.calendar.wait_for_events
+    expect(@page.calendar).to have_events(count: 2)
+  end
+
+  def when_they_remove_a_slot
+    # click on today's availability
+    @page.calendar.events.last.click
+
+    @page.wait_until_availability_modal_visible
+    @page.availability_modal.tap do |modal|
+      expect(modal.title.text).to eq('Availability for 26 June 2017')
+
+      modal.am.click
+    end
+  end
+
+  def and_they_add_another
+    @page.availability_modal.pm.click
+    @page.availability_modal.save.click
+  end
+
+  def then_the_availability_is_affected
+    @page.wait_until_availability_modal_invisible
+
+    @page.wait_for_calendar_events
+    @page.calendar.events.tap do |events|
+      expect(events.first).to have_text('AM')
+      expect(events.last).to  have_text('PM')
+    end
+  end
+end

--- a/spec/features/booking_manager_manages_schedules_spec.rb
+++ b/spec/features/booking_manager_manages_schedules_spec.rb
@@ -18,11 +18,22 @@ RSpec.feature 'Booking manager manages schedules' do
     @page.load
   end
 
-  def then_they_see_default_schedules_across_their_locations
+  def then_they_see_default_schedules_across_their_locations # rubocop:disable Metrics/AbcSize
     expect(@page).to be_loaded
     # Enfield is 'hidden' so will not be displayed
     expect(@page).to have_schedules(count: 5)
+
+    # the booking location
     expect(@page.schedules.first.location.text).to eq('Hackney')
+    expect(@page.schedules.first.manage['href']).to eq(
+      new_schedule_path(location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+    )
+
+    # the first child location
+    expect(@page.schedules.second.location.text).to eq('Dalston')
+    expect(@page.schedules.second.manage['href']).to eq(
+      new_schedule_path(location_id: '183080c6-642b-4b8f-96fd-891f5cd9f9c7')
+    )
   end
 
   def when_they_manage_the_booking_location_schedule

--- a/spec/requests/internal_bookable_slots_api_spec.rb
+++ b/spec/requests/internal_bookable_slots_api_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /locations/:location_id/bookable_slots.json' do
+  scenario 'Retrieving slots in a given location' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      travel_to '2017-05-01 13:00' do
+        given_a_location_with_a_schedule_exists
+        when_a_request_for_bookable_slots_is_made
+        then_the_service_responds_ok
+        and_the_slots_are_serialized_as_json
+      end
+    end
+  end
+
+  def given_a_location_with_a_schedule_exists
+    @schedule = create(:schedule, :blank, monday_am: true, &:generate_bookable_slots!)
+  end
+
+  def when_a_request_for_bookable_slots_is_made
+    get bookable_slots_path(location_id: @schedule.location_id),
+        params: { start: '2017-05-01', end: '2017-05-31' },
+        as: :json
+  end
+
+  def then_the_service_responds_ok
+    expect(response).to be_ok
+  end
+
+  def and_the_slots_are_serialized_as_json
+    @json = JSON.parse(response.body)
+
+    # 3 slots returned for the given month
+    expect(@json.count).to eq(3)
+    expect(@json.first).to include(
+      'start' => '2017-05-08T09:00:00.000Z',
+      'end'   => '2017-05-08T13:00:00.000Z'
+    )
+  end
+end

--- a/spec/support/pages/availability.rb
+++ b/spec/support/pages/availability.rb
@@ -1,0 +1,20 @@
+module Pages
+  class Availability < SitePrism::Page
+    set_url '/locations/{location_id}/bookable_slots'
+
+    section :calendar, '.t-calendar' do
+      elements :events, '.t-event'
+    end
+
+    section :availability_modal, '.t-availability-modal' do
+      element :title, '.t-title'
+      element :am, '.t-am'
+      element :pm, '.t-pm'
+      element :save, '.t-save'
+    end
+
+    def wait_for_calendar_events
+      find('.t-calendar-rendered', visible: false)
+    end
+  end
+end

--- a/spec/support/pages/schedules.rb
+++ b/spec/support/pages/schedules.rb
@@ -5,6 +5,7 @@ module Pages
     sections :schedules, '.t-schedule' do
       element :location, '.t-location'
       element :manage, '.t-manage'
+      element :availability, '.t-availability'
 
       section :summary, '.t-summary' do
         %i(monday tuesday wednesday thursday friday).each do |day|


### PR DESCRIPTION
Grants booking managers the ability to alter custom availability, based
on previouly built populated schedules.

New schedules wipe out previously saved slots.

### Schedules

![schedules](https://user-images.githubusercontent.com/41963/27596740-5b9ed58e-5b58-11e7-9472-161fb398035e.png)

### Calendar

![calendar](https://user-images.githubusercontent.com/41963/27596751-643f7d56-5b58-11e7-9d4f-aff91b79259c.png)

### Availability

![availability](https://user-images.githubusercontent.com/41963/27596765-6fb4385c-5b58-11e7-9df6-f209b8822023.png)
