### PR TITLE
Don't display schedules for hidden locations

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,6 +1,7 @@
 class SchedulesController < ApplicationController
   def index
     @booking_location = booking_location
+    @child_locations  = booking_location.locations.reject(&:hidden?)
   end
 
   def new

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -35,7 +35,7 @@
             <%= link_to 'Modify', new_schedule_path(location_id: @booking_location.id), class: 'btn btn-info t-manage' %>
           </td>
         </tr>
-        <% @booking_location.locations.each do |location| %>
+        <% @child_locations.each do |location| %>
           <tr class="t-schedule">
             <td class="t-location">
               <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span> <%= location.name %>

--- a/spec/features/booking_manager_manages_schedules_spec.rb
+++ b/spec/features/booking_manager_manages_schedules_spec.rb
@@ -20,7 +20,8 @@ RSpec.feature 'Booking manager manages schedules' do
 
   def then_they_see_default_schedules_across_their_locations
     expect(@page).to be_loaded
-    expect(@page).to have_schedules(count: 6)
+    # Enfield is 'hidden' so will not be displayed
+    expect(@page).to have_schedules(count: 5)
     expect(@page.schedules.first.location.text).to eq('Hackney')
   end
 


### PR DESCRIPTION
Booking managers seem to be confused about how to treat hidden
locations so some have schedules and some don't. This isn't necessary
since they don't appear to customers during the booking journey and
therefore cannot be booked.

Some locations have a great number of hidden locations and picking
through them when managing schedules is a pain, so we elected to not
display them in the schedules grid.