### PR TITLE
Bump `booking_locations`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    booking_locations (0.19.0)
+    booking_locations (0.20.0)
       activesupport (>= 4, <= 6)
       globalid
     bootsnap (1.3.0)


### PR DESCRIPTION
This stops API timeouts being swallowed at the adapter level.