### PR TITLE
Ensure DOB is validated before eligibility

### DIFF
--- a/app/forms/agent_booking_form.rb
+++ b/app/forms/agent_booking_form.rb
@@ -31,7 +31,6 @@ class AgentBookingForm # rubocop:disable ClassLength
   validates :name, presence: true
   validates :booking_location_id, presence: true
   validates :location_id, presence: true
-  validates :date_of_birth, presence: true, format: %r{\d{1,2}\/\d{1,2}\/\d{2,4}}
   validates :email, presence: true, email: true, allow_blank: true
   validates :postcode, postcode: true, allow_blank: true
   validates :phone, presence: true, format: /\A([\d+\-\s\+()]+)\z/
@@ -69,7 +68,10 @@ class AgentBookingForm # rubocop:disable ClassLength
   private
 
   def validate_eligibility
-    return if date_of_birth.blank?
+    unless %r{\d{1,2}\/\d{1,2}\/\d{4}}.match?(date_of_birth)
+      errors.add(:date_of_birth, 'must be formatted eg 01/01/1950')
+      return
+    end
 
     errors.add(:base, 'Must be aged 50 or over to be eligible') if age < 50
   end

--- a/spec/forms/agent_booking_form_spec.rb
+++ b/spec/forms/agent_booking_form_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe AgentBookingForm do
       expect(subject).to be_valid
     end
 
+    context 'dob validation bug' do
+      it 'requires a date of birth' do
+        subject.date_of_birth = ''
+
+        expect(subject).to be_invalid
+      end
+
+      it 'requires a four digit year fragment' do
+        subject.date_of_birth = '01/02/53'
+
+        expect(subject).to be_invalid
+      end
+    end
+
     context 'when one of the legacy journey email addresses are provided' do
       %w(tpbooking@pensionwise.gov.uk tpbookings@pensionwise.gov.uk).each do |email|
         it "requires an address for '#{email}'" do


### PR DESCRIPTION
This was causing errors to be raised at the preview stage and the
resulting message is not particularly useful to the agent.