### PR TITLE
Reduce grace period across the weekend

### DIFF
--- a/app/lib/grace_period.rb
+++ b/app/lib/grace_period.rb
@@ -3,8 +3,8 @@ class GracePeriod
     3 => :monday,
     4 => :tuesday,
     5 => :wednesday,
-    6 => :thursday,
-    0 => :thursday
+    6 => :wednesday,
+    0 => :wednesday
   }.freeze
 
   def initialize(from = Date.current)


### PR DESCRIPTION
Customers will now see slots for Wednesday on Saturday and Sunday,
previously the earliest would have been Thursday.