### PR TITLE
Revert "Alter confirmation message for new year"

### DIFF
--- a/app/views/booking_requests/customer.html.erb
+++ b/app/views/booking_requests/customer.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= p do %>
-  Thank you for requesting a Pension Wise appointment. We’ll confirm the date in the new year.
+  Thank you for requesting a Pension Wise appointment. We’ll confirm the date in the next 2 working days.
 <% end %>
 
 <%= p do %>

--- a/app/views/booking_requests/customer.text.erb
+++ b/app/views/booking_requests/customer.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @booking_request.name %>,
 
-Thank you for requesting a Pension Wise appointment. We'll confirm the date in the new year.
+Thank you for requesting a Pension Wise appointment. We'll confirm your appointment in the next 2 working days.
 
 Your requested dates (UK local time):
 


### PR DESCRIPTION
This no longer applies after the new year break.