### PR TITLE
Merge settings for DB configuration

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -79,4 +79,5 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 production:
+  <<: *default
   url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
Whoops, we weren't merging the default settings prior to this, so the
default pool sizes were being used.