### PR TITLE
Notify when status changes to pending

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -32,7 +32,10 @@ class Appointment < ActiveRecord::Base
   end
 
   def notify?
-    previous_changes.any? && previous_changes.exclude?(:status)
+    return unless previous_changes.any?
+    return true if previous_changes.exclude?(:status)
+
+    previous_changes[:status] && pending?
   end
 
   def calculate_statistics

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -98,10 +98,12 @@ RSpec.describe Appointment do
 
     describe '#notify?' do
       context 'when the status was changed' do
-        it 'returns false' do
-          original.update(status: 1)
-
+        it 'handles correctly' do
+          original.update(status: :completed)
           expect(original).to_not be_notify
+
+          original.update(status: :pending)
+          expect(original).to be_notify
         end
       end
 


### PR DESCRIPTION
When an appointment changed from cancelled back to pending the customer
was not being informed and thus appointments were being missed.

This change ensures customers are notified by email when the status
changes back to pending from any other.