### PR TITLE
Correctly validate when no slots are chosen

### DIFF
--- a/app/forms/agent_booking_form.rb
+++ b/app/forms/agent_booking_form.rb
@@ -93,7 +93,7 @@ class AgentBookingForm # rubocop:disable ClassLength
   end
 
   def age
-    at = earliest_slot_time
+    return 0 unless at = earliest_slot_time
 
     date_of_birth = self.date_of_birth.in_time_zone
 

--- a/spec/forms/agent_booking_form_spec.rb
+++ b/spec/forms/agent_booking_form_spec.rb
@@ -93,6 +93,16 @@ RSpec.describe AgentBookingForm do
 
         expect(subject).to_not be_valid
       end
+
+      context 'when no slots were selected' do
+        it 'is not valid' do
+          subject.first_choice_slot  = ''
+          subject.second_choice_slot = ''
+          subject.third_choice_slot  = ''
+
+          expect(subject).to be_invalid
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Age and appointment type require at least one slot to be chosen to
correctly calculate the age at time of appointment. We need to guard
against instances when agents attempt to submit a booking without first
selecting at least one slot.