### PR TITLE
Display booking date/time elsewhere

### DIFF
--- a/app/views/agent/booking_requests/index.html.erb
+++ b/app/views/agent/booking_requests/index.html.erb
@@ -65,8 +65,8 @@
         <tbody>
           <% @booking_requests.each do |booking_request| %>
             <tr class="t-booking-request">
-              <td title="<%= booking_request.created_at.to_s(:govuk_date) %>">
-                <%= time_ago_in_words(booking_request.created_at) %> ago<br>
+              <td>
+                <%= booking_request.created_at.in_time_zone('London').to_s(:govuk_date) %>
               </td>
               <td>
                 <%= booking_request.name %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -50,12 +50,12 @@
         <caption><span class="sr-only">Appointments</span></caption>
         <thead>
           <tr class="table-header">
-            <th>Date of appointment</th>
-            <th>Time of appointment</th>
+            <th>Appointment</th>
             <th>Customer name</th>
             <th>Guider</th>
             <th>Location</th>
             <th>Reference</th>
+            <th>Requested</th>
             <th>Status</th>
             <th></th>
           </tr>
@@ -64,10 +64,7 @@
           <% @appointments.page.each do |appointment| %>
             <tr class="t-appointment">
               <td>
-                <%= appointment.proceeded_at.strftime('%A, %b %e') %>
-              </td>
-              <td>
-                <%= appointment.proceeded_at.strftime('%H:%M') %>
+                <%= appointment.proceeded_at.to_s(:govuk_date) %>
               </td>
               <td>
                 <%= appointment.name %>
@@ -80,6 +77,9 @@
               </td>
               <td>
                 <%= appointment.reference %>
+              </td>
+              <td>
+                <%= appointment.booking_request.created_at.in_time_zone('London').to_s(:govuk_date) %>
               </td>
               <td>
                 <%= appointment.status.titleize %>


### PR DESCRIPTION
We display the full booking date/time elsewhere so for consistency and
ease-of-use we should do the same in other booking and appointment views.