### PR TITLE
Determine the canonical number for bookings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.16.0)
+    booking_locations (0.17.0)
       activesupport (>= 4, <= 6)
       globalid
     bootsnap (1.1.2)

--- a/app/mailers/booking_requests.rb
+++ b/app/mailers/booking_requests.rb
@@ -1,7 +1,7 @@
 class BookingRequests < ApplicationMailer
   def customer(booking_request, booking_location)
     @booking_request  = booking_request
-    @booking_location = booking_location
+    @actual_location  = booking_location.location_for(booking_request.location_id)
 
     mailgun_headers('customer_booking_request')
     mail(

--- a/app/models/location_aware_entity.rb
+++ b/app/models/location_aware_entity.rb
@@ -6,6 +6,8 @@ class LocationAwareEntity < SimpleDelegator
     super(entity)
   end
 
+  delegate :online_booking_twilio_number, to: :actual_location
+
   def location_name
     actual_location.name
   end

--- a/app/views/appointments/customer.html.erb
+++ b/app/views/appointments/customer.html.erb
@@ -21,7 +21,7 @@
 <%= render 'shared/email/appointment_details' %>
 
 <%= p do %>
-  Call <%= @appointment.booking_location.online_booking_twilio_number %> or email us to change or cancel your booking. You may be asked for your booking reference number.
+  Call <%= @appointment.online_booking_twilio_number %> or email us to change or cancel your booking. You may be asked for your booking reference number.
 <% end %>
 
 <%= render 'shared/email/preparing_for_appointment' %>

--- a/app/views/appointments/customer.text.erb
+++ b/app/views/appointments/customer.text.erb
@@ -14,6 +14,6 @@ Thank you for booking a Pension Wise appointment.
 
 <%= render 'shared/email/appointment_details' %>
 
-Call <%= @appointment.booking_location.online_booking_twilio_number %> or email us to change or cancel your booking. You may be asked for your booking reference number.
+Call <%= @appointment.online_booking_twilio_number %> or email us to change or cancel your booking. You may be asked for your booking reference number.
 
 <%= render '/shared/email/preparing_for_appointment' %>

--- a/app/views/appointments/reminder.html.erb
+++ b/app/views/appointments/reminder.html.erb
@@ -13,7 +13,7 @@
 <%= render 'shared/email/appointment_details' %>
 
 <%= p do %>
-  Call <%= @appointment.booking_location.online_booking_twilio_number %> or email us to change or cancel your booking. You may be asked for your booking reference number.
+  Call <%= @appointment.online_booking_twilio_number %> or email us to change or cancel your booking. You may be asked for your booking reference number.
 <% end %>
 
 <%= render 'shared/email/preparing_for_appointment' %>

--- a/app/views/appointments/reminder.text.erb
+++ b/app/views/appointments/reminder.text.erb
@@ -6,6 +6,6 @@ This is a reminder that you have a Pension Wise appointment booked for:
 
 <%= render 'shared/email/appointment_details' %>
 
-Call <%= @appointment.booking_location.online_booking_twilio_number %> or email us to change or cancel your booking. You may be asked for your booking reference number.
+Call <%= @appointment.online_booking_twilio_number %> or email us to change or cancel your booking. You may be asked for your booking reference number.
 
 <%= render '/shared/email/preparing_for_appointment' %>

--- a/app/views/booking_requests/customer.html.erb
+++ b/app/views/booking_requests/customer.html.erb
@@ -34,7 +34,7 @@
   Appointment location:
   <br>
   <strong class="emphasize">
-    <%= @booking_location.name_for(@booking_request.location_id) %>
+    <%= @actual_location.name %>
   </strong>
 <% end %>
 
@@ -63,5 +63,5 @@
 <% end %>
 
 <%= p do %>
-  Call <%= @booking_location.online_booking_twilio_number %> or email us to change or cancel your booking request. You may be asked for your booking reference number.
+  Call <%= @actual_location.online_booking_twilio_number %> or email us to change or cancel your booking request. You may be asked for your booking reference number.
 <% end %>

--- a/app/views/booking_requests/customer.text.erb
+++ b/app/views/booking_requests/customer.text.erb
@@ -15,7 +15,7 @@ or
 <%= @booking_request.tertiary_slot %>
 
 Appointment location:
-<%= @booking_location.name_for(@booking_request.location_id) %>
+<%= @actual_location.name %>
 
 Your phone number:
 <%= @booking_request.phone %>
@@ -26,4 +26,4 @@ Memorable word:
 Reference number:
 <%= @booking_request.reference %>
 
-Call <%= @booking_location.online_booking_twilio_number %> or email us to change or cancel your booking request. You may be asked for your booking reference number.
+Call <%= @actual_location.online_booking_twilio_number %> or email us to change or cancel your booking request. You may be asked for your booking reference number.

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Appointments do
-  let(:appointment) { build_stubbed(:appointment) }
+  let(:appointment) do
+    build_stubbed(:appointment, location_id: '183080c6-642b-4b8f-96fd-891f5cd9f9c7')
+  end
   let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
 
   describe 'Customer reminder' do
@@ -22,8 +24,8 @@ RSpec.describe Appointments do
       it 'includes the appointment particulars' do
         expect(body).to include('2:00pm')
         expect(body).to include('20 June 2016')
-        expect(body).to include('Hackney')
-        expect(body).to include('+442086291134')
+        expect(body).to include('Dalston')
+        expect(body).to include('+44800123456')
         expect(body).to include(appointment.reference)
       end
 
@@ -33,10 +35,10 @@ RSpec.describe Appointments do
 
       it 'includes the address' do
         expect(body).to include(
-          '300 Mare St',
+          '22 Dalston Lane',
           'Hackney',
           'London',
-          'E8 1HE'
+          'E8 3AZ'
         )
       end
     end
@@ -60,8 +62,8 @@ RSpec.describe Appointments do
       it 'includes the appointment particulars' do
         expect(body).to include('2:00pm')
         expect(body).to include('20 June 2016')
-        expect(body).to include('Hackney')
-        expect(body).to include('+442086291134')
+        expect(body).to include('Dalston')
+        expect(body).to include('+44800123456')
         expect(body).to include(appointment.reference)
       end
 
@@ -71,10 +73,10 @@ RSpec.describe Appointments do
 
       it 'includes the address' do
         expect(body).to include(
-          '300 Mare St',
+          '22 Dalston Lane',
           'Hackney',
           'London',
-          'E8 1HE'
+          'E8 3AZ'
         )
       end
 

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe BookingRequests do
     let(:location_id) { '183080c6-642b-4b8f-96fd-891f5cd9f9c7' }
     let(:booking_location_id) { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
     let(:booking_location) { BookingLocations.find(booking_location_id) }
+    let(:actual_location) { booking_location.location_for(location_id) }
     let(:booking_request) do
       create(:booking_request, location_id: location_id, booking_location_id: booking_location_id)
     end
@@ -31,9 +32,9 @@ RSpec.describe BookingRequests do
         expect(body).to include('s*******p')
       end
 
-      it 'includes the booking location particulars' do
-        expect(body).to include(booking_location.name_for(location_id))
-        expect(body).to include(booking_location.online_booking_twilio_number)
+      it 'includes the actual location particulars' do
+        expect(body).to include(actual_location.name)
+        expect(body).to include(actual_location.online_booking_twilio_number)
       end
 
       it 'includes the three selected slots' do


### PR DESCRIPTION
Allows the administrator to override a parent's online booking twilio
number with that of its child location.