### PR TITLE
Format phone numbers with a leading '0'

### DIFF
--- a/app/models/location_aware_entity.rb
+++ b/app/models/location_aware_entity.rb
@@ -6,7 +6,9 @@ class LocationAwareEntity < SimpleDelegator
     super(entity)
   end
 
-  delegate :online_booking_twilio_number, to: :actual_location
+  def online_booking_twilio_number
+    actual_location&.online_booking_twilio_number.to_s.sub(/^\+44/, '0')
+  end
 
   def location_name
     actual_location.name

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Appointments do
         expect(body).to include('2:00pm')
         expect(body).to include('20 June 2016')
         expect(body).to include('Dalston')
-        expect(body).to include('+44800123456')
+        expect(body).to include('0800123456')
         expect(body).to include(appointment.reference)
       end
 
@@ -86,7 +86,7 @@ RSpec.describe Appointments do
         expect(body).to include('2:00pm')
         expect(body).to include('20 June 2016')
         expect(body).to include('Dalston')
-        expect(body).to include('+44800123456')
+        expect(body).to include('0800123456')
         expect(body).to include(appointment.reference)
       end
 


### PR DESCRIPTION
Customers have expressed confusion over numbers starting with the
international prefix.