### PR TITLE
Fix the 2-day range for reminders

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -55,7 +55,7 @@ class Appointment < ActiveRecord::Base
   end
 
   def self.needing_reminder # rubocop:disable AbcSize
-    two_day_reminder_range   = Time.zone.now..48.hours.from_now
+    two_day_reminder_range   = 2.days.from_now.beginning_of_day..2.days.from_now.end_of_day
     seven_day_reminder_range = 7.days.from_now.beginning_of_day..7.days.from_now.end_of_day
 
     pending

--- a/spec/features/scheduled_appointment_reminders_spec.rb
+++ b/spec/features/scheduled_appointment_reminders_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Scheduled appointment reminders' do
   scenario 'more than 48 hours before the appointment, it does not send a reminder' do
     perform_enqueued_jobs do
-      travel_to Time.zone.parse('2016-06-18 11:55') do
+      travel_to Time.zone.parse('2016-06-17 11:55') do
         given_an_unreminded_appointment_exists
         when_the_reminder_job_runs
         then_no_email_reminder_is_delivered


### PR DESCRIPTION
Now the job is moving to run once per day we should fix the range to
ensure the correct appointments are included for reminders.