### PR TITLE
Add push notifications for email failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-daterangepicker'
   gem 'rails-assets-fullcalendar'
+  gem 'rails-assets-growl'
   gem 'rails-assets-mailgun-validator-jquery', '0.0.3'
+  gem 'rails-assets-pusher'
 end
 
 source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
@@ -29,6 +31,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'pg', '~> 0.21'
   gem 'plek'
   gem 'puma'
+  gem 'pusher'
   gem 'rails', '~> 5.1.2'
   gem 'rails-observers'
   gem 'sassc-rails'
@@ -44,6 +47,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
     gem 'factory_bot_rails'
     gem 'phantomjs'
     gem 'pry-byebug'
+    gem 'pusher-fake'
     gem 'rspec-rails'
     gem 'site_prism'
   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    cookiejar (0.3.3)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
       simplecov (~> 0.14.1)
@@ -93,12 +94,25 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    daemons (1.2.6)
     database_cleaner (1.6.2)
     diff-lcs (1.3)
     docile (1.1.5)
+    em-http-request (1.1.5)
+      addressable (>= 2.3.4)
+      cookiejar (!= 0.3.1)
+      em-socksify (>= 0.3)
+      eventmachine (>= 1.0.3)
+      http_parser.rb (>= 0.6.0)
+    em-socksify (0.3.2)
+      eventmachine (>= 1.0.0.beta.4)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
     email_validator (1.6.0)
       activemodel
     erubi (1.7.1)
+    eventmachine (1.2.6)
     execjs (2.7.0)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
@@ -130,6 +144,8 @@ GEM
       rails (>= 3.2.0)
     hashdiff (0.3.7)
     hashie (3.5.7)
+    http_parser.rb (0.6.0)
+    httpclient (2.8.3)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jquery-rails (4.3.1)
@@ -210,6 +226,16 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.2)
     puma (3.11.2)
+    pusher (1.3.1)
+      httpclient (~> 2.7)
+      multi_json (~> 1.0)
+      pusher-signature (~> 0.1.8)
+    pusher-fake (1.9.0)
+      em-http-request (~> 1.1)
+      em-websocket (~> 0.5)
+      multi_json (~> 1.6)
+      thin (~> 1.5)
+    pusher-signature (0.1.8)
     rack (2.0.5)
     rack-protection (2.0.0)
       rack
@@ -233,9 +259,12 @@ GEM
     rails-assets-fullcalendar (3.8.1)
       rails-assets-jquery (>= 2, < 4)
       rails-assets-moment (>= 2.9.0, < 3)
+    rails-assets-growl (1.3.5)
+      rails-assets-jquery
     rails-assets-jquery (3.3.1)
     rails-assets-mailgun-validator-jquery (0.0.3)
     rails-assets-moment (2.20.1)
+    rails-assets-pusher (4.2.2)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -351,6 +380,10 @@ GEM
       sprockets (>= 3.0.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -407,10 +440,14 @@ DEPENDENCIES
   poltergeist!
   pry-byebug!
   puma!
+  pusher!
+  pusher-fake!
   rails (~> 5.1.2)!
   rails-assets-bootstrap-daterangepicker!
   rails-assets-fullcalendar!
+  rails-assets-growl!
   rails-assets-mailgun-validator-jquery (= 0.0.3)!
+  rails-assets-pusher!
   rails-observers!
   rails_12factor!
   redis-rails!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,6 +3,9 @@
 //= require fullcalendar
 //= require bootstrap-daterangepicker
 //= require mailgun-validator-jquery
+//= require growl
+//= require pusher
+//= require planner-base
 //= require_tree .
 
 PWPlanner.poller.init();

--- a/app/assets/javascripts/modules/drop-notifications.es6
+++ b/app/assets/javascripts/modules/drop-notifications.es6
@@ -1,0 +1,28 @@
+/* global PlannerBase, Pusher */
+
+{
+  'use strict';
+
+  class DropNotifications extends PlannerBase {
+    start(el) {
+      super.start(el);
+      this.setupPusher();
+    }
+
+    setupPusher() {
+      const channel = Pusher.instance.subscribe('drop_notifications');
+
+      channel.bind(this.config.event, this.handlePushEvent.bind(this));
+
+      $(window).on('beforeunload', () => {
+        channel.unbind(this.config.event, this.handlePushEvent.bind(this));
+      });
+    }
+
+    handlePushEvent(payload) {
+      jQuery.growl.error(payload);
+    }
+  }
+
+  window.GOVUKAdmin.Modules.DropNotifications = DropNotifications;
+}

--- a/app/assets/javascripts/planner-base.es6
+++ b/app/assets/javascripts/planner-base.es6
@@ -1,0 +1,42 @@
+/*eslint-disable no-unused-vars*/
+class PlannerBase {
+/*eslint-enable no-unused-vars*/
+  start(el) {
+    this.$el = el;
+
+    this.config = $.extend(
+      true,
+      this.config || {},
+      this.getElementConfig(),
+      this.getCookieConfig()
+    );
+
+    this.saveWarningMessage = 'You have unsaved changes - Save, or undo the changes.';
+  }
+
+  getElementConfig() {
+    return this.$el.data('config');
+  }
+
+  getCookieConfig() {
+    if (this.config && this.config.cookieName) {
+      const cookieValue = GOVUKAdmin.cookie(this.config.cookieName);
+
+      if (cookieValue) {
+        return JSON.parse(cookieValue);
+      }
+    }
+
+    return {};
+  }
+
+  clearUnloadEvent() {
+    $(window).off('beforeunload');
+  }
+
+  setUnloadEvent() {
+    $(window).on('beforeunload', () => {
+      return this.saveWarningMessage;
+    });
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import 'govuk_admin_template';
 @import 'bootstrap-daterangepicker';
 @import 'fullcalendar';
+@import 'growl';
 
 @import 'helpers/**/*';
 @import 'layout/**/*';

--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -33,7 +33,8 @@ class DropForm
       booking_request
     )
 
-    DropNotificationJob.perform_later(booking_request)
+    EmailDropNotificationJob.perform_later(booking_request)
+    PusherDropNotificationJob.perform_later(booking_request)
   end
 
   private

--- a/app/helpers/pusher_helper.rb
+++ b/app/helpers/pusher_helper.rb
@@ -1,0 +1,29 @@
+module PusherHelper
+  def pusher_setup
+    return unless current_user.booking_manager?
+    return unless pusher_configured?
+
+    safe_join([pusher_script_tag, pusher_module_tag], "\n")
+  end
+
+  def pusher_configured?
+    defined?(PusherFake) || ENV['PUSHER_KEY']
+  end
+
+  def pusher_module_tag
+    config = { event: current_user.booking_location_id }
+    content_tag :div, '', data: { module: 'drop-notifications', config: config.to_json }
+  end
+
+  def pusher_script_tag
+    content_tag(:script, pusher_javascript.html_safe) # rubocop:disable Rails/OutputSafety
+  end
+
+  def pusher_javascript
+    if defined?(PusherFake)
+      %(Pusher.instance = #{PusherFake.javascript})
+    else
+      %[Pusher.instance = new Pusher("#{ENV['PUSHER_KEY']}", { cluster: "eu", encrypted: true });]
+    end
+  end
+end

--- a/app/jobs/email_drop_notification_job.rb
+++ b/app/jobs/email_drop_notification_job.rb
@@ -1,4 +1,4 @@
-class DropNotificationJob < ActiveJob::Base
+class EmailDropNotificationJob < ActiveJob::Base
   queue_as :default
 
   def perform(booking_request)

--- a/app/jobs/pusher_drop_notification_job.rb
+++ b/app/jobs/pusher_drop_notification_job.rb
@@ -1,0 +1,38 @@
+class PusherDropNotificationJob < ActiveJob::Base
+  queue_as :default
+
+  include Rails.application.routes.url_helpers
+
+  def perform(booking_request)
+    notify_booking_managers(booking_request)
+  end
+
+  private
+
+  def notify_booking_managers(booking_request)
+    channel = 'drop_notifications'
+    event = booking_request.booking_location_id
+
+    Pusher.trigger(channel, event, payload(booking_request))
+  end
+
+  def payload(booking_request)
+    {
+      title: 'Email failure', fixed: true,
+      message: payload_message(booking_request),
+      url: payload_url(booking_request)
+    }
+  end
+
+  def payload_message(booking_request)
+    "The email to #{booking_request.email} failed to send"
+  end
+
+  def payload_url(booking_request)
+    if booking_request.appointment
+      edit_appointment_path(booking_request.appointment)
+    else
+      new_booking_request_appointment_path(booking_request)
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,6 +55,7 @@
 
 <% content_for :body_end do %>
   <%= javascript_include_tag 'application' %>
+  <%= pusher_setup %>
 <% end %>
 
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/config/initializers/pusher.rb
+++ b/config/initializers/pusher.rb
@@ -1,0 +1,5 @@
+Pusher.app_id = ENV.fetch('PUSHER_APP_ID') { 'pension_wise_planner' }
+Pusher.key    = ENV.fetch('PUSHER_KEY')    { 'pusher_key' }
+Pusher.secret = ENV.fetch('PUSHER_SECRET') { 'pusher_secret' }
+
+require 'pusher-fake/support/base' if Rails.env.development?

--- a/spec/features/agent_does_not_receive_push_notifications.rb
+++ b/spec/features/agent_does_not_receive_push_notifications.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'Agent does not receive push notifications' do
+  scenario 'When placing a booking request', js: true do
+    given_the_user_identifies_as_an_agent do
+      when_they_are_placing_a_booking_request
+      then_they_are_not_connected_via_websocket
+    end
+  end
+
+  def when_they_are_placing_a_booking_request
+    @page = Pages::AgentBooking.new
+    @page.load(location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+  end
+
+  def then_they_are_not_connected_via_websocket
+    expect(page.evaluate_script('Pusher.instance')).to be_nil
+  end
+end

--- a/spec/features/booking_manager_receives_a_push_nofication_about_email_failure_spec.rb
+++ b/spec/features/booking_manager_receives_a_push_nofication_about_email_failure_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.feature 'Booking manager receives a push notification about email failure' do
+  scenario 'When viewing booking requests', js: true do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      when_the_booking_manager_views_the_booking_requests
+      then_they_are_connected_via_websocket
+      when_an_email_failure_occurs
+      then_a_growl_notification_appears
+    end
+  end
+
+  def when_the_booking_manager_views_the_booking_requests
+    @page = Pages::BookingRequests.new
+    @page.load
+  end
+
+  def then_they_are_connected_via_websocket
+    expect(connect).to eq('connected')
+  end
+
+  def when_an_email_failure_occurs
+    booking_request = create(:hackney_booking_request)
+    PusherDropNotificationJob.perform_now(booking_request)
+  end
+
+  def then_a_growl_notification_appears
+    expect(@page.growls.first.title).to have_text('Email failure')
+    expect(@page.growls.first.message).to have_text('The email to morty@example.com failed to send')
+  end
+end

--- a/spec/helpers/pusher_helper_spec.rb
+++ b/spec/helpers/pusher_helper_spec.rb
@@ -1,0 +1,173 @@
+require 'rails_helper'
+
+RSpec.describe PusherHelper do
+  module CurrentUser
+    def current_user
+      @current_user ||= FactoryBot.build_stubbed(:hackney_booking_manager)
+    end
+  end
+
+  before do
+    helper.extend(CurrentUser)
+  end
+
+  describe '#pusher_configured?' do
+    context 'when PusherFake is defined' do
+      before do
+        stub_const('PusherFake', true)
+      end
+
+      context 'and PUSHER_KEY is set' do
+        before do
+          allow(ENV).to receive(:[]).with('PUSHER_KEY').and_return('pusher_key')
+        end
+
+        it 'returns true' do
+          expect(helper.pusher_configured?).to be_truthy
+        end
+      end
+
+      context 'and PUSHER_KEY is not set' do
+        before do
+          allow(ENV).to receive(:[]).with('PUSHER_KEY').and_return(nil)
+        end
+
+        it 'returns true' do
+          expect(helper.pusher_configured?).to be_truthy
+        end
+      end
+    end
+
+    context 'when PusherFake is not defined' do
+      before do
+        hide_const('PusherFake')
+      end
+
+      context 'and PUSHER_KEY is set' do
+        before do
+          allow(ENV).to receive(:[]).with('PUSHER_KEY').and_return('pusher_key')
+        end
+
+        it 'returns true' do
+          expect(helper.pusher_configured?).to be_truthy
+        end
+      end
+
+      context 'and PUSHER_KEY is not set' do
+        before do
+          allow(ENV).to receive(:[]).with('PUSHER_KEY').and_return(nil)
+        end
+
+        it 'returns false' do
+          expect(helper.pusher_configured?).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe '#pusher_javascript' do
+    context 'when PusherFake is defined' do
+      let(:pusher_fake) do
+        Class.new do
+          def self.javascript
+            'new Pusher("pusher_key",{"wsHost":"127.0.0.1","wsPort":61336,"cluster":"us-east-1"});'
+          end
+        end
+      end
+
+      before do
+        stub_const('PusherFake', pusher_fake)
+      end
+
+      it 'returns the PusherFake javascript' do
+        expect(helper.pusher_javascript).to eq %(
+          Pusher.instance = new Pusher("pusher_key",{"wsHost":"127.0.0.1","wsPort":61336,"cluster":"us-east-1"});
+        ).strip
+      end
+    end
+
+    context 'when PusherFake is not defined' do
+      before do
+        hide_const('PusherFake')
+        allow(ENV).to receive(:[]).with('PUSHER_KEY').and_return('pusher_key')
+      end
+
+      it 'returns the real javascript' do
+        expect(helper.pusher_javascript).to eq %(
+          Pusher.instance = new Pusher("pusher_key", { cluster: "eu", encrypted: true });
+        ).strip
+      end
+    end
+  end
+
+  # rubocop:disable Metrics/LineLength
+  describe '#pusher_module_tag' do
+    it 'returns a <div> tag with the correct attributes' do
+      expect(helper.pusher_module_tag).to eq %(
+        <div data-module="drop-notifications" data-config="{&quot;event&quot;:&quot;ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef&quot;}"></div>
+      ).strip
+    end
+  end
+  # rubocop:enable Metrics/LineLength
+
+  describe '#pusher_script_tag' do
+    let(:javascript) { 'Pusher.instance = new Pusher("pusher_key", { cluster: "eu", encrypted: true });' }
+
+    before do
+      allow(helper).to receive(:pusher_javascript).and_return(javascript)
+    end
+
+    it 'returns a <script> tag with the correct javascript' do
+      expect(helper.pusher_script_tag).to eq %(
+        <script>Pusher.instance = new Pusher("pusher_key", { cluster: "eu", encrypted: true });</script>
+      ).strip
+    end
+  end
+
+  describe '#pusher_setup' do
+    context 'when pusher_configured? returns false' do
+      before do
+        allow(helper).to receive(:pusher_configured?).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(helper.pusher_setup).to be_nil
+      end
+    end
+
+    context 'when current_user is not a booking manager' do
+      before do
+        allow(helper).to receive(:pusher_configured?).and_return(true)
+        allow(helper.current_user).to receive(:booking_manager?).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(helper.pusher_setup).to be_nil
+      end
+    end
+
+    context 'when pusher is configured and the current user is a booking manager' do
+      let(:pusher_fake) do
+        Class.new do
+          def self.javascript
+            'new Pusher("pusher_key",{"wsHost":"127.0.0.1","wsPort":61336,"cluster":"us-east-1"});'
+          end
+        end
+      end
+
+      before do
+        stub_const('PusherFake', pusher_fake)
+
+        allow(helper).to receive(:pusher_configured?).and_return(true)
+        allow(helper.current_user).to receive(:booking_manager?).and_return(true)
+      end
+
+      it 'returns the module and script tags' do
+        expect(helper.pusher_setup).to eq <<~HTML.strip
+          <script>Pusher.instance = new Pusher("pusher_key",{"wsHost":"127.0.0.1","wsPort":61336,"cluster":"us-east-1"});</script>
+          <div data-module="drop-notifications" data-config="{&quot;event&quot;:&quot;ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef&quot;}"></div>
+        HTML
+      end
+    end
+  end
+end

--- a/spec/jobs/email_drop_notification_job_spec.rb
+++ b/spec/jobs/email_drop_notification_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe DropNotificationJob, '#perform' do
+RSpec.describe EmailDropNotificationJob, '#perform' do
   let(:booking_request) { create(:hackney_booking_request) }
 
   subject { described_class.new.perform(booking_request) }

--- a/spec/jobs/pusher_drop_notification_job_spec.rb
+++ b/spec/jobs/pusher_drop_notification_job_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe PusherDropNotificationJob, '#perform' do
+  context 'when the booking request has not been fulfilled' do
+    let(:booking_request) { create(:hackney_booking_request) }
+
+    it 'sends a push notification that an email failure occurred' do
+      expect(Pusher).to receive(:trigger).with(
+        'drop_notifications',
+        'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
+        title: 'Email failure', fixed: true,
+        message: 'The email to morty@example.com failed to send',
+        url: "/booking_requests/#{booking_request.id}/appointments/new"
+      )
+
+      described_class.perform_now(booking_request)
+    end
+  end
+
+  context 'when the booking request has been fulfilled' do
+    let(:appointment) { create(:appointment) }
+    let(:booking_request) { appointment.booking_request }
+
+    it 'sends a push notification that an email failure occurred' do
+      expect(Pusher).to receive(:trigger).with(
+        'drop_notifications',
+        'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
+        title: 'Email failure', fixed: true,
+        message: 'The email to morty@example.com failed to send',
+        url: "/appointments/#{appointment.id}/edit"
+      )
+
+      described_class.perform_now(booking_request)
+    end
+  end
+end

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -8,9 +8,14 @@ RSpec.describe 'POST /mail_gun/drops' do
         when_mail_gun_posts_a_drop_notification
         then_an_activity_is_created
         and_an_email_is_sent_to_the_booking_manager
+        and_a_push_notification_is_sent_to_online_booking_managers
         and_the_service_responds_ok
       end
     end
+  end
+
+  before do
+    allow(Pusher).to receive(:trigger)
   end
 
   def with_a_configured_token(token)
@@ -47,6 +52,17 @@ RSpec.describe 'POST /mail_gun/drops' do
   def and_an_email_is_sent_to_the_booking_manager
     expect(last_email.subject).to eq('Email Failure - Pension Wise Booking Request')
     expect(last_email.to).to eq(['rick@example.com'])
+  end
+
+  def and_a_push_notification_is_sent_to_online_booking_managers
+    expect(Pusher).to have_received(:trigger).with(
+      'drop_notifications',
+      'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
+      title: 'Email failure',
+      fixed: true,
+      message: 'The email to morty@example.com failed to send',
+      url: "/booking_requests/#{@booking_request.id}/appointments/new"
+    )
   end
 
   def and_the_service_responds_ok

--- a/spec/support/pages/booking_requests.rb
+++ b/spec/support/pages/booking_requests.rb
@@ -17,5 +17,10 @@ module Pages
     end
 
     element :location, '.t-location'
+
+    sections :growls, '#growls-default .growl' do
+      element :title, '.growl-title'
+      element :message, '.growl-message'
+    end
   end
 end

--- a/spec/support/pusher.rb
+++ b/spec/support/pusher.rb
@@ -1,0 +1,25 @@
+require 'pusher-fake/support/base'
+
+RSpec.configure do |config|
+  config.after(:each, type: :feature) do
+    PusherFake::Channel.reset
+  end
+end
+
+RSpec.configure do |config|
+  helpers = Module.new do
+    def connect
+      state = nil
+
+      Timeout.timeout(5) do
+        until state == 'connected'
+          state = page.evaluate_script('Pusher.instance.connection.state')
+        end
+      end
+
+      state
+    end
+  end
+
+  config.include helpers, type: :feature
+end


### PR DESCRIPTION
Using in-page growl type notifications to alert booking managers to email failures. Notifications aren't automatically dismissed but don't persist across page loads.