### PR TITLE
Regenerate scheduled slots approaching end

### DIFF
--- a/app/jobs/schedule_regeneration_job.rb
+++ b/app/jobs/schedule_regeneration_job.rb
@@ -1,0 +1,7 @@
+class ScheduleRegenerationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    ScheduleRegeneration.new.call
+  end
+end

--- a/app/lib/bookable_slot_generator.rb
+++ b/app/lib/bookable_slot_generator.rb
@@ -1,4 +1,6 @@
 class BookableSlotGenerator
+  include SlotGenerator
+
   def initialize(schedule)
     @schedule = schedule
   end
@@ -10,37 +12,15 @@ class BookableSlotGenerator
     end
   end
 
+  def slot_window
+    Hash[to: 4.months.from_now]
+  end
+
   private
-
-  def create_scheduled_slots!
-    slots_to_create.map do |slot|
-      schedule.bookable_slots.create!(
-        date: slot.date,
-        start: slot.start,
-        end: slot.end
-      )
-    end
-  end
-
-  def scheduled_slots
-    @scheduled_slots ||= schedule.attributes.slice(
-      *Schedule::SLOT_ATTRIBUTES.map(&:to_s)
-    ).select { |_, v| v }
-  end
-
-  def slots_to_create
-    return [] if scheduled_slots.empty?
-
-    DefaultBookableSlots.new(to: 4.months.from_now).call.select do |slot|
-      scheduled_slots.key?(slot.label)
-    end
-  end
 
   def delete_existing_slots!
     schedule_ids = Schedule.where(location_id: schedule.location_id).pluck(:id)
 
     BookableSlot.for_deletion(schedule_ids).delete_all
   end
-
-  attr_reader :schedule
 end

--- a/app/lib/bookable_slot_regenerator.rb
+++ b/app/lib/bookable_slot_regenerator.rb
@@ -1,4 +1,6 @@
 class BookableSlotRegenerator
+  include SlotGenerator
+
   def initialize(schedule)
     @schedule = schedule
   end
@@ -7,38 +9,10 @@ class BookableSlotRegenerator
     Schedule.transaction { create_scheduled_slots! }
   end
 
-  private
-
-  def create_scheduled_slots!
-    slots_to_create.map do |slot|
-      schedule.bookable_slots.create!(
-        date: slot.date,
-        start: slot.start,
-        end: slot.end
-      )
-    end
-  end
-
-  def scheduled_slots
-    @scheduled_slots ||= schedule.attributes.slice(
-      *Schedule::SLOT_ATTRIBUTES.map(&:to_s)
-    ).select { |_, v| v }
-  end
-
-  def slots_to_create
-    return [] if scheduled_slots.empty?
-
-    DefaultBookableSlots.new(**slot_regeneration_window).call.select do |slot|
-      scheduled_slots.key?(slot.label)
-    end
-  end
-
-  def slot_regeneration_window
+  def slot_window
     {
       from: schedule.bookable_slots.last.date,
       to:   schedule.bookable_slots.last.date.advance(months: 4)
     }
   end
-
-  attr_reader :schedule
 end

--- a/app/lib/bookable_slot_regenerator.rb
+++ b/app/lib/bookable_slot_regenerator.rb
@@ -1,0 +1,44 @@
+class BookableSlotRegenerator
+  def initialize(schedule)
+    @schedule = schedule
+  end
+
+  def call
+    Schedule.transaction { create_scheduled_slots! }
+  end
+
+  private
+
+  def create_scheduled_slots!
+    slots_to_create.map do |slot|
+      schedule.bookable_slots.create!(
+        date: slot.date,
+        start: slot.start,
+        end: slot.end
+      )
+    end
+  end
+
+  def scheduled_slots
+    @scheduled_slots ||= schedule.attributes.slice(
+      *Schedule::SLOT_ATTRIBUTES.map(&:to_s)
+    ).select { |_, v| v }
+  end
+
+  def slots_to_create
+    return [] if scheduled_slots.empty?
+
+    DefaultBookableSlots.new(**slot_regeneration_window).call.select do |slot|
+      scheduled_slots.key?(slot.label)
+    end
+  end
+
+  def slot_regeneration_window
+    {
+      from: schedule.bookable_slots.last.date,
+      to:   schedule.bookable_slots.last.date.advance(months: 4)
+    }
+  end
+
+  attr_reader :schedule
+end

--- a/app/lib/schedule_regeneration.rb
+++ b/app/lib/schedule_regeneration.rb
@@ -1,0 +1,18 @@
+class ScheduleRegeneration
+  attr_reader :window
+
+  def initialize(window: 6.weeks.from_now)
+    @window = window
+  end
+
+  def call
+    schedules_for_regeneration.find_each(&:regenerate_bookable_slots!)
+  end
+
+  def schedules_for_regeneration
+    Schedule
+      .joins(:bookable_slots)
+      .group(:id)
+      .having('max(bookable_slots.date) = ?', window)
+  end
+end

--- a/app/lib/slot_generator.rb
+++ b/app/lib/slot_generator.rb
@@ -1,0 +1,27 @@
+module SlotGenerator
+  def create_scheduled_slots!
+    slots_to_create.map do |slot|
+      schedule.bookable_slots.create!(
+        date: slot.date,
+        start: slot.start,
+        end: slot.end
+      )
+    end
+  end
+
+  def scheduled_slots
+    @scheduled_slots ||= schedule.attributes.slice(
+      *Schedule::SLOT_ATTRIBUTES.map(&:to_s)
+    ).select { |_, v| v }
+  end
+
+  def slots_to_create
+    return [] if scheduled_slots.empty?
+
+    DefaultBookableSlots.new(**slot_window).call.select do |slot|
+      scheduled_slots.key?(slot.label)
+    end
+  end
+
+  attr_reader :schedule
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -22,6 +22,10 @@ class Schedule < ActiveRecord::Base
     BookableSlotGenerator.new(self).call
   end
 
+  def regenerate_bookable_slots!
+    BookableSlotRegenerator.new(self).call
+  end
+
   def create_bookable_slots(date:, am:, pm:)
     create_bookable_slot(date: date, period: BookableSlot::AM) if am
     create_bookable_slot(date: date, period: BookableSlot::PM) if pm

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -8,5 +8,9 @@ FactoryGirl.define do
         add_attribute(attribute, false)
       end
     end
+
+    trait :dalston do
+      location_id '183080c6-642b-4b8f-96fd-891f5cd9f9c7'
+    end
   end
 end

--- a/spec/features/schedule_regeneration_spec.rb
+++ b/spec/features/schedule_regeneration_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.feature 'Scheduled slot regeneration' do
+  scenario 'Regenerating slots for a given schedule' do
+    travel_to '2017-07-18 13:00' do
+      given_a_schedule_requiring_regeneration_exists
+      when_the_slot_regeneration_job_is_performed
+      then_the_necessary_slots_are_generated
+      and_the_slots_prior_to_cutoff_are_not_modified
+    end
+  end
+
+  def given_a_schedule_requiring_regeneration_exists
+    @schedule = create(:schedule, :blank, monday_am: true) do |schedule|
+      # this should be left as-is after regeneration
+      @prior_to_cutoff = create(:bookable_slot, :am, schedule: schedule, date: 1.day.ago)
+
+      # this is the last slot, landing on the cutoff
+      @lands_on_cutoff = create(:bookable_slot, :am, schedule: schedule, date: 6.weeks.from_now)
+    end
+  end
+
+  def when_the_slot_regeneration_job_is_performed
+    ScheduleRegenerationJob.new.perform
+  end
+
+  def then_the_necessary_slots_are_generated
+    expect(@schedule.bookable_slots.last).to have_attributes(
+      date: Date.parse('2017-12-18'),
+      start: BookableSlot::AM.start,
+      end: BookableSlot::AM.end
+    )
+  end
+
+  def and_the_slots_prior_to_cutoff_are_not_modified
+    expect(@schedule.bookable_slots).to include(@prior_to_cutoff)
+  end
+end

--- a/spec/lib/schedule_regeneration_spec.rb
+++ b/spec/lib/schedule_regeneration_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe ScheduleRegeneration do
+  describe '#scheduled_for_generation' do
+    it 'returns schedules with their final slot at the end of the booking window' do
+      # this will be present
+      @schedule = create(:schedule) do |schedule|
+        create(:bookable_slot, :am, date: 6.weeks.from_now, schedule: schedule)
+      end
+
+      # this won't since it is blank
+      @blank = create(:schedule, :blank)
+
+      # this won't since the last slot is not today
+      @other = create(:schedule, :dalston, :blank, monday_am: true, &:generate_bookable_slots!)
+
+      expect(subject.schedules_for_regeneration).to match_array(@schedule)
+    end
+  end
+end


### PR DESCRIPTION
When scheduled daily, this job will pick up those schedules with
availability ending on the day of execution and regenerate slots from that
day on to 4 months from then based on the slots in the given schedule.

It's not expected that there will be many schedules per day this affects
given the variance in schedules and the day their availability is scheduled
to end.