### PR TITLE
Add activity entry when resending emails

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -3,7 +3,7 @@ class ConfirmationsController < ApplicationController
     @booking_request = current_user.booking_requests.find(params[:booking_request_id])
 
     if @booking_request.appointment
-      AppointmentChangeNotificationJob.perform_later(@booking_request.appointment, false)
+      AppointmentChangeNotificationJob.perform_later(@booking_request.appointment)
     else
       CustomerConfirmationJob.perform_later(@booking_request)
     end

--- a/app/jobs/appointment_change_notification_job.rb
+++ b/app/jobs/appointment_change_notification_job.rb
@@ -1,13 +1,13 @@
 class AppointmentChangeNotificationJob < ActiveJob::Base
   queue_as :default
 
-  def perform(appointment, log_activity = true)
+  def perform(appointment)
     return unless appointment.email?
 
     booking_location = BookingLocations.find(appointment.location_id)
 
     Appointments.customer(appointment, booking_location).deliver
 
-    AppointmentMailActivity.from(appointment) if log_activity
+    AppointmentMailActivity.from(appointment)
   end
 end


### PR DESCRIPTION
This was previously being skipped as the appointment could be
'updated', but this path couldn't have been followed anyway, always
resulting in the 'booked' activity - which is good enough in this
instance.