### PR TITLE
Exclude guider days from bookable slots

### DIFF
--- a/app/lib/default_bookable_slots.rb
+++ b/app/lib/default_bookable_slots.rb
@@ -29,11 +29,11 @@ class DefaultBookableSlots
   private
 
   def available_days
-    (grace_period_end..to).reject { |day| day.on_weekend? || bank_holiday?(day) }
+    (grace_period_end..to).reject { |day| day.on_weekend? || excluded?(day) }
   end
 
-  def bank_holiday?(date)
-    BANK_HOLIDAYS.include?(date)
+  def excluded?(date)
+    EXCLUSIONS.include?(date)
   end
 
   def grace_period_end

--- a/config/initializers/bookable_slots.rb
+++ b/config/initializers/bookable_slots.rb
@@ -1,5 +1,5 @@
 # Days that are always excluded from availability
-BANK_HOLIDAYS = [
+EXCLUSIONS = [
   Date.parse('29/05/2017'),
   Date.parse('28/08/2017'),
   Date.parse('25/12/2017'),

--- a/config/initializers/bookable_slots.rb
+++ b/config/initializers/bookable_slots.rb
@@ -2,6 +2,8 @@
 EXCLUSIONS = [
   Date.parse('29/05/2017'),
   Date.parse('28/08/2017'),
+  Date.parse('03/10/2017'),
+  Date.parse('04/10/2017'),
   Date.parse('25/12/2017'),
   Date.parse('26/12/2017')
 ].freeze

--- a/db/migrate/20170801100607_remove_excluded_slots_for_guider_day.rb
+++ b/db/migrate/20170801100607_remove_excluded_slots_for_guider_day.rb
@@ -1,0 +1,11 @@
+class RemoveExcludedSlotsForGuiderDay < ActiveRecord::Migration[5.1]
+  def up
+    BookableSlot.where(
+      date: Date.parse('03/10/2017')..Date.parse('04/10/2017')
+    ).delete_all
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170605122227) do
+ActiveRecord::Schema.define(version: 20170801100607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
There is a two day guider event occurring on these newly added days so we
must ensure we display no booking availability during this time.