### PR TITLE
Validate time presence

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -26,6 +26,7 @@ class AppointmentForm
   validates :guider_id, presence: true
   validates :location_id, presence: true
   validates :date, presence: true
+  validates :time, presence: true
 
   validate :validate_date
   validate :validate_not_with_an_existing_booking_request
@@ -118,6 +119,6 @@ class AppointmentForm
     hour   = params.delete('time(4i)')
     minute = params.delete('time(5i)')
 
-    @time = Time.zone.parse("#{hour}:#{minute}") if hour && minute
+    @time = Time.zone.parse("#{hour}:#{minute}") if hour.present? && minute.present?
   end
 end

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -92,6 +92,13 @@ RSpec.describe AppointmentForm do
       expect(subject).to_not be_valid
     end
 
+    it 'requires a time' do
+      params['time(4i)'] = ''
+      params['time(5i)'] = ''
+
+      expect(subject).to be_invalid
+    end
+
     describe '#date' do
       it 'is required' do
         params[:date] = ''


### PR DESCRIPTION
Since we removed the preselection of time during the fulfilment of
bookings, we've seen several instances where agents or booking managers
forget to select the appointment time. This causes errors further down
in the mapper since their is an attempt to format the time.

Adding this validation will stop that from occuring and inform the
person attempting to place the booking exactly where they have gone
wrong.