### PR TITLE
Allow booking managers to resend confirmations

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,13 @@
+class ConfirmationsController < ApplicationController
+  def create
+    @booking_request = current_user.booking_requests.find(params[:booking_request_id])
+
+    if @booking_request.appointment
+      AppointmentChangeNotificationJob.perform_later(@booking_request.appointment, false)
+    else
+      CustomerConfirmationJob.perform_later(@booking_request)
+    end
+
+    redirect_back success: 'The confirmation was re-sent successfully.', fallback_location: root_path
+  end
+end

--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -13,6 +13,7 @@ class AppointmentForm # rubocop:disable ClassLength
     agent
     address?
     consent
+    email?
   ).freeze
 
   validates :name, presence: true

--- a/app/jobs/appointment_change_notification_job.rb
+++ b/app/jobs/appointment_change_notification_job.rb
@@ -1,13 +1,13 @@
 class AppointmentChangeNotificationJob < ActiveJob::Base
   queue_as :default
 
-  def perform(appointment)
+  def perform(appointment, log_activity = true)
     return unless appointment.email?
 
     booking_location = BookingLocations.find(appointment.location_id)
 
     Appointments.customer(appointment, booking_location).deliver
 
-    AppointmentMailActivity.from(appointment)
+    AppointmentMailActivity.from(appointment) if log_activity
   end
 end

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -34,63 +34,75 @@
   booking_request: @appointment_form.booking_request
 } %>
 
-<%= form_for @appointment_form do |f| %>
-  <div class="row">
-    <div class="col-md-4">
-      <h2 class="h3">Requested appointment</h2>
-      <p>The customer has requested the following time slots, in order of preference.</p>
+<div class="row">
+  <div class="col-md-4">
+    <h2 class="h3">Requested appointment</h2>
+    <p>The customer has requested the following time slots, in order of preference.</p>
 
-      <div class="is-chosen SlotPicker--selected">
-        <div class="SlotPicker-choice is-chosen">
-          <div class="SlotPicker-choiceInner">
-            <div class="SlotPicker-position"><span>1</span></div>
-            <div class="SlotPicker-choiceContent">
-              <p class="SlotPicker-date t-slot-1-date"><%= @appointment_form.primary_slot.formatted_date %></p>
-              <p class="SlotPicker-time t-slot-1-period"><%= @appointment_form.primary_slot.period %></p>
-            </div>
+    <div class="is-chosen SlotPicker--selected">
+      <div class="SlotPicker-choice is-chosen">
+        <div class="SlotPicker-choiceInner">
+          <div class="SlotPicker-position"><span>1</span></div>
+          <div class="SlotPicker-choiceContent">
+            <p class="SlotPicker-date t-slot-1-date"><%= @appointment_form.primary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-1-period"><%= @appointment_form.primary_slot.period %></p>
           </div>
         </div>
-
-        <% if @appointment_form.secondary_slot %>
-        <div class="SlotPicker-choice is-chosen">
-          <div class="SlotPicker-choiceInner">
-            <div class="SlotPicker-position"><span>2</span></div>
-            <div class="SlotPicker-choiceContent">
-              <p class="SlotPicker-date t-slot-2-date"><%= @appointment_form.secondary_slot.formatted_date %></p>
-              <p class="SlotPicker-time t-slot-2-period"><%= @appointment_form.secondary_slot.period %></p>
-            </div>
-          </div>
-        </div>
-        <% end %>
-
-        <% if @appointment_form.tertiary_slot %>
-        <div class="SlotPicker-choice is-chosen">
-          <div class="SlotPicker-choiceInner">
-            <div class="SlotPicker-position"><span>3</span></div>
-            <div class="SlotPicker-choiceContent">
-              <p class="SlotPicker-date t-slot-3-date"><%= @appointment_form.tertiary_slot.formatted_date %></p>
-              <p class="SlotPicker-time t-slot-3-period"><%= @appointment_form.tertiary_slot.period %></p>
-            </div>
-          </div>
-        </div>
-        <% end %>
       </div>
 
-      <hr>
-      <h3 class="h4">Customer research consent:</h3>
-      <p class="lead">
-        <strong class="t-gdpr-consent"><%= @appointment_form.consent %></strong>
-      </p>
+      <% if @appointment_form.secondary_slot %>
+      <div class="SlotPicker-choice is-chosen">
+        <div class="SlotPicker-choiceInner">
+          <div class="SlotPicker-position"><span>2</span></div>
+          <div class="SlotPicker-choiceContent">
+            <p class="SlotPicker-date t-slot-2-date"><%= @appointment_form.secondary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-2-period"><%= @appointment_form.secondary_slot.period %></p>
+          </div>
+        </div>
+      </div>
+      <% end %>
 
-      <% if @appointment_form.postal_confirmation? %>
-      <hr>
-      <h2 class="h3">Postal address</h2>
-      <%= simple_format(@appointment_form.postal_address_lines, class: 't-postal-address') %>
-      <p>
-        <small><%= link_to 'Edit', edit_booking_request_postal_address_path(@appointment_form.booking_request), class: 't-edit-postal-address' %></small>
-      </p>
+      <% if @appointment_form.tertiary_slot %>
+      <div class="SlotPicker-choice is-chosen">
+        <div class="SlotPicker-choiceInner">
+          <div class="SlotPicker-position"><span>3</span></div>
+          <div class="SlotPicker-choiceContent">
+            <p class="SlotPicker-date t-slot-3-date"><%= @appointment_form.tertiary_slot.formatted_date %></p>
+            <p class="SlotPicker-time t-slot-3-period"><%= @appointment_form.tertiary_slot.period %></p>
+          </div>
+        </div>
+      </div>
       <% end %>
     </div>
+
+    <hr>
+    <h3 class="h4">Customer research consent:</h3>
+    <p class="lead">
+      <strong class="t-gdpr-consent"><%= @appointment_form.consent %></strong>
+    </p>
+
+    <% if @appointment_form.postal_confirmation? %>
+    <hr>
+    <h2 class="h3">Postal address</h2>
+    <%= simple_format(@appointment_form.postal_address_lines, class: 't-postal-address') %>
+    <p>
+      <small><%= link_to 'Edit', edit_booking_request_postal_address_path(@appointment_form.booking_request), class: 't-edit-postal-address' %></small>
+    </p>
+    <% end %>
+
+    <% if @appointment_form.email? %>
+      <hr>
+      <%= button_to(
+            'Resend email confirmation',
+            booking_request_confirmation_path(@appointment_form.booking_request),
+            class: 'btn btn-default btn-block t-resend-confirmation',
+            data: { confirm: 'Are you sure?' }
+        )
+      %>
+    <% end %>
+  </div>
+
+  <%= form_for @appointment_form do |f| %>
     <div class="col-md-8 l-appointment-details">
       <div class="well">
         <% if @appointment_form.errors.any? %>
@@ -192,5 +204,5 @@
         </div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -135,6 +135,15 @@
       <button type="button" class="btn btn-default btn-block booking-request-status-btn js-booking-request-change-status-button t-booking-request-change-state-button">
         Change booking request status
       </button>
+      <% if @appointment_form.email? %>
+        <%= button_to(
+              'Resend email confirmation',
+              booking_request_confirmation_path(@appointment_form.booking_request),
+              class: 'btn btn-default btn-block t-resend-confirmation',
+              data: { confirm: 'Are you sure?' }
+          )
+        %>
+      <% end %>
     </div>
 
     <%= form_for @appointment_form,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
     resources :appointments, only: %i(new create)
 
     resource :postal_address, only: %i(edit update)
+
+    resource :confirmation, only: :create
   end
 
   resources :schedules, only: %i(index new create) do

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -2,6 +2,16 @@
 require 'rails_helper'
 
 RSpec.feature 'Booking Manager edits an Appointment' do
+  scenario 'Resending the appointment confirmation', js: true do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_is_an_appointment
+      when_the_booking_manager_edits_the_appointment
+      then_the_appointment_details_are_presented
+      when_they_resend_the_confirmation
+      then_the_confirmation_is_sent
+    end
+  end
+
   scenario 'Viewing the full changes' do
     given_the_user_identifies_as_hackneys_booking_manager do
       and_there_is_an_appointment_with_changes
@@ -45,6 +55,16 @@ RSpec.feature 'Booking Manager edits an Appointment' do
         and_the_customer_is_not_notified
       end
     end
+  end
+
+  def when_they_resend_the_confirmation
+    @page.accept_confirm do
+      @page.resend_confirmation.click
+    end
+  end
+
+  def then_the_confirmation_is_sent
+    assert_enqueued_jobs(1, only: AppointmentChangeNotificationJob)
   end
 
   def and_there_is_an_appointment_with_changes

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -2,6 +2,16 @@
 require 'rails_helper'
 
 RSpec.feature 'Fulfiling Booking Requests' do
+  scenario 'Bookings manager re-sends the customer confirmation email', js: true do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_is_an_unfulfilled_booking_request
+      when_the_booking_manager_attempts_to_fulfil
+      then_they_are_shown_the_fulfilment_page
+      when_they_resend_the_customer_confirmation_email
+      then_the_customer_is_sent_the_email
+    end
+  end
+
   scenario 'Bookings manager attempts to fulfil with a hidden location' do
     given_the_user_identifies_as_hackneys_booking_manager do
       and_there_is_an_unfulfilled_booking_request
@@ -59,6 +69,16 @@ RSpec.feature 'Fulfiling Booking Requests' do
         then_they_see_the_validation_messages
       end
     end
+  end
+
+  def when_they_resend_the_customer_confirmation_email
+    @page.accept_confirm do
+      @page.resend_confirmation.click
+    end
+  end
+
+  def then_the_customer_is_sent_the_email
+    assert_enqueued_jobs(1, only: CustomerConfirmationJob)
   end
 
   def when_they_change_the_chosen_location_to_a_hidden_one

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -31,6 +31,7 @@ module Pages
     element :slot_three_period, '.t-slot-3-period'
 
     element :submit, '.t-submit'
+    element :resend_confirmation, '.t-resend-confirmation'
 
     element :postal_address, '.t-postal-address'
     element :edit_postal_address, '.t-edit-postal-address'

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -37,6 +37,7 @@ module Pages
     element :time_minute, '#appointment_time_5i'
 
     element :change_booking_state, '.t-booking-request-change-state-button'
+    element :resend_confirmation, '.t-resend-confirmation'
 
     element :booking_request_active_status, '.t-booking-request-active-status'
     element :booking_request_awaiting_customer_status, '.t-booking-request-awaiting-customer-feedback-status'


### PR DESCRIPTION
Booking managers can now resend email confirmations at either the
booking request or appointment stage when the booking has an associated
email address.