### PR TITLE
Disallow `tpbookings@pensionwise.gov.uk`

### DIFF
--- a/app/forms/agent_booking_form.rb
+++ b/app/forms/agent_booking_form.rb
@@ -81,7 +81,7 @@ class AgentBookingForm # rubocop:disable ClassLength
   end
 
   def email_provided?
-    email.present? && email != 'tpbooking@pensionwise.gov.uk'
+    email.present? && /tpbookings?@pensionwise.gov.uk/ !~ email
   end
 
   def age_range

--- a/spec/forms/agent_booking_form_spec.rb
+++ b/spec/forms/agent_booking_form_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe AgentBookingForm do
       expect(subject).to be_valid
     end
 
+    context 'when one of the legacy journey email addresses are provided' do
+      %w(tpbooking@pensionwise.gov.uk tpbookings@pensionwise.gov.uk).each do |email|
+        it "requires an address for '#{email}'" do
+          subject.email = email
+          subject.address_line_one = ''
+
+          expect(subject).to be_invalid
+        end
+      end
+    end
+
     context 'when an email is not provided' do
       it 'requires an address' do
         subject.email = ''


### PR DESCRIPTION
Some agents are using this as a workaround to avoid entering an address.