### PR TITLE
Validate time when fulfilling

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -1,4 +1,4 @@
-class AppointmentForm
+class AppointmentForm # rubocop:disable ClassLength
   include ActiveModel::Model
   include PostalAddressable
 
@@ -29,6 +29,7 @@ class AppointmentForm
   validates :time, presence: true
 
   validate :validate_date
+  validate :validate_time
   validate :validate_not_with_an_existing_booking_request
 
   attr_reader :location_aware_booking_request
@@ -96,6 +97,12 @@ class AppointmentForm
 
   def validate_not_with_an_existing_booking_request
     errors.add(:base, 'has already been fulfilled') if location_aware_booking_request.appointment
+  end
+
+  def validate_time
+    return unless time
+
+    errors.add(:time, 'must be during the permitted hours') unless (8..18).cover?(time.hour)
   end
 
   def validate_date

--- a/spec/forms/appointment_form_spec.rb
+++ b/spec/forms/appointment_form_spec.rb
@@ -92,11 +92,19 @@ RSpec.describe AppointmentForm do
       expect(subject).to_not be_valid
     end
 
-    it 'requires a time' do
-      params['time(4i)'] = ''
-      params['time(5i)'] = ''
+    describe '#time' do
+      it 'is required' do
+        params['time(4i)'] = ''
+        params['time(5i)'] = ''
 
-      expect(subject).to be_invalid
+        expect(subject).to be_invalid
+      end
+
+      it 'must be during permitted hours' do
+        params['time(4i)'] = '00'
+
+        expect(subject).to be_invalid
+      end
     end
 
     describe '#date' do


### PR DESCRIPTION
We had a few instances where appointments were created for times outside
of the usual office hours of 8AM to 7PM. This change ensures this does
not happen again.