### PR TITLE
Do not notify customer when appointment elapsed

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -54,7 +54,7 @@ class Appointment < ActiveRecord::Base
   end
 
   def notify?
-    return unless previous_changes.any?
+    return if previous_changes.none? || proceeded_at.past?
     return true if previous_changes.exclude?(:status)
 
     previous_changes[:status] && pending?

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -22,15 +22,17 @@ RSpec.feature 'Booking Manager edits an Appointment' do
 
   scenario 'Successfully editing an Appointment' do
     perform_enqueued_jobs do
-      given_the_user_identifies_as_hackneys_booking_manager do
-        and_there_is_an_appointment
-        when_the_booking_manager_edits_the_appointment
-        then_the_appointment_details_are_presented
-        and_they_see_the_requested_slots
-        when_they_modify_the_appointment_details
-        then_the_appointment_is_updated
-        and_the_customer_is_notified
-        and_the_booking_request_has_associated_audit_and_mail_activity
+      travel_to '2016-01-01' do # ensure appointment has not elapsed
+        given_the_user_identifies_as_hackneys_booking_manager do
+          and_there_is_an_appointment
+          when_the_booking_manager_edits_the_appointment
+          then_the_appointment_details_are_presented
+          and_they_see_the_requested_slots
+          when_they_modify_the_appointment_details
+          then_the_appointment_is_updated
+          and_the_customer_is_notified
+          and_the_booking_request_has_associated_audit_and_mail_activity
+        end
       end
     end
   end
@@ -195,8 +197,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
 
   def and_the_booking_request_has_associated_audit_and_mail_activity
     expect(@booking_request.activities.count).to eq(2)
-    expect(@booking_request.activities[0]).to be_a(AppointmentMailActivity)
-    expect(@booking_request.activities[1]).to be_a(AuditActivity)
+    expect(@booking_request.activities.map(&:class)).to include(AppointmentMailActivity, AuditActivity)
   end
 
   def then_they_see_the_original_status

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -133,19 +133,29 @@ RSpec.describe Appointment do
     describe '#notify?' do
       context 'when the status was changed' do
         it 'handles correctly' do
-          original.update(status: :completed)
-          expect(original).to_not be_notify
+          travel_to '2016-01-01 13:00' do
+            original.update(status: :completed)
+            expect(original).to_not be_notify
 
-          original.update(status: :pending)
-          expect(original).to be_notify
+            original.update(status: :pending)
+            expect(original).to be_notify
+          end
+        end
+
+        context 'when the appointment has elapsed' do
+          it 'is false' do
+            expect(original).not_to be_notify
+          end
         end
       end
 
       context 'when the status was not changed' do
         it 'returns true' do
-          original.update(name: 'George')
+          travel_to '2016-01-01 13:00' do
+            original.update(name: 'George')
 
-          expect(original).to be_notify
+            expect(original).to be_notify
+          end
         end
       end
     end


### PR DESCRIPTION
We were always sending notifications regardless whether the appointment
had elapsed and this didn't make any sense.