### PR TITLE
Display the agent landing page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,16 +6,19 @@ class HomeController < ActionController::Base
 
   before_action do
     authorise_user!(
-      any_of: [User::BOOKING_MANAGER_PERMISSION, User::AGENT_MANAGER_PERMISSION]
+      any_of: [
+        User::BOOKING_MANAGER_PERMISSION,
+        User::AGENT_MANAGER_PERMISSION,
+        User::AGENT_PERMISSION
+      ]
     )
   end
 
   def index
-    if agent_manager_only?
-      redirect_to agent_search_index_path
-    else
-      redirect_to booking_requests_path
-    end
+    return redirect_to agent_search_index_path if agent_manager_only?
+    return redirect_to booking_requests_path   if current_user.booking_manager?
+
+    render :index, layout: 'application'
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def booking_journey_path
+    Plek.find('www') + '/en/book-face-to-face'
+  end
+
   def safe_location_name(location_id)
     location = BookingLocations.find(location_id)
     location&.name_for(location_id)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:page_title, t('service.title', page_title: 'Place a booking request')) %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li class="active">Place a booking request</li>
+  </ol>
+
+  <h1>Place a booking request</h1>
+</div>
+
+<div class="lead notice">
+  <p>
+    To place a booking request you should follow the customer booking journey.
+  </p>
+  <p>
+    <%= link_to 'Place a booking request', booking_journey_path, class: 'btn btn-primary btn-lg' %>
+  </p>
+</div>

--- a/spec/features/agent_views_landing_page_spec.rb
+++ b/spec/features/agent_views_landing_page_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.feature 'Agent views the landing page' do
+  scenario 'The agent is displayed a notice' do
+    given_the_user_identifies_as_an_agent do
+      when_they_visit_the_application
+      then_they_are_displayed_a_notice
+    end
+  end
+
+  def when_they_visit_the_application
+    visit '/'
+  end
+
+  def then_they_are_displayed_a_notice
+    expect(page).to have_text('Place a booking request')
+  end
+end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -8,6 +8,15 @@ module UserHelpers
     ENV['GDS_SSO_MOCK_INVALID'] = sso_env
   end
 
+  def given_the_user_identifies_as_an_agent
+    @user = create(:agent)
+    GDS::SSO.test_user = @user
+
+    yield
+  ensure
+    GDS::SSO.test_user = nil
+  end
+
   def given_the_user_identifies_as_hackneys_administrator
     @user = create(:hackney_administrator)
     GDS::SSO.test_user = @user


### PR DESCRIPTION
When the user only possesses the `agent` permission they should be
displayed a notice and link back to the customer booking journey.