### PR TITLE
Improve display of admin locations

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
         <%= f.select :organisation_content_id,
               options_for_select(booking_location_options, current_user.organisation_content_id),
               {},
-              { class: 't-location js-location' }
+              { class: 't-location js-location form-control input-sm' }
         %>
       </div>
     <% end %>


### PR DESCRIPTION
Makes the dropdown for switching administrator's currently assigned
location much more consistently sized and styled.

## Before

<img width="461" alt="screen shot 2018-04-30 at 11 55 10" src="https://user-images.githubusercontent.com/41963/39424216-6f22d9c8-4c6d-11e8-8ea0-e0e915e268cd.png">

## After

<img width="565" alt="screen shot 2018-04-30 at 11 27 01" src="https://user-images.githubusercontent.com/41963/39424222-77086a4a-4c6d-11e8-9d0d-90bfb902ee34.png">
