### PR TITLE
Resolve agent booking search issues

### DIFF
--- a/app/forms/agent_search_form.rb
+++ b/app/forms/agent_search_form.rb
@@ -8,26 +8,20 @@ class AgentSearchForm
   attr_accessor :agent
   attr_accessor :page
 
-  def initialize(params = {})
-    params[:status] ||= BookingRequest.statuses.first
-
-    super(params)
-  end
-
   def results # rubocop:disable Metrics/AbcSize
     scope = BookingRequest.placed_by_agents
     scope = scope.where(id: reference) if reference.present?
     scope = scope.where('booking_requests.name ILIKE ?', "%#{name}%") if name.present?
     scope = scope.where(status: status) if status.present?
     scope = scope.where(created_at: date_range) if date_range
-    scope = scope.where(agent_id: agent) if agent
+    scope = scope.where(agent_id: agent) if agent.present?
     scope.page(page)
   end
 
   private
 
   def date_range
-    return unless date.present?
+    return if date.blank?
 
     first, last = date.split(' - ').map(&:to_date)
     first.beginning_of_day..last.end_of_day

--- a/spec/features/agent_searches_for_booking_requests_spec.rb
+++ b/spec/features/agent_searches_for_booking_requests_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.feature 'Agent searches for booking requests' do
+  scenario 'Searching via a given booking reference' do
+    given_the_user_identifies_as_an_agent_manager
+    and_booking_requests_exist
+    when_they_visit_the_site
+    and_search_for_a_particular_booking_reference
+    then_they_see_the_booking_request
+  end
+
   scenario 'Searching for booking requests' do
     given_the_user_identifies_as_an_agent_manager
     and_booking_requests_exist
@@ -14,7 +22,7 @@ RSpec.feature 'Agent searches for booking requests' do
 
   def and_booking_requests_exist
     # these will be returned
-    create_list(:hackney_booking_request, 3, agent: User.first)
+    @bookings = create_list(:hackney_booking_request, 3, agent: User.first)
     # this will be missing as it's not an agent booking
     create(:hackney_booking_request, name: 'Mr Missing')
   end
@@ -29,5 +37,15 @@ RSpec.feature 'Agent searches for booking requests' do
 
     expect(@page).to have_booking_requests(count: 3)
     expect(@page).to have_no_text('Mr Missing')
+  end
+
+  def and_search_for_a_particular_booking_reference
+    @page = Pages::AgentBookingSearch.new
+    @page.reference.set(@bookings.first.id)
+    @page.submit.click
+  end
+
+  def then_they_see_the_booking_request
+    expect(@page).to have_booking_requests(count: 1)
   end
 end

--- a/spec/support/pages/agent_booking_search.rb
+++ b/spec/support/pages/agent_booking_search.rb
@@ -2,6 +2,9 @@ module Pages
   class AgentBookingSearch < SitePrism::Page
     set_url '/agents/booking_requests'
 
+    element :reference, '.t-reference'
+    element :submit, '.t-submit'
+
     elements :booking_requests, '.t-booking-request'
   end
 end


### PR DESCRIPTION
We don't need to pre-select the status field and when no agent was
provided we were still adding an agent clause checking against a blank
ID, thus causing incorrect results.