### PR TITLE
Rename from 'Appointment Planner'

### DIFF
--- a/app/views/agent/booking_requests/index.html.erb
+++ b/app/views/agent/booking_requests/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: 'Teleperformance booking requests')) %>
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><%= link_to 'Appointment planner', root_path %></li>
+    <li><%= link_to 'Planner', root_path %></li>
     <li class="active">Teleperformance booking requests</li>
   </ol>
 

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li><a href="<%= root_path %>">Booking requests</a></li>
     <li class="active"><%= location.name %></li>
   </ol>

--- a/app/views/agent/booking_requests/show.html.erb
+++ b/app/views/agent/booking_requests/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li><a href="<%= root_path %>">Booking requests</a></li>
     <li class="active"><%= location.name %></li>
   </ol>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -18,7 +18,7 @@
 
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li><a href="<%= appointments_path %>">Appointments</a></li>
     <li class="active"><%= @appointment_form.name %></li>
   </ol>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: 'Appointments')) %>
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li class="active">Appointments</li>
   </ol>
 

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -46,7 +46,7 @@
 
   <div class="page-header">
     <ol class="breadcrumb">
-      <li><a href="<%= root_path %>">Appointment planner</a></li>
+      <li><a href="<%= root_path %>">Planner</a></li>
       <li><a href="<%= root_path %>">Booking requests</a></li>
       <li class="active"><%= @appointment_form.name %></li>
     </ol>

--- a/app/views/bookable_slots/index.html.erb
+++ b/app/views/bookable_slots/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: 'Availability')) %>
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li><%= link_to 'Schedules', schedules_path %></li>
     <li class="active">Availability for <%= @location.name %></li>
   </ol>

--- a/app/views/booking_requests/index.html.erb
+++ b/app/views/booking_requests/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: 'Booking requests')) %>
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><%= link_to 'Appointment planner', root_path %></li>
+    <li><%= link_to 'Planner', root_path %></li>
     <li class="active">Booking requests</li>
   </ol>
 

--- a/app/views/changes/index.html.erb
+++ b/app/views/changes/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: "Changes for appointment #{@appointment.name}")) %>
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li><a href="<%= appointments_path %>">Appointments</a></li>
     <li><%= link_to @appointment.name, edit_appointment_path(@appointment) %></li>
     <li class="active">Changes</li>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: 'Place a booking request')) %>
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li class="active">Place a booking request</li>
   </ol>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 <% end %>
 
 <%= content_for :app_title do %>
-  Appointment Planner
+  Planner
 <% end %>
 
 <%= content_for :navbar_items do %>

--- a/app/views/postal_addresses/edit.html.erb
+++ b/app/views/postal_addresses/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <% if @booking_request.appointment %>
       <li><a href="<%= appointments_path %>">Appointments</a></li>
       <li><a href="<%= edit_appointment_path(@booking_request.appointment) %>"><%= @booking_request.name %></a></li>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: 'Schedules')) %>
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li class="active">Schedules</li>
   </ol>
 

--- a/app/views/schedules/new.html.erb
+++ b/app/views/schedules/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:page_title, t('service.title', page_title: "Edit schedule for #{@location.name}")) %>
 <div class="page-header">
   <ol class="breadcrumb">
-    <li><a href="<%= root_path %>">Appointment planner</a></li>
+    <li><a href="<%= root_path %>">Planner</a></li>
     <li><a href="<%= schedules_path %>">Schedules</a></li>
     <li class="active">Edit schedule for <%= @location.name %></li>
   </ol>

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,7 +1,7 @@
 GovukAdminTemplate.environment_style = Rails.env.staging? ? 'preview' : ENV['RAILS_ENV']
 
 GovukAdminTemplate.configure do |c|
-  c.app_title = 'Appointment Planner'
+  c.app_title = 'Planner'
   c.show_flash = true
   c.show_signout = true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
       is_true: "Requested, please discuss with customer"
       is_false: "Not requested"
   service:
-    title: '%{page_title} - Appointment Planner'
+    title: '%{page_title} - Planner'
 
   booking_request:
     status_descriptions:


### PR DESCRIPTION
We've never referred to this system as 'Appointment Planner' in comms
or otherwise, free up valuable real-estate in the navigation
bar and make the naming consistent with code artifacts.