### PR TITLE
Revert "Remove N+1 query on booking request slots"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ActiveRecord::Base
 
   def unfulfilled_booking_requests
     booking_requests
-      .includes(:appointment, :slots)
+      .includes(:appointment)
       .where(appointments: { booking_request_id: nil })
   end
 


### PR DESCRIPTION
This reverts commit 0d1da14eadf7953b33d88fcbc190bfe3a08ba235.

When eager-loading the associated slots, the `order` clause on the
`slots` association is ignored. I'll revert this now for a quick fix
and follow up with better specs to catch this next time.