### PR TITLE
SMS reminders and cancellations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'kaminari'
   gem 'momentjs-rails'
   gem 'newrelic_rpm'
+  gem 'notifications-ruby-client'
   gem 'oj'
   gem 'pg', '~> 0.21'
   gem 'plek'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,8 @@ GEM
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    notifications-ruby-client (2.6.0)
+      jwt (>= 1.5, < 3)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
@@ -433,6 +435,7 @@ DEPENDENCIES
   lograge!
   momentjs-rails!
   newrelic_rpm!
+  notifications-ruby-client!
   oj!
   pg (~> 0.21)!
   phantomjs!

--- a/app/controllers/sms_cancellations_controller.rb
+++ b/app/controllers/sms_cancellations_controller.rb
@@ -1,0 +1,35 @@
+class SmsCancellationsController < ActionController::Base
+  wrap_parameters false
+
+  before_action :token_authenticate
+
+  def create
+    SmsCancellation.new(callback_params).call
+
+    head :no_content
+  end
+
+  private
+
+  def callback_params
+    params.permit(:source_number, :message)
+  end
+
+  def token_authenticate
+    authenticate_or_request_with_http_token do |token|
+      ActiveSupport::SecurityUtils.secure_compare(
+        ::Digest::SHA256.hexdigest(token),
+        ::Digest::SHA256.hexdigest(notify_callback_bearer_token)
+      )
+    end
+  end
+
+  def notify_callback_bearer_token
+    ENV.fetch('NOTIFY_CALLBACK_BEARER_TOKEN')
+  end
+
+  def append_info_to_payload(payload)
+    super
+    payload[:params] = request.filtered_parameters
+  end
+end

--- a/app/forms/sms_cancellation.rb
+++ b/app/forms/sms_cancellation.rb
@@ -1,0 +1,33 @@
+class SmsCancellation
+  include ActiveModel::Model
+
+  attr_accessor :source_number
+  attr_accessor :message
+
+  validates :source_number, presence: true
+  validates :message, presence: true, format: { with: /\A'?cancel'?/i }
+
+  def call
+    if valid? && appointment
+      appointment.cancel!
+      send_notifications
+    else
+      SmsCancellationFailureJob.perform_later(source_number)
+    end
+  end
+
+  private
+
+  def send_notifications
+    BookingManagerSmsCancellationJob.perform_later(appointment)
+    SmsCancellationSuccessJob.perform_later(appointment)
+  end
+
+  def appointment
+    @appointment ||= Appointment.for_sms_cancellation(normalised_source_number)
+  end
+
+  def normalised_source_number
+    source_number.sub(/\A44/, '0').delete(' ')
+  end
+end

--- a/app/jobs/booking_manager_sms_cancellation_job.rb
+++ b/app/jobs/booking_manager_sms_cancellation_job.rb
@@ -1,0 +1,19 @@
+class BookingManagerSmsCancellationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(appointment)
+    recipients = booking_managers(appointment)
+
+    recipients.each do |recipient|
+      Appointments.booking_manager_cancellation(recipient, appointment).deliver_later
+    end
+  end
+
+  private
+
+  def booking_managers(appointment)
+    User.active.where(
+      organisation_content_id: appointment.booking_request.booking_location_id
+    )
+  end
+end

--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -1,13 +1,5 @@
-require 'notifications/client'
-
-class SmsAppointmentReminderJob < ActiveJob::Base
+class SmsAppointmentReminderJob < SmsJobBase
   TEMPLATE_ID = '443d8862-3c3c-438d-8fe6-6a3e1aa539eb'.freeze
-
-  queue_as :default
-
-  rescue_from(Notifications::Client::RequestError) do |exception|
-    Bugsnag.notify(exception)
-  end
 
   def perform(appointment)
     return unless api_key
@@ -25,8 +17,6 @@ class SmsAppointmentReminderJob < ActiveJob::Base
   private
 
   def send_sms_reminder(appointment)
-    sms_client = Notifications::Client.new(api_key)
-
     sms_client.send_sms(
       phone_number: appointment.phone,
       template_id: TEMPLATE_ID,
@@ -36,9 +26,5 @@ class SmsAppointmentReminderJob < ActiveJob::Base
         location: appointment.location_name
       }
     )
-  end
-
-  def api_key
-    ENV['NOTIFY_API_KEY']
   end
 end

--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -1,0 +1,44 @@
+require 'notifications/client'
+
+class SmsAppointmentReminderJob < ActiveJob::Base
+  TEMPLATE_ID = '443d8862-3c3c-438d-8fe6-6a3e1aa539eb'.freeze
+
+  queue_as :default
+
+  rescue_from(Notifications::Client::RequestError) do |exception|
+    Bugsnag.notify(exception)
+  end
+
+  def perform(appointment)
+    return unless api_key
+
+    appointment = LocationAwareEntity.new(
+      entity: appointment,
+      booking_location: BookingLocations.find(appointment.location_id)
+    )
+
+    send_sms_reminder(appointment)
+
+    SmsReminderActivity.from(appointment)
+  end
+
+  private
+
+  def send_sms_reminder(appointment)
+    sms_client = Notifications::Client.new(api_key)
+
+    sms_client.send_sms(
+      phone_number: appointment.phone,
+      template_id: TEMPLATE_ID,
+      reference: appointment.reference,
+      personalisation: {
+        date: appointment.proceeded_at.to_s(:govuk_date_short),
+        location: appointment.location_name
+      }
+    )
+  end
+
+  def api_key
+    ENV['NOTIFY_API_KEY']
+  end
+end

--- a/app/jobs/sms_appointment_reminders_job.rb
+++ b/app/jobs/sms_appointment_reminders_job.rb
@@ -1,0 +1,9 @@
+class SmsAppointmentRemindersJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    Appointment.needing_sms_reminder.find_each do |appointment|
+      SmsAppointmentReminderJob.perform_later(appointment)
+    end
+  end
+end

--- a/app/jobs/sms_cancellation_failure_job.rb
+++ b/app/jobs/sms_cancellation_failure_job.rb
@@ -1,0 +1,13 @@
+class SmsCancellationFailureJob < SmsJobBase
+  TEMPLATE_ID = 'b0ede1e7-3855-44c6-b0d3-e2521ca3b550'.freeze
+
+  def perform(mobile_number)
+    return unless api_key
+
+    sms_client.send_sms(
+      phone_number: mobile_number,
+      template_id: TEMPLATE_ID,
+      reference: mobile_number
+    )
+  end
+end

--- a/app/jobs/sms_cancellation_success_job.rb
+++ b/app/jobs/sms_cancellation_success_job.rb
@@ -1,0 +1,13 @@
+class SmsCancellationSuccessJob < SmsJobBase
+  TEMPLATE_ID = '1cbd533d-4cae-40a6-a2b5-339af96b3c58'.freeze
+
+  def perform(appointment)
+    return unless api_key
+
+    sms_client.send_sms(
+      phone_number: appointment.phone,
+      template_id: TEMPLATE_ID,
+      reference: appointment.reference
+    )
+  end
+end

--- a/app/jobs/sms_job_base.rb
+++ b/app/jobs/sms_job_base.rb
@@ -1,0 +1,19 @@
+require 'notifications/client'
+
+class SmsJobBase < ActiveJob::Base
+  queue_as :default
+
+  rescue_from(Notifications::Client::RequestError) do |exception|
+    Bugsnag.notify(exception)
+  end
+
+  protected
+
+  def sms_client
+    @sms_client ||= Notifications::Client.new(api_key)
+  end
+
+  def api_key
+    ENV['NOTIFY_API_KEY']
+  end
+end

--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -1,4 +1,12 @@
 class Appointments < ApplicationMailer
+  def booking_manager_cancellation(booking_manager, appointment)
+    @appointment = appointment
+
+    mailgun_headers :sms_appointment_cancellation
+
+    mail(to: booking_manager.email, subject: 'Pension Wise Appointment SMS Cancellation')
+  end
+
   def customer(appointment, booking_location)
     @appointment = LocationAwareEntity.new(
       entity: appointment,

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -71,6 +71,7 @@ class Appointment < ActiveRecord::Base
     window = 2.days.from_now.beginning_of_day..2.days.from_now.end_of_day
 
     pending
+      .not_booked_today
       .where(proceeded_at: window)
       .where("phone like '07%'")
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -56,6 +56,14 @@ class Appointment < ActiveRecord::Base
     proceeded_at.in_time_zone('London').utc_offset.zero? ? 'GMT' : 'BST'
   end
 
+  def self.needing_sms_reminder
+    window = 2.days.from_now.beginning_of_day..2.days.from_now.end_of_day
+
+    pending
+      .where(proceeded_at: window)
+      .where("phone like '07%'")
+  end
+
   def self.needing_reminder # rubocop:disable AbcSize
     two_day_reminder_range   = 2.days.from_now.beginning_of_day..2.days.from_now.end_of_day
     seven_day_reminder_range = 7.days.from_now.beginning_of_day..7.days.from_now.end_of_day

--- a/app/models/sms_cancellation_activity.rb
+++ b/app/models/sms_cancellation_activity.rb
@@ -1,0 +1,5 @@
+class SmsCancellationActivity < Activity
+  def self.from(appointment)
+    create!(booking_request: appointment.booking_request, message: '')
+  end
+end

--- a/app/models/sms_reminder_activity.rb
+++ b/app/models/sms_reminder_activity.rb
@@ -1,0 +1,5 @@
+class SmsReminderActivity < Activity
+  def self.from(appointment)
+    create!(booking_request: appointment.booking_request, message: '')
+  end
+end

--- a/app/views/activities/_sms_cancellation_activity.html.erb
+++ b/app/views/activities/_sms_cancellation_activity.html.erb
@@ -1,0 +1,5 @@
+<li class="activity-feed__item t-activity" id="activity-<%= sms_cancellation_activity.id %>">
+  <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+  <strong>The customer</strong> cancelled their appointment via SMS
+  <em class="badge"><%= time_ago_in_words(sms_cancellation_activity.created_at) %> ago</em>
+</li>

--- a/app/views/activities/_sms_reminder_activity.html.erb
+++ b/app/views/activities/_sms_reminder_activity.html.erb
@@ -1,0 +1,5 @@
+<li class="activity-feed__item t-activity" id="activity-<%= sms_reminder_activity.id %>">
+  <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+  <strong>The system</strong> sent an appointment reminder SMS to the customer
+  <em class="badge"><%= time_ago_in_words(sms_reminder_activity.created_at) %> ago</em>
+</li>

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -79,6 +79,7 @@
         <div class="form-group">
           <%= f.label :phone %>
           <%= f.text_field :phone, class: 'form-control t-phone' %>
+          <div class="help-block">Pension Wise will use this to send an SMS appointment reminder by 8am - 48 hours before the appointment. Customers can cancel appointments via SMS.</div>
         </div>
         <div class="form-group">
           <%= f.label :email %>

--- a/app/views/appointments/booking_manager_cancellation.html.erb
+++ b/app/views/appointments/booking_manager_cancellation.html.erb
@@ -1,0 +1,15 @@
+<h1 style="color: #0B0C0C !important;font-family: Helvetica, Arial, sans-serif;margin: 15px 0;font-weight: 700;font-size: 20px;line-height: 1.111111111;padding: 15px 0;">
+  SMS Appointment Cancellation
+</h1>
+
+<%= p do %>
+  The customer cancelled their appointment by SMS.
+<% end %>
+
+<%= p do %>
+  Appointment reference: <%= @appointment.reference %>.
+<% end %>
+
+<%= p do %>
+  <%= link_to 'View the appointment', edit_appointment_url(@appointment) %>.
+<% end %>

--- a/app/views/appointments/booking_manager_cancellation.text.erb
+++ b/app/views/appointments/booking_manager_cancellation.text.erb
@@ -1,0 +1,7 @@
+SMS Appointment Cancellation
+
+The customer cancelled their appointment by SMS.
+
+Appointment reference: <%= @appointment.reference %>.
+
+<%= link_to 'View the appointment', edit_appointment_url(@appointment) %>.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ require 'sidekiq/web'
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
+  resources :sms_cancellations, only: :create
+
   namespace :mail_gun do
     resources :drops, only: :create
   end

--- a/spec/features/sms_appointment_reminder_spec.rb
+++ b/spec/features/sms_appointment_reminder_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature 'SMS appointment reminders' do
+  scenario 'Executing the SMS appointment reminders job' do
+    travel_to '2018-05-28 08:00 UTC' do
+      given_appointments_due_sms_reminders_exist
+      when_the_task_is_executed
+      then_the_required_jobs_are_scheduled
+    end
+  end
+
+  def given_appointments_due_sms_reminders_exist
+    # past the reminder window
+    @past = create(:appointment, proceeded_at: 5.days.from_now)
+    # in the window but no mobile number
+    @no_mobile = create(:appointment, phone: '02082524727', proceeded_at: 2.days.from_now)
+    # in the window with a mobile number
+    @mobile = create(:appointment, phone: '07715930455', proceeded_at: 2.days.from_now)
+  end
+
+  def when_the_task_is_executed
+    SmsAppointmentRemindersJob.perform_now
+  end
+
+  def then_the_required_jobs_are_scheduled
+    assert_enqueued_jobs(1, only: SmsAppointmentReminderJob)
+  end
+end

--- a/spec/features/sms_appointment_reminder_spec.rb
+++ b/spec/features/sms_appointment_reminder_spec.rb
@@ -9,13 +9,15 @@ RSpec.feature 'SMS appointment reminders' do
     end
   end
 
-  def given_appointments_due_sms_reminders_exist
+  def given_appointments_due_sms_reminders_exist # rubocop:disable AbcSize
+    # on the same day so excluded
+    @same_day = create(:appointment, proceeded_at: 2.days.from_now)
     # past the reminder window
-    @past = create(:appointment, proceeded_at: 5.days.from_now)
+    @past = create(:appointment, proceeded_at: 5.days.from_now, created_at: 1.day.ago)
     # in the window but no mobile number
-    @no_mobile = create(:appointment, phone: '02082524727', proceeded_at: 2.days.from_now)
+    @no_mobile = create(:appointment, phone: '02082524727', proceeded_at: 2.days.from_now, created_at: 1.day.ago)
     # in the window with a mobile number
-    @mobile = create(:appointment, phone: '07715930455', proceeded_at: 2.days.from_now)
+    @mobile = create(:appointment, phone: '07715930455', proceeded_at: 2.days.from_now, created_at: 1.day.ago)
   end
 
   def when_the_task_is_executed

--- a/spec/forms/sms_cancellation_spec.rb
+++ b/spec/forms/sms_cancellation_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe SmsCancellation do
+  subject { described_class.new(source_number: '07715 930 455', message: 'Cancel.') }
+
+  describe 'validation' do
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    it 'requires the `source_number`' do
+      subject.source_number = ''
+
+      expect(subject).to be_invalid
+    end
+
+    it 'requires the correct `message` for cancellation' do
+      subject.message = 'Please cancel my appointment.'
+      expect(subject).to be_invalid
+
+      subject.message = "'Cancel'"
+      expect(subject).to be_valid
+    end
+  end
+
+  describe '#call' do
+    let(:appointment) { create(:appointment, phone: '07715930455', status: :completed) }
+
+    context 'when the underlying appointment is not pending' do
+      it 'does not attempt to cancel and notifies the customer' do
+        subject.call
+
+        expect(appointment.reload).to be_completed
+
+        assert_enqueued_jobs(1, only: SmsCancellationFailureJob)
+      end
+    end
+  end
+end

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe SmsAppointmentReminderJob, '#perform' do
+  let(:appointment) { create(:appointment, phone: '07715 930 444') }
+  let(:client) { double(Notifications::Client, send_sms: true) }
+
+  it 'sends an SMS' do
+    expect(client).to receive(:send_sms).with(
+      phone_number: '07715 930 444',
+      template_id: SmsAppointmentReminderJob::TEMPLATE_ID,
+      reference: appointment.reference,
+      personalisation: {
+        date: '2:00pm, 20 Jun 2016',
+        location: 'Hackney'
+      }
+    )
+
+    described_class.new.perform(appointment)
+
+    expect(appointment.activities.first).to be_an(SmsReminderActivity)
+  end
+
+  before do
+    ENV['NOTIFY_API_KEY'] = 'blahblah'
+
+    allow(Notifications::Client).to receive(:new).and_return(client)
+  end
+
+  after do
+    ENV.delete('NOTIFY_API_KEY')
+  end
+end

--- a/spec/jobs/sms_cancellation_failure_job_spec.rb
+++ b/spec/jobs/sms_cancellation_failure_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SmsCancellationFailureJob, '#perform' do
+  let(:number) { '07715 930 455' }
+  let(:client) { double(Notifications::Client, send_sms: true) }
+
+  it 'sends an SMS' do
+    expect(client).to receive(:send_sms).with(
+      phone_number: '07715 930 455',
+      template_id: SmsCancellationFailureJob::TEMPLATE_ID,
+      reference: '07715 930 455'
+    )
+
+    described_class.new.perform(number)
+  end
+
+  before do
+    ENV['NOTIFY_API_KEY'] = 'blahblah'
+
+    allow(Notifications::Client).to receive(:new).and_return(client)
+  end
+
+  after do
+    ENV.delete('NOTIFY_API_KEY')
+  end
+end

--- a/spec/jobs/sms_cancellation_success_job_spec.rb
+++ b/spec/jobs/sms_cancellation_success_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe SmsCancellationSuccessJob, '#perform' do
+  let(:appointment) { create(:appointment, phone: '07715 930 444') }
+  let(:client) { double(Notifications::Client, send_sms: true) }
+
+  it 'sends an SMS' do
+    expect(client).to receive(:send_sms).with(
+      phone_number: '07715 930 444',
+      template_id: SmsCancellationSuccessJob::TEMPLATE_ID,
+      reference: appointment.reference
+    )
+
+    described_class.new.perform(appointment)
+  end
+
+  before do
+    ENV['NOTIFY_API_KEY'] = 'blahblah'
+
+    allow(Notifications::Client).to receive(:new).and_return(client)
+  end
+
+  after do
+    ENV.delete('NOTIFY_API_KEY')
+  end
+end

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -6,6 +6,29 @@ RSpec.describe Appointments do
   end
   let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
 
+  describe 'SMS cancellation' do
+    let(:booking_manager) { create(:hackney_booking_manager) }
+
+    subject(:mail) { described_class.booking_manager_cancellation(booking_manager, appointment) }
+
+    it_behaves_like 'mailgun identified email'
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Pension Wise Appointment SMS Cancellation')
+      expect(mail.to).to eq([booking_manager.email])
+      expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+    end
+
+    describe 'rendering the body' do
+      let(:body) { subject.body.encoded }
+
+      it 'includes the appointment particulars' do
+        expect(body).to include(appointment.reference)
+        expect(body).to include("/appointments/#{appointment.id}/edit")
+      end
+    end
+  end
+
   describe 'Customer reminder' do
     subject(:mail) { described_class.reminder(appointment, hackney) }
 

--- a/spec/requests/sms_cancellation_callback_spec.rb
+++ b/spec/requests/sms_cancellation_callback_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+require 'securerandom'
+
+RSpec.describe 'POST /sms_cancellations', type: :request do
+  scenario 'unauthorised access' do
+    when_the_client_makes_an_unauthorised_request
+    then_the_service_does_not_grant_access
+  end
+
+  scenario 'successfully cancelling an existing appointment' do
+    given_a_pending_appointment_exists
+    when_the_client_requests_cancellation_by_sms
+    then_the_service_responds_no_content
+    and_the_appointment_is_cancelled
+    and_a_cancellation_activity_is_created
+    and_the_customer_is_sent_a_confirmation_sms
+    and_the_booking_managers_are_notified_by_email
+  end
+
+  def given_a_pending_appointment_exists
+    @appointment = create(:appointment, phone: '07715930455')
+  end
+
+  def when_the_client_requests_cancellation_by_sms
+    ENV['NOTIFY_CALLBACK_BEARER_TOKEN'] = 'deadbeef'
+
+    token   = ActionController::HttpAuthentication::Token.encode_credentials('deadbeef')
+    headers = { 'HTTP_AUTHORIZATION' => token, 'CONTENT_TYPE' => 'application/json' }
+    payload = { 'source_number' => '447715 930 455', 'message' => 'Cancel' }
+
+    post sms_cancellations_path, params: payload.to_json, headers: headers
+  end
+
+  def then_the_service_responds_no_content
+    expect(response).to be_no_content
+  end
+
+  def and_the_appointment_is_cancelled
+    @appointment.reload
+
+    expect(@appointment).to be_cancelled_by_customer_sms
+  end
+
+  def and_a_cancellation_activity_is_created
+    expect(@appointment.activities.first).to be_an(SmsCancellationActivity)
+  end
+
+  def and_the_customer_is_sent_a_confirmation_sms
+    assert_enqueued_jobs(1, only: SmsCancellationSuccessJob)
+  end
+
+  def and_the_booking_managers_are_notified_by_email
+    assert_enqueued_jobs(1, only: BookingManagerSmsCancellationJob)
+  end
+
+  def when_the_client_makes_an_unauthorised_request
+    ENV['NOTIFY_CALLBACK_BEARER_TOKEN'] = 'welp'
+    token = ActionController::HttpAuthentication::Token.encode_credentials('deadbeef')
+
+    post sms_cancellations_path, headers: { 'HTTP_AUTHORIZATION' => token }
+  end
+
+  def then_the_service_does_not_grant_access
+    expect(response.location).to end_with('/auth/gds')
+  end
+end


### PR DESCRIPTION
Handle SMS cancellation requests

The customer can reply to their SMS reminder and cancel the appointment.
When this happens, the appointment is cancelled, the activity feed is
updated and the booking managers are notified.

Send SMS reminders 48hr before appointment

Sends an SMS reminder to the customer at 48hrs before their appointment is
due to proceed. Adds an activity in the feed for tracking, also allows the
customer to reply 'Cancel' for cancellation.