### PR TITLE
Stop polling upon receipt of an erroneous status

### DIFF
--- a/app/assets/javascripts/poller.js
+++ b/app/assets/javascripts/poller.js
@@ -43,8 +43,15 @@
     },
 
     poll: function() {
-      $.ajax({ url: this.url(), data: { timestamp: this.getLast() } })
-       .always($.proxy(this.handleResponse, this));
+      $.ajax({
+        url: this.url(),
+        data: { timestamp: this.getLast() },
+        error: $.proxy(this.handleError, this)
+      }).always($.proxy(this.handleResponse, this));
+    },
+
+    handleError: function() {
+      this.stop();
     },
 
     handleResponse: function(data, status, request) {


### PR DESCRIPTION
This ensures the poller stops when it receives an error. This has been
happening when booking requests can no longer be found. Due to the
polling interval this will cause a spike of reported errors
unnecessarily.