### PR TITLE
Audit schedule creation

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -17,6 +17,7 @@ class Schedule < ActiveRecord::Base
   alias default? new_record?
 
   has_associated_audits
+  audited on: :create
 
   def generate_bookable_slots!
     BookableSlotGenerator.new(self).call


### PR DESCRIPTION
This helps us track who created schedules since we've had a few issues
recently where booking managers have created erroneous schedules and
wiped out existing availability.