### PR TITLE
Send both a 48hr and a 7-day email reminder

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -54,13 +54,14 @@ class Appointment < ActiveRecord::Base
     proceeded_at.in_time_zone('London').utc_offset.zero? ? 'GMT' : 'BST'
   end
 
-  def self.needing_reminder
+  def self.needing_reminder # rubocop:disable AbcSize
+    two_day_reminder_range   = Time.zone.now..48.hours.from_now
+    seven_day_reminder_range = 7.days.from_now.beginning_of_day..7.days.from_now.end_of_day
+
     pending
-      .where(proceeded_at: Time.zone.now..48.hours.from_now)
-      .where.not(
-        booking_request_id: ReminderActivity.pluck(:booking_request_id),
-        email: ''
-      )
+      .where(proceeded_at: two_day_reminder_range)
+      .or(where(proceeded_at: seven_day_reminder_range))
+      .where.not(email: '')
   end
 
   private

--- a/spec/features/scheduled_appointment_reminders_spec.rb
+++ b/spec/features/scheduled_appointment_reminders_spec.rb
@@ -23,13 +23,13 @@ RSpec.feature 'Scheduled appointment reminders' do
     end
   end
 
-  scenario 'it does not send a reminder if one has already been sent' do
+  scenario 'within 7 days of the appointment it does send a reminder' do
     perform_enqueued_jobs do
-      travel_to Time.zone.parse('2016-06-18 12:05') do
-        given_an_already_reminded_appointment_exists
+      travel_to Time.zone.parse('2016-06-13 12:05') do
+        given_an_unreminded_appointment_exists
         when_the_reminder_job_runs
-        then_no_email_reminder_is_delivered
-        and_no_additional_reminder_activity_is_logged
+        then_an_email_reminder_is_delivered
+        and_a_reminder_activity_is_logged
       end
     end
   end
@@ -37,13 +37,6 @@ RSpec.feature 'Scheduled appointment reminders' do
   def given_an_unreminded_appointment_exists
     @proceeded_at = Time.zone.parse('2016-06-20 12:00')
     @appointment = create(:appointment, proceeded_at: @proceeded_at)
-  end
-
-  def given_an_already_reminded_appointment_exists
-    @proceeded_at = Time.zone.parse('2016-06-20 12:00')
-    @appointment = create(:appointment, proceeded_at: @proceeded_at) do |a|
-      create(:reminder_activity, booking_request: a.booking_request)
-    end
   end
 
   def when_the_reminder_job_runs


### PR DESCRIPTION
Previously we had just sent an appointment reminder email at 48hrs
before the appointment. Sending an earlier reminder at 7-days prior to
the appointment is thought to help mitigate cancellations and no-shows
thus freeing up slots earlier for other customers.

I removed the check for an existing `ReminderActivity` instance as this
just adds further complexity for no apparent gain. The reminders have
been running for over a year and have never caused issues with regards
retries or any circumstances that would cause a customer to receive
multiple, erroneous reminders.