### PR TITLE
Remove postal confirmation banner message

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,13 +1,5 @@
 <% content_for(:page_title, t('service.title', page_title: "Manage appointment for #{@appointment_form.name}")) %>
 
-<% if @appointment_form.postal_confirmation? %>
-<div class="alert alert-warning" role="alert">
-  <p>
-  The customer has requested postal confirmation.
-  </p>
-</div>
-<% end %>
-
 <% if @appointment_form.agent %>
 <div class="alert alert-warning" role="alert">
   <p>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -38,9 +38,6 @@
     <p>
     This booking was placed by <strong><%= @appointment_form.agent.name %></strong> on behalf of the customer.
     </p>
-    <% if @appointment_form.postal_confirmation? %>
-    <p>The customer has requested postal confirmation.</p>
-    <% end %>
   </div>
   <% end %>
 


### PR DESCRIPTION
When the customer has requested a postal confirmation we already display
the link to 'Postal address' in the left side bar which allows them to
modify the customer supplied address. Since we now automatically process
printed confirmations via notify we no longer need to display the banner
as a cue for the agent to manually print the letter.