### PR TITLE
Add some buffer to the connection pools

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= Integer(ENV.fetch('MAX_THREADS') { 3 }) * 2 %>
+  pool: <%= Integer(ENV.fetch('MAX_THREADS') { 3 }) * 3 %>
 
 development:
   <<: *default


### PR DESCRIPTION
`MAX_THREADS` is set to 10 in production. We often exhaust the pool in
the background workers, this shouldn't happen as sidekiq has a
concurrency of 10. Increasing the pool size should give us some extra
room but I'll keep an eye on it.