### PR TITLE
Allow weekend availability when permitted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.18.0)
+    booking_locations (0.19.0)
       activesupport (>= 4, <= 6)
       globalid
     bootsnap (1.3.0)

--- a/app/assets/javascripts/modules/availability-calendar.es6
+++ b/app/assets/javascripts/modules/availability-calendar.es6
@@ -21,7 +21,7 @@
         displayEventTime: false,
         columnFormat: 'ddd D/M',
         height: 'auto',
-        weekends: false,
+        weekends: el.data('display-weekends'),
         defaultView: 'month',
         slotDuration: '12:00:00',
         slotLabelFormat: 'A',

--- a/app/views/bookable_slots/index.html.erb
+++ b/app/views/bookable_slots/index.html.erb
@@ -19,7 +19,8 @@
   data-module="availability-calendar"
   data-default-date="<%= Time.zone.now.iso8601 %>"
   data-slots-uri="<%= bookable_slots_path(location_id: @location.id) %>"
-  data-edit-slots-uri="<%= edit_schedule_bookable_slots_path(@schedule) %>">
+  data-edit-slots-uri="<%= edit_schedule_bookable_slots_path(@schedule) %>"
+  data-display-weekends="<%= @location.online_booking_weekends? %>">
   <div
     class="modal <%= 'fade' unless Rails.env.test? %> js-availability-modal"
     tabindex="-1"

--- a/spec/features/booking_manager_manages_availability_spec.rb
+++ b/spec/features/booking_manager_manages_availability_spec.rb
@@ -8,11 +8,37 @@ RSpec.feature 'Booking manager manages availability' do
         when_they_view_their_schedules
         and_choose_to_edit_the_availability
         then_they_are_shown_the_existing_availability
+        and_they_do_not_see_weekends
         when_they_remove_a_slot
         and_they_add_another
         then_the_availability_is_affected
       end
     end
+  end
+
+  scenario 'Viewing weekend availability', js: true do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_a_schedule_with_weekends_exists
+      when_they_view_the_weekend_schedule
+      then_they_see_the_weekends
+    end
+  end
+
+  def and_a_schedule_with_weekends_exists
+    @schedule = create(:schedule, :blank, :dalston)
+  end
+
+  def when_they_view_the_weekend_schedule
+    @page = Pages::Availability.new
+    @page.load(location_id: @schedule.location_id)
+  end
+
+  def then_they_see_the_weekends
+    expect(@page).to have_text(/Sat|Sun/)
+  end
+
+  def and_they_do_not_see_weekends
+    expect(@page).to have_no_text(/Sat|Sun/)
   end
 
   def and_a_schedule_exists


### PR DESCRIPTION
When the location's `online_booking_weekends` flag is set, we need to
display Saturday/Sunday so the booking manager can assign availability
for those days. When availability exists across the weekend, this is
automatically presented for booking in the customer and agent journeys.