### PR TITLE
Permit 500 characters for `additional_info`

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -158,7 +158,7 @@
             </div>
             <div class="form-group">
               <%= f.label :additional_info %>
-              <%= f.text_area :additional_info, class: 'form-control t-additional-info', rows: 5, maxlength: 160, readonly: true %>
+              <%= f.text_area :additional_info, class: 'form-control t-additional-info', rows: 5, maxlength: 500, readonly: true %>
             </div>
             <div class="form-group">
               <div class="well appointment-status-well">

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -214,7 +214,7 @@
 
             <div class="form-group">
               <%= f.label :additional_info %>
-              <%= f.text_area :additional_info, class: 'form-control t-additional-info', rows: 5, maxlength: 160, readonly: true %>
+              <%= f.text_area :additional_info, class: 'form-control t-additional-info', rows: 5, maxlength: 500, readonly: true %>
             </div>
 
             <div class="form-group">

--- a/db/migrate/20171129144205_extend_appointment_additional_info.rb
+++ b/db/migrate/20171129144205_extend_appointment_additional_info.rb
@@ -1,0 +1,5 @@
+class ExtendAppointmentAdditionalInfo < ActiveRecord::Migration[5.1]
+  def change
+    change_column :appointments, :additional_info, :string, limit: 500, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121144146) do
+ActiveRecord::Schema.define(version: 20171129144205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 20171121144146) do
     t.date "date_of_birth"
     t.boolean "defined_contribution_pot_confirmed", default: true, null: false
     t.boolean "accessibility_requirements", default: false, null: false
-    t.string "additional_info", limit: 160, default: "", null: false
+    t.string "additional_info", limit: 500, default: "", null: false
     t.index ["booking_request_id"], name: "index_appointments_on_booking_request_id"
     t.index ["location_id"], name: "index_appointments_on_location_id"
   end


### PR DESCRIPTION
This wasn't changed in step with its booking request counterpart.