### PR TITLE
Restrict appointment times from 8AM to 6:45PM

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -136,7 +136,7 @@
             <div class="form-group">
               <%= f.label :proceeded_at, 'Time of appointment' %>
               <div class="form-control">
-                <%= f.time_select(:proceeded_at, ignore_date: true, minute_step: 15) %>
+                <%= f.time_select(:proceeded_at, ignore_date: true, minute_step: 15, start_hour: 8, end_hour: 18) %>
               </div>
             </div>
             <div class="form-group">

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -187,7 +187,9 @@
                 <%= f.time_select(
                   :time,
                   ignore_date: true,
-                  minute_step: 15
+                  minute_step: 15,
+                  start_hour: 8,
+                  end_hour: 18
                 ) %>
               </div>
             </div>


### PR DESCRIPTION
This stops booking managers choosing times outside of those servicable
by the various locations.