### PR TITLE
Do not send email reminders upon booking

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -30,6 +30,8 @@ class Appointment < ActiveRecord::Base
   validates :guider_id, presence: true
   validate  :validate_proceeded_at
 
+  scope :not_booked_today, -> { where.not(created_at: Time.current.beginning_of_day..Time.current.end_of_day) }
+
   def updated?
     audits.present?
   end
@@ -59,6 +61,7 @@ class Appointment < ActiveRecord::Base
     seven_day_reminder_range = 7.days.from_now.beginning_of_day..7.days.from_now.end_of_day
 
     pending
+      .not_booked_today
       .where(proceeded_at: [two_day_reminder_range, seven_day_reminder_range])
       .where.not(email: '')
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -59,8 +59,7 @@ class Appointment < ActiveRecord::Base
     seven_day_reminder_range = 7.days.from_now.beginning_of_day..7.days.from_now.end_of_day
 
     pending
-      .where(proceeded_at: two_day_reminder_range)
-      .or(pending.where(proceeded_at: seven_day_reminder_range))
+      .where(proceeded_at: [two_day_reminder_range, seven_day_reminder_range])
       .where.not(email: '')
   end
 

--- a/spec/features/scheduled_appointment_reminders_spec.rb
+++ b/spec/features/scheduled_appointment_reminders_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'Scheduled appointment reminders' do
 
   def given_an_unreminded_appointment_exists
     @proceeded_at = Time.zone.parse('2016-06-20 12:00')
-    @appointment = create(:appointment, proceeded_at: @proceeded_at)
+    @appointment = create(:appointment, proceeded_at: @proceeded_at, created_at: 1.day.ago)
   end
 
   def when_the_reminder_job_runs

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -6,13 +6,19 @@ RSpec.describe Appointment do
   describe '.needing_reminder' do
     context 'with an appointment 7 days in the future' do
       it 'is included correctly based on its status' do
-        appointment = create(:appointment, proceeded_at: 7.days.from_now)
+        appointment = create(:appointment, proceeded_at: 7.days.from_now, created_at: 1.day.ago)
 
         expect(described_class.needing_reminder).to include(appointment)
 
         appointment.update(status: :cancelled_by_customer)
 
         expect(described_class.needing_reminder).to be_empty
+      end
+
+      it 'excludes appointments created the same day' do
+        appointment = create(:appointment, proceeded_at: 7.days.from_now)
+
+        expect(described_class.needing_reminder).to_not include(appointment)
       end
     end
   end


### PR DESCRIPTION
Guards against the sending of email reminders on the same day as
appointments are booked. We already send a confirmation so the reminder
would be redundant.