### PR TITLE
Customers may chose between one and three slots

### DIFF
--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -59,8 +59,6 @@ class BookingRequest < ActiveRecord::Base
   private
 
   def validate_slots
-    unless slots.map(&:priority).sort == [1, 2, 3] # rubocop:disable Style/GuardClause
-      errors.add(:slots, 'you must provide a slot for each permitted priority (1, 2, 3)')
-    end
+    errors.add(:slots, 'you must provide at least one slot') if slots.empty?
   end
 end

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -34,6 +34,7 @@
           </div>
         </div>
 
+        <% if @appointment_form.secondary_slot %>
         <div class="SlotPicker-choice is-chosen">
           <div class="SlotPicker-choiceInner">
             <div class="SlotPicker-position"><span>2</span></div>
@@ -43,7 +44,9 @@
             </div>
           </div>
         </div>
+        <% end %>
 
+        <% if @appointment_form.tertiary_slot %>
         <div class="SlotPicker-choice is-chosen">
           <div class="SlotPicker-choiceInner">
             <div class="SlotPicker-position"><span>3</span></div>
@@ -53,6 +56,7 @@
             </div>
           </div>
         </div>
+        <% end %>
       </div>
     </div>
     <div class="col-md-8 l-appointment-details">

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -72,6 +72,7 @@
           </div>
         </div>
 
+        <% if @appointment_form.secondary_slot %>
         <div class="SlotPicker-choice is-chosen">
           <div class="SlotPicker-choiceInner">
             <div class="SlotPicker-position"><span>2</span></div>
@@ -81,7 +82,9 @@
             </div>
           </div>
         </div>
+        <% end %>
 
+        <% if @appointment_form.tertiary_slot %>
         <div class="SlotPicker-choice is-chosen">
           <div class="SlotPicker-choiceInner">
             <div class="SlotPicker-position"><span>3</span></div>
@@ -91,6 +94,7 @@
             </div>
           </div>
         </div>
+        <% end %>
       </div>
 
       <h3 class="h4">Requested location:</h3>

--- a/app/views/booking_requests/customer.html.erb
+++ b/app/views/booking_requests/customer.html.erb
@@ -20,7 +20,7 @@
   <strong class="emphasize">
     <%= @booking_request.secondary_slot %>
   </strong>
-<% end %>
+<% end if @booking_request.secondary_slot %>
 
 <%= p do %>
   or
@@ -28,7 +28,7 @@
   <strong class="emphasize">
     <%= @booking_request.tertiary_slot %>
   </strong>
-<% end %>
+<% end if @booking_request.tertiary_slot %>
 
 <%= p do %>
   Appointment location:

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -73,9 +73,9 @@
                 <a href="https://www.pensionwise.gov.uk/locations/<%= booking_request.location_id %>"><%= guard_missing_location(booking_request, :location_name) %></a>
               </td>
               <td>
-                <%= booking_request.primary_slot %><br>
-                <%= booking_request.secondary_slot %><br>
-                <%= booking_request.tertiary_slot %>
+                <%= booking_request.primary_slot %>
+                <% if booking_request.secondary_slot %><br><%= booking_request.secondary_slot %><% end %>
+                <% if booking_request.tertiary_slot  %><br><%= booking_request.tertiary_slot %><% end %>
               </td>
               <td>
                 <%= booking_request.reference %>

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -15,10 +15,12 @@ FactoryGirl.define do
     marketing_opt_in false
     defined_contribution_pot_confirmed true
 
-    after(:build) do |booking_request|
-      booking_request.slots << build(:slot, priority: 1)
-      booking_request.slots << build(:slot, priority: 2)
-      booking_request.slots << build(:slot, priority: 3)
+    transient { number_of_slots 1 }
+
+    after(:build) do |booking_request, evaluator|
+      (1..evaluator.number_of_slots).each do |slot_number|
+        booking_request.slots << build(:slot, priority: slot_number)
+      end
     end
 
     factory :hackney_booking_request do

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -86,7 +86,10 @@ RSpec.feature 'Booking Manager edits an Appointment' do
   end
 
   def and_there_is_an_appointment
-    @appointment = create(:appointment)
+    @appointment = create(
+      :appointment,
+      booking_request: build(:hackney_booking_request, number_of_slots: 3)
+    )
   end
 
   def when_the_booking_manager_edits_the_appointment

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
   end
 
   def and_there_is_an_unfulfilled_booking_request
-    @booking_request = create(:hackney_booking_request)
+    @booking_request = create(:hackney_booking_request, number_of_slots: 3)
   end
 
   def when_the_booking_manager_attempts_to_fulfil

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe BookingRequest do
   end
 
   describe '#slots' do
-    let(:request) { create(:booking_request) }
+    let(:request) { create(:booking_request, number_of_slots: 3) }
 
     it 'is returned in order of #priority' do
       expect(request.slots.pluck(:priority)).to eq([1, 2, 3])

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -60,17 +60,9 @@ RSpec.describe BookingRequest do
       expect(build(:booking_request, defined_contribution_pot_confirmed: '')).to_not be_valid
     end
 
-    it 'requires 3 slots' do
+    it 'requires at least one slot' do
       build(:booking_request) do |booking|
         booking.slots.clear
-
-        expect(booking).to_not be_valid
-      end
-    end
-
-    it 'requires one slot of each permitted priority' do
-      build(:booking_request) do |booking|
-        booking.slots << build(:slot)
 
         expect(booking).to_not be_valid
       end


### PR DESCRIPTION
When we have actual availability we shouldn't force customers to chose
three slots. This change permits the customer to select between one and
three potential slots.

![booking requests](https://user-images.githubusercontent.com/41963/27680346-51b1ce94-5cb3-11e7-9a10-a80e1648fa57.png)

![make appointment](https://user-images.githubusercontent.com/41963/27680362-5e44e9e8-5cb3-11e7-87f0-61d679f85e24.png)

