### PR TITLE
Show appointment counts on bookable slots in the schedule

### DIFF
--- a/app/assets/javascripts/modules/availability-calendar.es6
+++ b/app/assets/javascripts/modules/availability-calendar.es6
@@ -33,6 +33,19 @@
           $(element).attr('id', event.id);
 
           element.find('.fc-content').addClass('availability-calendar__event--on t-event');
+
+          if (event.appointments) {
+            $(element).prepend(`
+              <span class="appointment-calendar__appointment-count">
+                <span aria-hidden="true" class="glyphicon glyphicon-user"></span>
+                <span class="t-appointment-count">${event.appointments}</span>
+                <span class="sr-only"> appointments in this time period</span>
+              </span>
+            `);
+          }
+        },
+        eventAfterRender: (event, element) => {
+          element.closest('td').addClass(`t-slot-${event.id}`);
         },
         eventClick: (event) => {
           this.availabilityModal(event.start);

--- a/app/assets/stylesheets/components/_availability-calendar.scss
+++ b/app/assets/stylesheets/components/_availability-calendar.scss
@@ -83,11 +83,13 @@
   }
 }
 
+// Positioned absolutely over `.fc-content` which has `z-index: 2`
 .appointment-calendar__appointment-count {
   width: 100%;
   position: absolute;
   bottom: 0;
   left: 0;
+  z-index: 3;
 
   .fc-month-view & {
     bottom: 20%;

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -14,6 +14,14 @@ class BookableSlot < ActiveRecord::Base
     PM.pm?(self.end)
   end
 
+  def appointments
+    ending_at = am? ? end_at - 1.minute : end_at
+
+    Appointment
+      .where(location_id: schedule.location_id)
+      .where(proceeded_at: start_at..ending_at)
+  end
+
   def self.windowed(date_range)
     where(date: date_range)
   end
@@ -21,5 +29,15 @@ class BookableSlot < ActiveRecord::Base
   def self.for_deletion(schedule_ids)
     where(schedule_id: schedule_ids)
       .where(arel_table[:date].gteq(Time.zone.now))
+  end
+
+  private
+
+  def start_at
+    Time.zone.parse("#{date} #{start.insert(2, ':')}")
+  end
+
+  def end_at
+    Time.zone.parse("#{date} #{self.end.insert(2, ':')}")
   end
 end

--- a/app/serializers/calendar_bookable_slot_serializer.rb
+++ b/app/serializers/calendar_bookable_slot_serializer.rb
@@ -13,6 +13,10 @@ class CalendarBookableSlotSerializer < ActiveModel::Serializer
     BookableSlot::AM.period(object.start).upcase
   end
 
+  attribute :appointments do
+    object.appointments.count
+  end
+
   def delimit(time)
     time.dup.insert(2, ':')
   end

--- a/spec/features/schedule_appointment_counts_spec.rb
+++ b/spec/features/schedule_appointment_counts_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.feature 'Appointment counts displayed on schedules', js: true do
+  scenario 'Viewing the right appointment counts' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_i_have_a_schedule
+      and_i_am_examining_bookable_slots_for_a_particular_date
+
+      and_there_is_one_appointment_first_thing_in_the_morning
+      and_there_is_one_appointment_mid_morning
+      and_there_is_one_appointment_late_morning
+
+      and_there_is_an_appointment_at_1pm
+      and_there_is_one_appointment_mid_afternoon
+      and_there_is_one_appointment_last_thing_in_the_day
+
+      when_i_look_at_the_schedule
+      then_i_see_there_are_three_appointments_in_the_morning
+      and_i_see_there_are_three_appointments_in_the_afternoon
+    end
+  end
+end
+
+def and_i_have_a_schedule
+  @schedule = create(:schedule)
+end
+
+def and_i_am_examining_bookable_slots_for_a_particular_date
+  @date = Date.current.next_week(:wednesday).to_s
+  @am_slot = create(:bookable_slot, :am, date: @date, schedule: @schedule)
+  @pm_slot = create(:bookable_slot, :pm, date: @date, schedule: @schedule)
+end
+
+def and_there_is_one_appointment_first_thing_in_the_morning
+  create(:appointment, proceeded_at: Time.zone.parse("#{@date} 09:00"))
+end
+
+def and_there_is_one_appointment_mid_morning
+  create(:appointment, proceeded_at: Time.zone.parse("#{@date} 11:00"))
+end
+
+def and_there_is_one_appointment_late_morning
+  create(:appointment, proceeded_at: Time.zone.parse("#{@date} 12:30"))
+end
+
+def and_there_is_an_appointment_at_1pm
+  create(:appointment, proceeded_at: Time.zone.parse("#{@date} 13:00"))
+end
+
+def and_there_is_one_appointment_mid_afternoon
+  create(:appointment, proceeded_at: Time.zone.parse("#{@date} 15:00"))
+end
+
+def and_there_is_one_appointment_last_thing_in_the_day
+  create(:appointment, proceeded_at: Time.zone.parse("#{@date} 17:00"))
+end
+
+def when_i_look_at_the_schedule
+  @page = Pages::BookableSlots.new
+  @page.load(location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+end
+
+def then_i_see_there_are_three_appointments_in_the_morning
+  expect(@page.slot(@am_slot)).to have_content(3)
+end
+
+def and_i_see_there_are_three_appointments_in_the_afternoon
+  expect(@page.slot(@pm_slot)).to have_content(3)
+end

--- a/spec/support/pages/bookable_slots.rb
+++ b/spec/support/pages/bookable_slots.rb
@@ -1,0 +1,13 @@
+module Pages
+  class BookableSlot < SitePrism::Section
+    element :appointment_count, '.t-appointment-count'
+  end
+
+  class BookableSlots < SitePrism::Page
+    set_url '/locations/{location_id}/bookable_slots'
+
+    def slot(bookable_slot)
+      BookableSlot.new(self, find_first(".t-slot-#{bookable_slot.id}"))
+    end
+  end
+end


### PR DESCRIPTION
If a bookable slot has been defined on a day, displays the number of appointments starting during that slot.

Appointments booked for 13:00, the crossover point of what's considered AM or PM, get counted as PM.

<img width="714" alt="screen shot 2017-07-18 at 11 48 41" src="https://user-images.githubusercontent.com/9943/28313544-2970f13e-6baf-11e7-954f-4447b25d8daa.png">
