### PR TITLE
Add `where_you_heard` to booking requests

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -53,6 +53,7 @@ module Api
           :defined_contribution_pot_confirmed,
           :additional_info,
           :placed_by_agent,
+          :where_you_heard,
           slots: %i(date from to priority)
         ).tap { |p| p[:slots_attributes] = p.delete(:slots) }
       end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -27,6 +27,7 @@ class BookingRequest < ActiveRecord::Base
   validates :defined_contribution_pot_confirmed, inclusion: { in: [true, false] }
   validates :placed_by_agent, inclusion: { in: [true, false] }
   validates :additional_info, length: { maximum: 160 }, allow_blank: true
+  validates :where_you_heard, presence: true
   validate :validate_slots
 
   alias reference to_param

--- a/db/migrate/20171019145702_add_where_you_heard_to_booking_requests.rb
+++ b/db/migrate/20171019145702_add_where_you_heard_to_booking_requests.rb
@@ -1,0 +1,5 @@
+class AddWhereYouHeardToBookingRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_column :booking_requests, :where_you_heard, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170822093403) do
+ActiveRecord::Schema.define(version: 20171019145702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20170822093403) do
     t.integer "status", default: 0, null: false
     t.string "additional_info", limit: 160, default: "", null: false
     t.boolean "placed_by_agent", default: false, null: false
+    t.integer "where_you_heard", default: 0, null: false
   end
 
   create_table "schedules", force: :cascade do |t|

--- a/spec/models/booking_request_spec.rb
+++ b/spec/models/booking_request_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe BookingRequest do
     expect(described_class.new).to_not be_placed_by_agent
   end
 
+  it 'defaults `where_you_heard`' do
+    expect(described_class.new.where_you_heard).to be_zero
+  end
+
   describe '#memorable_word' do
     it 'can be obscured' do
       expect(build_stubbed(:booking_request).memorable_word).to eq('spaceship')

--- a/spec/requests/create_a_booking_request_spec.rb
+++ b/spec/requests/create_a_booking_request_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
         'marketing_opt_in' => true,
         'defined_contribution_pot_confirmed' => true,
         'placed_by_agent' => true,
+        'where_you_heard' => 1,
         'slots' => [
           {
             'date' => '2016-01-01',
@@ -83,7 +84,8 @@ RSpec.describe 'POST /api/v1/booking_requests' do
       accessibility_requirements: false,
       marketing_opt_in: true,
       defined_contribution_pot_confirmed: true,
-      placed_by_agent: true
+      placed_by_agent: true,
+      where_you_heard: 1
     )
   end
 


### PR DESCRIPTION
Allows the customer to specify where they heard about Pension Wise when
placing their booking.