### PR TITLE
Store status changes separately for reporting

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -12,8 +12,11 @@ class Appointment < ActiveRecord::Base
   )
 
   before_save :calculate_statistics, if: :proceeded_at_changed?
+  before_create :track_status
+  before_update :track_status_transition
 
   belongs_to :booking_request
+  has_many :status_transitions
 
   delegate :reference, :activities, :agent_id?, to: :booking_request
 
@@ -61,6 +64,14 @@ class Appointment < ActiveRecord::Base
   end
 
   private
+
+  def track_status
+    status_transitions << StatusTransition.new(status: status)
+  end
+
+  def track_status_transition
+    track_status if status_changed?
+  end
 
   def after_audit
     AuditActivity.from(audits.last, booking_request)

--- a/app/models/status_transition.rb
+++ b/app/models/status_transition.rb
@@ -1,0 +1,3 @@
+class StatusTransition < ActiveRecord::Base
+  belongs_to :appointment
+end

--- a/db/migrate/20180502091455_create_status_transitions.rb
+++ b/db/migrate/20180502091455_create_status_transitions.rb
@@ -1,0 +1,10 @@
+class CreateStatusTransitions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :status_transitions do |t|
+      t.belongs_to :appointment, index: true
+      t.string :status, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180420111141) do
+ActiveRecord::Schema.define(version: 20180502091455) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,14 @@ ActiveRecord::Schema.define(version: 20180420111141) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["booking_request_id"], name: "index_slots_on_booking_request_id"
+  end
+
+  create_table "status_transitions", force: :cascade do |t|
+    t.bigint "appointment_id"
+    t.string "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appointment_id"], name: "index_status_transitions_on_appointment_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|

--- a/lib/tasks/statuses.rake
+++ b/lib/tasks/statuses.rake
@@ -1,0 +1,22 @@
+namespace :statuses do
+  desc 'Generate `status_transitions` from audits'
+  task generate: :environment do
+    ActiveRecord::Base.transaction do
+      Audited::Audit.find_each do |audit|
+        if audit.audited_changes.key?('status') && audit.auditable
+          appointment = audit.auditable
+          status      = audit.audited_changes['status']
+
+          # Status is scalar for the initial creation
+          status = status.is_a?(Array) ? status.last : status
+
+          appointment.status_transitions.create!(
+            status: status,
+            created_at: audit.created_at,
+            updated_at: audit.created_at
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -3,6 +3,20 @@ require 'rails_helper'
 RSpec.describe Appointment do
   subject { build_stubbed(:appointment) }
 
+  context 'when the status changes before saving' do
+    it 'stores the associated statuses' do
+      appointment = create(:appointment)
+
+      expect(appointment.status_transitions.pluck(:status)).to match_array('pending')
+
+      appointment.update(status: :cancelled_by_pension_wise)
+
+      expect(appointment.status_transitions.pluck(:status)).to match_array(
+        %w(pending cancelled_by_pension_wise)
+      )
+    end
+  end
+
   it 'defaults #status to `pending`' do
     expect(described_class.new).to be_pending
   end


### PR DESCRIPTION
This helps us better understand the various states and what triggers
them during the appointment lifecycle. Previously, this information was
locked away in the audit trail and was not easily queried.

This also includes a rake task to backfill previous appointments with
their associated status transitions.