### PR TITLE
Do not prefill appointment date during fulfilment

### DIFF
--- a/app/assets/javascripts/date-time-picker.js
+++ b/app/assets/javascripts/date-time-picker.js
@@ -7,6 +7,7 @@
       this.config = $.extend(
         true,
         {
+          autoUpdateInput: false,
           singleDatePicker: true,
           locale: {
             format: 'DD MMMM YYYY'

--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -1,4 +1,4 @@
-class AppointmentForm # rubocop:disable ClassLength
+class AppointmentForm
   include ActiveModel::Model
   include PostalAddressable
 
@@ -76,10 +76,6 @@ class AppointmentForm # rubocop:disable ClassLength
 
   def location_id
     @location_id ||= location_aware_booking_request.location_id
-  end
-
-  def date
-    @date ||= location_aware_booking_request.primary_slot.date
   end
 
   def time

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -213,7 +213,7 @@
 
             <div class="form-group">
               <%= f.label :date %>
-              <%= f.text_field :date, class: 'js-date-time-picker t-date form-control', value: @appointment_form.date.to_date.to_s(:govuk_date) %>
+              <%= f.text_field :date, class: 'js-date-time-picker t-date form-control', value: @appointment_form.date %>
             </div>
 
             <div class="form-group form-group--time">

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -153,8 +153,6 @@ RSpec.feature 'Fulfiling Booking Requests' do
   end
 
   def and_the_time_and_date_of_the_appointment
-    # ensure date defaults to primary slot date
-    expect(@page.date.value).to eq(@booking_request.primary_slot.date.strftime('%d %B %Y'))
     # refine to 2016-06-20
     @page.advance_date!
 

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -128,12 +128,6 @@ RSpec.describe AppointmentForm do
     expect(subject.agent).to eq(booking_request.agent)
   end
 
-  describe '#date' do
-    it 'defaults to the primary slot date' do
-      expect(subject.date).to eq(booking_request.primary_slot.date)
-    end
-  end
-
   describe '#time' do
     context 'when provided with params' do
       let(:params) { Hash['time(4i)' => '13', 'time(5i)' => '00'] }

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -54,7 +54,7 @@ module Pages
     section :activity_feed, Sections::ActivityFeed, '.t-activity-feed'
 
     def advance_date!
-      chosen_date = Date.parse(date.value)
+      chosen_date = date.value ? date.value.to_date : Date.current
 
       date.set(chosen_date.advance(days: 1))
     end


### PR DESCRIPTION
Per the title, booking managers have asked that we don't prefill the
appointment date with the primary slot, during fulfilment.