### PR TITLE
Administrator quick appointment search

### DIFF
--- a/app/assets/javascripts/modules/quick-search.es6
+++ b/app/assets/javascripts/modules/quick-search.es6
@@ -1,0 +1,21 @@
+{
+  'use strict';
+
+  class QuickSearch {
+    start(el) {
+      this.$el = $(el);
+      this.$button = this.$el.find('.js-quick-search-button');
+      this.$input = this.$el.find('.js-quick-search-input');
+
+      this.bindEvents();
+    }
+
+    bindEvents() {
+      this.$button.on('click', () => {
+        setTimeout(() => this.$input.focus(), 0); // next tick
+      });
+    }
+  }
+
+  window.GOVUKAdmin.Modules.QuickSearch = QuickSearch;
+}

--- a/app/assets/stylesheets/components/_quick-search.scss
+++ b/app/assets/stylesheets/components/_quick-search.scss
@@ -1,0 +1,13 @@
+.quick-search__dropdown {
+  box-sizing: border-box;
+  padding: 8px;
+  white-space: nowrap;
+}
+
+.quick-search__input {
+  font-weight: normal;
+}
+
+.quick-search__label {
+  margin-bottom: 0;
+}

--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -1,0 +1,23 @@
+module Admin
+  class SearchesController < ApplicationController
+    before_action { authorise_user!(User::ADMINISTRATOR_PERMISSION) }
+
+    def show
+      if @appointment = Appointment.find_by(booking_request_id: params[:id])
+        assign!(@appointment)
+
+        redirect_to edit_appointment_path(@appointment)
+      else
+        redirect_back warning: "The appointment '#{params[:id]}' could not be found.", fallback_location: root_path
+      end
+    end
+
+    private
+
+    def assign!(appointment)
+      current_user.update!(
+        organisation_content_id: appointment.booking_location_id
+      )
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  add_flash_types :success
+  add_flash_types :success, :warning
 
   include GDS::SSO::ControllerMethods
   include LogrageFilterer

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -18,7 +18,7 @@ class Appointment < ActiveRecord::Base
   belongs_to :booking_request
   has_many :status_transitions
 
-  delegate :reference, :activities, :agent_id?, to: :booking_request
+  delegate :reference, :activities, :agent_id?, :booking_location_id, to: :booking_request
 
   validates :name, presence: true
   validates :email, presence: true, email: true, unless: :agent_id?

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -35,7 +35,7 @@ class BookingRequest < ActiveRecord::Base
   alias reference to_param
 
   scope :placed_by_agents, lambda {
-    includes(:slots)
+    includes(:slots, :agent)
       .where.not(agent_id: nil)
       .order(:created_at)
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ActiveRecord::Base
 
   def unfulfilled_booking_requests
     booking_requests
-      .includes(:appointment)
+      .includes(:appointment, :slots)
       .where(appointments: { booking_request_id: nil })
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,24 @@
   <% end %>
 
   <% if current_user.administrator? %>
+    <li class="dropdown quick-search t-quick-search" data-module="quick-search">
+      <a href="#" class="dropdown-toggle js-quick-search-button" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+        <span class="sr-only">Find an appointment by reference</span>
+        <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+        <span class="caret"></span>
+      </a>
+      <div class="dropdown-menu quick-search__dropdown">
+        <form method="get" action="/admin/search" class="form-inline">
+          <div class="form-group quick-search__form-group">
+            <label for="quick-search-input" class="quick-search__label"><span class="sr-only">Reference</span>
+              <input type="text" id="quick-search-input" class="form-control input-sm quick-search__input js-quick-search-input" name="id" placeholder="Reference">
+            </label>
+          </div>
+          <input type="submit" class="quick-search__button btn btn-primary btn-xs t-quick-search-button" value="Search">
+        </form>
+      </div>
+    </li>
+
     <%= form_for current_user, html: { class: 'navbar-form navbar-right js-location-form' } do |f| %>
       <div class="form-group">
         <%= f.select :organisation_content_id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,10 @@ Rails.application.routes.draw do
     resources :booking_requests, only: :index, as: :search
   end
 
+  namespace :admin, path: '/admin' do
+    resource :search, only: :show
+  end
+
   root 'home#index'
 
   namespace :api, constraints: { format: :json } do

--- a/spec/features/administrator_searches_for_an_appointment_spec.rb
+++ b/spec/features/administrator_searches_for_an_appointment_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.feature 'Administrator searches for an appointment', js: true do
+  scenario 'Viewing as a less-privileged user' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      then_they_do_not_see_the_search_bar
+    end
+  end
+
+  scenario 'Viewing an appointment', js: true do
+    given_the_user_identifies_as_hackneys_administrator do
+      when_they_search_for_an_appointment
+      then_they_are_presented_with_the_appointment
+    end
+  end
+
+  def when_they_search_for_an_appointment
+    @appointment = create(:appointment)
+
+    visit '/'
+    find(:css, '.t-quick-search').click
+    fill_in 'quick-search-input', with: @appointment.reference
+    find(:css, '.t-quick-search-button').click
+  end
+
+  def then_they_are_presented_with_the_appointment
+    expect(page.current_path).to eq(edit_appointment_path(@appointment))
+  end
+
+  def then_they_do_not_see_the_search_bar
+    visit '/'
+
+    expect(page).to have_no_css('.t-quick-search')
+  end
+end


### PR DESCRIPTION
Allows administrators to quickly search for appointments by reference,
regardless of whether they are assigned to the particular delivery centre.