### PR TITLE
Lookup booking managers by DC

### DIFF
--- a/app/jobs/booking_manager_confirmation_job.rb
+++ b/app/jobs/booking_manager_confirmation_job.rb
@@ -2,7 +2,7 @@ class BookingManagerConfirmationJob < ActiveJob::Base
   queue_as :default
 
   def perform(booking_request)
-    booking_managers = User.active.where(organisation_content_id: booking_request.location_id)
+    booking_managers = User.active.where(organisation_content_id: booking_request.booking_location_id)
 
     raise BookingManagersNotFoundError unless booking_managers.present?
 

--- a/app/jobs/drop_notification_job.rb
+++ b/app/jobs/drop_notification_job.rb
@@ -2,7 +2,7 @@ class DropNotificationJob < ActiveJob::Base
   queue_as :default
 
   def perform(booking_request)
-    booking_managers = User.active.where(organisation_content_id: booking_request.location_id)
+    booking_managers = User.active.where(organisation_content_id: booking_request.booking_location_id)
 
     raise BookingManagersNotFoundError unless booking_managers.present?
 

--- a/spec/jobs/booking_manager_confirmation_job_spec.rb
+++ b/spec/jobs/booking_manager_confirmation_job_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BookingManagerConfirmationJob, '#perform' do
-  let(:location_id) { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
-  let(:booking_request) { create(:booking_request, location_id: location_id) }
+  let(:booking_request) { create(:hackney_booking_request) }
 
   subject { described_class.new.perform(booking_request) }
 

--- a/spec/jobs/drop_notification_job_spec.rb
+++ b/spec/jobs/drop_notification_job_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe DropNotificationJob, '#perform' do
-  let(:location_id) { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
-  let(:booking_request) { create(:booking_request, location_id: location_id) }
+  let(:booking_request) { create(:hackney_booking_request) }
 
   subject { described_class.new.perform(booking_request) }
 


### PR DESCRIPTION
This was previously looking up the associated booking managers by the
child location's ID, not the delivery centre's ID.