### PR TITLE
Use system phantomjs where present

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
     gem 'bootsnap'
     gem 'capybara'
     gem 'factory_girl_rails'
-    gem 'phantomjs-binaries'
+    gem 'phantomjs'
     gem 'pry-byebug'
     gem 'rspec-rails'
     gem 'site_prism'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,8 +200,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
-    phantomjs-binaries (2.1.1.1)
-      sys-uname (= 0.9.0)
+    phantomjs (2.1.1.0)
     plek (2.0.0)
     poltergeist (1.15.0)
       capybara (~> 2.1)
@@ -352,8 +351,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sys-uname (0.9.0)
-      ffi (>= 1.0.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
     thor (0.19.4)
@@ -406,7 +403,7 @@ DEPENDENCIES
   newrelic_rpm!
   oj!
   pg!
-  phantomjs-binaries!
+  phantomjs!
   plek!
   poltergeist!
   pry-byebug!
@@ -431,4 +428,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/spec/support/poltergeist.rb
+++ b/spec/support/poltergeist.rb
@@ -1,4 +1,11 @@
 require 'capybara/poltergeist'
 
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(
+    app,
+    phantomjs: Phantomjs.path
+  )
+end
+
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 20


### PR DESCRIPTION
This is preferable to `phantomjs-binaries` now the `phantomjs` gem uses
a CDN without an over-zealous rate limit.