### PR TITLE
Favour SMS reminders only where possible

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -78,10 +78,7 @@ class Appointment < ActiveRecord::Base
   end
 
   def self.needing_reminder
-    scoped = not_booked_today.with_email.pending
-
-    scoped.where(proceeded_at: day_range(2))
-          .or(scoped.without_mobile.where(proceeded_at: day_range(7)))
+    not_booked_today.with_email.without_mobile.pending.where(proceeded_at: [day_range(2), day_range(7)])
   end
 
   def self.for_sms_cancellation(number)

--- a/spec/features/scheduled_appointment_reminders_spec.rb
+++ b/spec/features/scheduled_appointment_reminders_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Scheduled appointment reminders' do
   scenario 'within 48 hours of the appointment, it does send a reminder' do
     perform_enqueued_jobs do
       travel_to Time.zone.parse('2016-06-18 12:05') do
-        given_an_unreminded_appointment_exists
+        given_an_unreminded_appointment_exists(phone: '02082524782')
         when_the_reminder_job_runs
         then_an_email_reminder_is_delivered
         and_a_reminder_activity_is_logged
@@ -37,6 +37,17 @@ RSpec.feature 'Scheduled appointment reminders' do
   scenario '7 day email reminders are not sent for appointments with mobiles' do
     perform_enqueued_jobs do
       travel_to Time.zone.parse('2016-06-13 11:55') do
+        given_an_unreminded_appointment_exists(phone: '07715930455')
+        when_the_reminder_job_runs
+        then_no_email_reminder_is_delivered
+        and_no_reminder_activity_is_logged
+      end
+    end
+  end
+
+  scenario '2 day email reminders are not sent for appointments with mobiles' do
+    perform_enqueued_jobs do
+      travel_to Time.zone.parse('2016-06-18 11:55') do
         given_an_unreminded_appointment_exists(phone: '07715930455')
         when_the_reminder_job_runs
         then_no_email_reminder_is_delivered


### PR DESCRIPTION
We now match the 7 day reminder behaviour - eg if the customer has a
mobile number we will not send an email reminder, preferring an SMS
reminder. If the customer has no mobile number we will always send email
reminders. So effectively they are now mutually exclusive.