### PR TITLE
Display customer's selected GDPR consent

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -1,4 +1,4 @@
-class AppointmentForm
+class AppointmentForm # rubocop:disable ClassLength
   include ActiveModel::Model
   include PostalAddressable
 
@@ -12,6 +12,7 @@ class AppointmentForm
     additional_info
     agent
     address?
+    consent
   ).freeze
 
   validates :name, presence: true

--- a/app/forms/edit_appointment_form.rb
+++ b/app/forms/edit_appointment_form.rb
@@ -1,7 +1,7 @@
 class EditAppointmentForm < SimpleDelegator
   include PostalAddressable
 
-  delegate :primary_slot, :secondary_slot, :tertiary_slot, :agent, to: :booking_request
+  delegate :primary_slot, :secondary_slot, :tertiary_slot, :agent, :consent, to: :booking_request
 
   def initialize(location_aware_appointment)
     super

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -44,6 +44,10 @@ class BookingRequest < ActiveRecord::Base
     where(email: email).order(:created_at).last
   end
 
+  def consent
+    gdpr_consent.present? ? gdpr_consent.titleize : 'No response'
+  end
+
   def memorable_word(obscure: false)
     return super() unless obscure
 

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -76,8 +76,14 @@
         <% end %>
       </div>
 
+      <hr>
+      <h3 class="h4">Customer research consent:</h3>
+      <p class="lead">
+        <strong class="t-gdpr-consent"><%= @appointment_form.consent %></strong>
+      </p>
+
       <% if @appointment_form.postal_confirmation? %>
-        <hr>
+      <hr>
       <h2 class="h3">Postal address</h2>
       <%= simple_format(@appointment_form.postal_address_lines, class: 't-postal-address') %>
       <p>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -108,6 +108,7 @@
         <% end %>
       </div>
 
+      <hr>
       <h3 class="h4">Requested location:</h3>
       <p class="lead">
         <strong>
@@ -115,6 +116,12 @@
             <%= guard_missing_location(@appointment_form.location_aware_booking_request, :location_name) %>
           </a>
         </strong>
+      </p>
+
+      <hr>
+      <h3 class="h4">Customer research consent:</h3>
+      <p class="lead">
+        <strong class="t-gdpr-consent"><%= @appointment_form.consent %></strong>
       </p>
       <% if @appointment_form.postal_confirmation? %>
       <hr>

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -111,6 +111,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     expect(@page.year_of_birth.value).to eq(@appointment.date_of_birth.year.to_s)
     expect(@page.defined_contribution_pot_confirmed_yes).to be_checked
     expect(@page.accessibility_requirements.value).to eq('1')
+    expect(@page.gdpr_consent).to have_text('Yes')
 
     # ensure Hackney is pre-selected
     expect(@page.location.value).to eq('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -94,6 +94,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
     expect(@page.defined_contribution_pot_confirmed_yes).to be_checked
     expect(@page.accessibility_requirements.value).to eq('1')
     expect(@page.additional_info.value).to eq('')
+    expect(@page.gdpr_consent).to have_text('Yes')
   end
 
   def and_they_see_the_requested_slots

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -17,6 +17,7 @@ module Pages
     element :accessibility_requirements, '.t-accessibility-requirements'
     element :defined_contribution_pot_confirmed_yes, '.t-defined-contribution-pot-confirmed-yes'
     element :defined_contribution_pot_confirmed_dont_know, '.t-defined-contribution-pot-confirmed-dont-know'
+    element :gdpr_consent, '.t-gdpr-consent'
 
     element :date, '.t-date'
     element :time_hour, '#appointment_proceeded_at_4i'

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -19,6 +19,7 @@ module Pages
     element :accessibility_requirements, '.t-accessibility-requirements'
     element :defined_contribution_pot_confirmed_yes, '.t-defined-contribution-pot-confirmed-yes'
     element :defined_contribution_pot_confirmed_dont_know, '.t-defined-contribution-pot-confirmed-dont-know'
+    element :gdpr_consent, '.t-gdpr-consent'
 
     element :slot_one_date,     '.t-slot-1-date'
     element :slot_one_period,   '.t-slot-1-period'


### PR DESCRIPTION
CAB's need to see this to know what to enter into their own systems. We now
display the customer's preferences against both the booking request and
appointment.

<img width="419" alt="screen shot 2018-05-25 at 10 16 18" src="https://user-images.githubusercontent.com/41963/40536617-b3c10992-6004-11e8-9345-6f1419bb0a97.png">
