### PR TITLE
Correctly validate email presence

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -11,10 +11,11 @@ class AppointmentForm
     booking_location
     additional_info
     agent
+    address?
   ).freeze
 
   validates :name, presence: true
-  validates :email, presence: true, email: true
+  validates :email, presence: true, email: true, unless: :address?
   validates :phone, presence: true
   validates :memorable_word, presence: true
   validates :accessibility_requirements, inclusion: { in: [true, false, '1', '0'] }

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -60,6 +60,10 @@ class BookingRequest < ActiveRecord::Base
     super.to_s.titleize
   end
 
+  def address?
+    [address_line_one, town, postcode].all?(&:present?)
+  end
+
   private
 
   def validate_slots

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -15,6 +15,9 @@ FactoryBot.define do
     marketing_opt_in false
     defined_contribution_pot_confirmed true
     placed_by_agent false
+    address_line_one '10 Some Road'
+    town 'Some Town'
+    postcode 'W1 1AA'
 
     transient { number_of_slots 1 }
 

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -39,6 +39,23 @@ RSpec.describe AppointmentForm do
       expect(subject).to be_valid
     end
 
+    context 'with an address' do
+      it 'does not require an email' do
+        subject.email = ''
+
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'with no address' do
+      it 'requires an email address' do
+        booking_request.address_line_one = ''
+        subject.email = ''
+
+        expect(subject).to_not be_valid
+      end
+    end
+
     it 'must not be associated with an existing appointment' do
       booking_request.appointment = build(:appointment)
 
@@ -47,12 +64,6 @@ RSpec.describe AppointmentForm do
 
     it 'requires a name' do
       params[:name] = ''
-
-      expect(subject).to_not be_valid
-    end
-
-    it 'requires an email' do
-      params[:email] = ''
 
       expect(subject).to_not be_valid
     end


### PR DESCRIPTION
In the case of agent bookings we should not require an email here when
an address is provided during the booking request phase.