### PR TITLE
Skip bank holidays in the grace period

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
   gem 'sprockets-es6'
   gem 'uglifier', '>= 1.3.0'
   gem 'uk_postcode'
+  gem 'working_hours'
 
   group :development, :test do
     gem 'bootsnap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,9 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    working_hours (1.1.3)
+      activesupport (>= 3.2)
+      tzinfo
     xpath (3.1.0)
       nokogiri (~> 1.8)
 
@@ -471,6 +474,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)!
   uk_postcode!
   webmock!
+  working_hours!
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app/lib/default_bookable_slots.rb
+++ b/app/lib/default_bookable_slots.rb
@@ -37,6 +37,6 @@ class DefaultBookableSlots
   end
 
   def grace_period_end
-    GracePeriod.new(from).call
+    GracePeriod.start
   end
 end

--- a/app/lib/grace_period.rb
+++ b/app/lib/grace_period.rb
@@ -1,25 +1,9 @@
 class GracePeriod
-  GRACE_PERIODS = {
-    3 => :monday,
-    4 => :tuesday,
-    5 => :wednesday,
-    6 => :wednesday,
-    0 => :wednesday
-  }.freeze
-
-  def initialize(from = Date.current)
-    @from = from
+  def self.start
+    3.working.days.from_now.to_date
   end
 
-  def call
-    if from.monday? || from.tuesday?
-      from.advance(days: 3)
-    else
-      from.next_week(GRACE_PERIODS[from.wday])
-    end
+  def self.end
+    40.working.days.from_now.to_date
   end
-
-  private
-
-  attr_reader :from
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -29,8 +29,8 @@ class Schedule < ActiveRecord::Base
   end
 
   def bookable_slots_in_window(
-    starting: GracePeriod.new.call,
-    ending:   8.weeks.from_now
+    starting: GracePeriod.start,
+    ending:   GracePeriod.end
   )
     return DefaultBookableSlots.new.call if default?
 

--- a/config/initializers/working_hours.rb
+++ b/config/initializers/working_hours.rb
@@ -1,0 +1,9 @@
+WorkingHours::Config.holidays = EXCLUSIONS
+
+WorkingHours::Config.working_hours = {
+  mon: { '09:00' => '17:30' },
+  tue: { '09:00' => '17:30' },
+  wed: { '09:00' => '17:30' },
+  thu: { '09:00' => '17:30' },
+  fri: { '09:00' => '17:30' }
+}

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'GET /api/v1/locations/{location_id}/bookable_slots' do
       # excluded as after booking window
       create(:bookable_slot, :am, schedule: schedule, date: 9.weeks.from_now)
       # will be returned
-      create(:bookable_slot, :am, schedule: schedule, date: GracePeriod.new.call)
+      create(:bookable_slot, :am, schedule: schedule, date: GracePeriod.start)
     end
   end
 


### PR DESCRIPTION
Bank holidays were not accounted for during the grace period previously.
This change ensures we bring parity with TAP (and eventually the other
planners).