### PR TITLE
Don't preselect slot time either

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -31,6 +31,7 @@ class AppointmentForm
   validate :validate_not_with_an_existing_booking_request
 
   attr_reader :location_aware_booking_request
+  attr_reader :time
   alias booking_request location_aware_booking_request
 
   attr_accessor :name
@@ -78,12 +79,6 @@ class AppointmentForm
     @location_id ||= location_aware_booking_request.location_id
   end
 
-  def time
-    @time ||= location_aware_booking_request.primary_slot.delimited_from
-
-    Time.zone.parse(@time)
-  end
-
   def additional_info
     @additional_info ||= location_aware_booking_request.additional_info
   end
@@ -123,6 +118,6 @@ class AppointmentForm
     hour   = params.delete('time(4i)')
     minute = params.delete('time(5i)')
 
-    @time = "#{hour}:#{minute}" if hour && minute
+    @time = Time.zone.parse("#{hour}:#{minute}") if hour && minute
   end
 end

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -213,7 +213,7 @@
 
             <div class="form-group">
               <%= f.label :date %>
-              <%= f.text_field :date, class: 'js-date-time-picker t-date form-control', value: @appointment_form.date %>
+              <%= f.text_field :date, class: 'js-date-time-picker t-date form-control', value: @appointment_form.date, autocomplete: 'nope' %>
             </div>
 
             <div class="form-group form-group--time">
@@ -221,6 +221,7 @@
               <div class="form-control">
                 <%= f.time_select(
                   :time,
+                  prompt: true,
                   ignore_date: true,
                   minute_step: 15,
                   start_hour: 8,

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -155,9 +155,6 @@ RSpec.feature 'Fulfiling Booking Requests' do
   def and_the_time_and_date_of_the_appointment
     # refine to 2016-06-20
     @page.advance_date!
-
-    # ensure time defaults to primary slot time
-    expect(@page.time).to eq('09:00')
     # refine time
     @page.set_time(hour: 15, minute: 30)
   end

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -136,12 +136,6 @@ RSpec.describe AppointmentForm do
         expect(subject.time.strftime('%H:%M')).to eq('13:00')
       end
     end
-
-    context 'when no params are provided' do
-      it 'defaults to the primary slot start time' do
-        expect(subject.time.strftime('%H:%M')).to eq(booking_request.primary_slot.delimited_from)
-      end
-    end
   end
 
   describe '#location_id' do

--- a/spec/support/pages/fulfil_booking_request.rb
+++ b/spec/support/pages/fulfil_booking_request.rb
@@ -60,8 +60,8 @@ module Pages
     end
 
     def set_time(hour:, minute:)
-      time_hour.set(hour)
-      time_minute.set(minute)
+      time_hour.select(hour)
+      time_minute.select(minute)
     end
 
     def time


### PR DESCRIPTION
We recently changed the fulfilment process to not preselect the primary
slot date. Booking managers have further requested we apply the same
logic to the slot time.

We also stop the date field from autocompleting, thus stopping the
prior values from obscuring the JS date picker component when both are
displayed together.