### PR TITLE
Add flag to identify bookings placed by agents

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -52,6 +52,7 @@ module Api
           :marketing_opt_in,
           :defined_contribution_pot_confirmed,
           :additional_info,
+          :placed_by_agent,
           slots: %i(date from to priority)
         ).tap { |p| p[:slots_attributes] = p.delete(:slots) }
       end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -25,6 +25,7 @@ class BookingRequest < ActiveRecord::Base
   validates :accessibility_requirements, inclusion: { in: [true, false] }
   validates :marketing_opt_in, inclusion: { in: [true, false] }
   validates :defined_contribution_pot_confirmed, inclusion: { in: [true, false] }
+  validates :placed_by_agent, inclusion: { in: [true, false] }
   validates :additional_info, length: { maximum: 160 }, allow_blank: true
   validate :validate_slots
 

--- a/db/migrate/20170822093403_add_place_by_agent_to_booking_requests.rb
+++ b/db/migrate/20170822093403_add_place_by_agent_to_booking_requests.rb
@@ -1,0 +1,5 @@
+class AddPlaceByAgentToBookingRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_column :booking_requests, :placed_by_agent, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170801100607) do
+ActiveRecord::Schema.define(version: 20170822093403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 20170801100607) do
     t.date "date_of_birth"
     t.integer "status", default: 0, null: false
     t.string "additional_info", limit: 160, default: "", null: false
+    t.boolean "placed_by_agent", default: false, null: false
   end
 
   create_table "schedules", force: :cascade do |t|

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
     accessibility_requirements true
     marketing_opt_in false
     defined_contribution_pot_confirmed true
+    placed_by_agent false
 
     transient { number_of_slots 1 }
 

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -99,6 +99,10 @@ RSpec.describe BookingRequest do
     expect(described_class.new).to be_active
   end
 
+  it 'defaults `placed_by_agent`' do
+    expect(described_class.new).to_not be_placed_by_agent
+  end
+
   describe '#memorable_word' do
     it 'can be obscured' do
       expect(build_stubbed(:booking_request).memorable_word).to eq('spaceship')

--- a/spec/requests/create_a_booking_request_spec.rb
+++ b/spec/requests/create_a_booking_request_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
         'accessibility_requirements' => false,
         'marketing_opt_in' => true,
         'defined_contribution_pot_confirmed' => true,
+        'placed_by_agent' => true,
         'slots' => [
           {
             'date' => '2016-01-01',
@@ -81,7 +82,8 @@ RSpec.describe 'POST /api/v1/booking_requests' do
       additional_info: 'Additional Info',
       accessibility_requirements: false,
       marketing_opt_in: true,
-      defined_contribution_pot_confirmed: true
+      defined_contribution_pot_confirmed: true,
+      placed_by_agent: true
     )
   end
 


### PR DESCRIPTION
This allows us to report on bookings placed by TP agents using the same
process as the regular customer journey.