### PR TITLE
Ensure 7-day reminders exclude non-pending

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -60,7 +60,7 @@ class Appointment < ActiveRecord::Base
 
     pending
       .where(proceeded_at: two_day_reminder_range)
-      .or(where(proceeded_at: seven_day_reminder_range))
+      .or(pending.where(proceeded_at: seven_day_reminder_range))
       .where.not(email: '')
   end
 

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -3,6 +3,20 @@ require 'rails_helper'
 RSpec.describe Appointment do
   subject { build_stubbed(:appointment) }
 
+  describe '.needing_reminder' do
+    context 'with an appointment 7 days in the future' do
+      it 'is included correctly based on its status' do
+        appointment = create(:appointment, proceeded_at: 7.days.from_now)
+
+        expect(described_class.needing_reminder).to include(appointment)
+
+        appointment.update(status: :cancelled_by_customer)
+
+        expect(described_class.needing_reminder).to be_empty
+      end
+    end
+  end
+
   context 'when the status changes before saving' do
     it 'stores the associated statuses' do
       appointment = create(:appointment)


### PR DESCRIPTION
This was incorrectly permitting statuses other than pending when
determining which customers to send the 7-day reminder email out to.