### PR TITLE
Only include the guider's first name in letters

### DIFF
--- a/app/presenters/printed_confirmation_presenter.rb
+++ b/app/presenters/printed_confirmation_presenter.rb
@@ -11,7 +11,7 @@ class PrintedConfirmationPresenter
       date: date,
       time: time,
       location: location,
-      guider: appointment.guider_name,
+      guider: appointment.guider_name.split.first,
       phone: appointment.online_booking_twilio_number,
       address_line_1: appointment.name,
       address_line_2: appointment.address_line_one,

--- a/spec/jobs/printed_confirmation_letter_job_spec.rb
+++ b/spec/jobs/printed_confirmation_letter_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PrintedConfirmationLetterJob, '#perform' do
           date: '20 June 2016',
           time: '2:00pm (BST)',
           location: "Hackney\nHackney Citizens Advice\n300 Mare St\nHackney\nLondon\nE8 1HE",
-          guider: 'Ben Lovell',
+          guider: 'Ben',
           phone: '02086291134',
           address_line_1: 'Mortimer Smith',
           address_line_2: '22 Dalston Lane',


### PR DESCRIPTION
This matches the email template.