### PR TITLE
Fix growl issues

### DIFF
--- a/app/assets/stylesheets/components/_growl.scss
+++ b/app/assets/stylesheets/components/_growl.scss
@@ -1,0 +1,5 @@
+#growls-default {
+  .growl {
+    cursor: pointer;
+  }
+}

--- a/app/jobs/pusher_drop_notification_job.rb
+++ b/app/jobs/pusher_drop_notification_job.rb
@@ -18,7 +18,7 @@ class PusherDropNotificationJob < ActiveJob::Base
 
   def payload(booking_request)
     {
-      title: 'Email failure', fixed: true,
+      title: 'Email failure', fixed: true, delayOnHover: false,
       message: payload_message(booking_request),
       url: payload_url(booking_request)
     }

--- a/spec/jobs/pusher_drop_notification_job_spec.rb
+++ b/spec/jobs/pusher_drop_notification_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PusherDropNotificationJob, '#perform' do
       expect(Pusher).to receive(:trigger).with(
         'drop_notifications',
         'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
-        title: 'Email failure', fixed: true,
+        title: 'Email failure', fixed: true, delayOnHover: false,
         message: 'The email to morty@example.com failed to deliver',
         url: "/booking_requests/#{booking_request.id}/appointments/new"
       )
@@ -25,7 +25,7 @@ RSpec.describe PusherDropNotificationJob, '#perform' do
       expect(Pusher).to receive(:trigger).with(
         'drop_notifications',
         'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
-        title: 'Email failure', fixed: true,
+        title: 'Email failure', fixed: true, delayOnHover: false,
         message: 'The email to morty@example.com failed to deliver',
         url: "/appointments/#{appointment.id}/edit"
       )

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'POST /mail_gun/drops' do
       'drop_notifications',
       'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef',
       title: 'Email failure',
-      fixed: true,
+      fixed: true, delayOnHover: false,
       message: 'The email to morty@example.com failed to deliver',
       url: "/booking_requests/#{@booking_request.id}/appointments/new"
     )


### PR DESCRIPTION
* Growl messages were disappearing after being hovered over
* Cursor was the default even though the whole growl was clickable