### PR TITLE
Allow booking managers to process appointments

### DIFF
--- a/app/assets/stylesheets/components/_action-buttons.scss
+++ b/app/assets/stylesheets/components/_action-buttons.scss
@@ -1,0 +1,5 @@
+.action-buttons {
+  margin-top: 1.4em;
+  text-align: right;
+  white-space: nowrap;
+}

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -50,7 +50,8 @@ class AppointmentsController < ApplicationController
         :appointment_date,
         :status,
         :location,
-        :guider
+        :guider,
+        :processed
       ).merge(
         current_user: current_user,
         page: params[:page]

--- a/app/controllers/processes_controller.rb
+++ b/app/controllers/processes_controller.rb
@@ -1,0 +1,8 @@
+class ProcessesController < ApplicationController
+  def create
+    @appointment = current_user.appointments.find(params[:appointment_id])
+    @appointment.process!(current_user)
+
+    redirect_back success: 'The appointment was marked as processed.', fallback_location: root_path
+  end
+end

--- a/app/forms/appointments_search_form.rb
+++ b/app/forms/appointments_search_form.rb
@@ -8,10 +8,12 @@ class AppointmentsSearchForm
   attr_accessor :guider
   attr_accessor :current_user
   attr_accessor :appointment_date
+  attr_accessor :processed
 
   def results # rubocop:disable Metrics/AbcSize
     scope = current_user.appointments
     scope = search_term_scope(scope)
+    scope = processed_scope(scope)
     scope = scope.where(proceeded_at: date_range) if date_range
     scope = scope.where(status: status) if status.present?
     scope = scope.where(location_id: location) if location.present?
@@ -21,6 +23,16 @@ class AppointmentsSearchForm
   end
 
   private
+
+  def processed_scope(scope)
+    return scope if processed.blank?
+
+    if ActiveRecord::Type::Boolean.new.cast(processed)
+      scope.where.not(processed_at: nil)
+    else
+      scope.where(processed_at: nil)
+    end
+  end
 
   def search_term_scope(scope)
     return scope unless search_term.present?

--- a/app/models/processed_activity.rb
+++ b/app/models/processed_activity.rb
@@ -1,0 +1,9 @@
+class ProcessedActivity < Activity
+  def self.from!(user:, appointment:)
+    create!(
+      user: user,
+      booking_request: appointment.booking_request,
+      message: ''
+    )
+  end
+end

--- a/app/views/activities/_processed_activity.html.erb
+++ b/app/views/activities/_processed_activity.html.erb
@@ -1,0 +1,5 @@
+<li class="activity-feed__item t-activity" id="activity-<%= processed_activity.id %>">
+  <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+  <strong><%= processed_activity.owner_name %></strong> processed the appointment
+  <span class="activity-feed__date"><%= timestamp(processed_activity.created_at) %></span>
+</li>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -15,10 +15,23 @@
     <li class="active"><%= @appointment_form.name %></li>
   </ol>
 
-  <h1>
-    Manage appointment for <%= @appointment_form.name %><br>
-    <small>Booking reference: <%= @appointment_form.reference %></small>
-  </h1>
+  <div class="row">
+    <div class="col-md-7">
+      <h1>
+        Manage appointment for <%= @appointment_form.name %><br>
+        <small>Booking reference: <%= @appointment_form.reference %></small>
+      </h1>
+    </div>
+
+    <div class="col-md-5 action-buttons">
+      <% unless @appointment_form.processed_at? %>
+        <%= link_to appointment_process_path(@appointment_form), method: :post, title: 'Mark as processed', class: 'btn btn-info t-process' do %>
+          <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+          <span>Mark as processed</span>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>
 
 <%= render partial: 'activities/activity_feed', locals: {

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -29,6 +29,9 @@
             <%= f.label :guider, class: 'filters__label' %><%= f.select :guider, guider_options(booking_location), { include_blank: 'All Guiders' }, { class: 'form-control filters__form-control t-guider' } %>
           </li>
           <li class="filters__item">
+            <%= f.label :processed, class: 'filters__label' %><%= f.select :processed, [['Yes', 'true'], ['No', 'false']], { include_blank: 'All' }, { class: 'form-control filters__form-control t-processed' } %>
+          </li>
+          <li class="filters__item">
            <%= f.button class: 't-submit btn btn-default filters__button' do %>
              <span aria-hidden="true" class="glyphicon glyphicon-search"></span> Search
            <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   resources :users, only: :update
 
   resources :appointments, only: %i(index edit update) do
+    resource :process, only: :create
     resources :changes, only: :index
   end
 

--- a/db/migrate/20181122151136_add_processed_at_to_appointments.rb
+++ b/db/migrate/20181122151136_add_processed_at_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddProcessedAtToAppointments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :appointments, :processed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181101122713) do
+ActiveRecord::Schema.define(version: 2018_11_22_151136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20181101122713) do
     t.boolean "defined_contribution_pot_confirmed", default: true, null: false
     t.boolean "accessibility_requirements", default: false, null: false
     t.string "additional_info", limit: 500, default: "", null: false
+    t.datetime "processed_at"
     t.index ["booking_request_id"], name: "index_appointments_on_booking_request_id"
     t.index ["location_id"], name: "index_appointments_on_location_id"
   end
@@ -76,6 +77,7 @@ ActiveRecord::Schema.define(version: 20181101122713) do
     t.string "end", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "guider_id"
     t.index ["schedule_id"], name: "index_bookable_slots_on_schedule_id"
   end
 

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -2,6 +2,15 @@
 require 'rails_helper'
 
 RSpec.feature 'Booking Manager edits an Appointment' do
+  scenario 'Processing an appointment' do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_there_is_an_appointment
+      when_the_booking_manager_edits_the_appointment
+      and_processes_the_appointment
+      then_the_appointment_is_processed
+    end
+  end
+
   scenario 'Resending the appointment confirmation', js: true do
     given_the_user_identifies_as_hackneys_booking_manager do
       and_there_is_an_appointment
@@ -57,6 +66,17 @@ RSpec.feature 'Booking Manager edits an Appointment' do
         and_the_customer_is_not_notified
       end
     end
+  end
+
+  def and_processes_the_appointment
+    @page = Pages::EditAppointment.new
+    expect(@page).to be_displayed
+
+    @page.process.click
+  end
+
+  def then_the_appointment_is_processed
+    expect(@page).to have_success
   end
 
   def when_they_resend_the_confirmation

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -30,6 +30,7 @@ module Pages
     element :slot_three_date,   '.t-slot-3-date'
     element :slot_three_period, '.t-slot-3-period'
 
+    element :process, '.t-process'
     element :submit, '.t-submit'
     element :resend_confirmation, '.t-resend-confirmation'
 


### PR DESCRIPTION
Gives booking managers the ability to mark appointments as processed to
signify they have been entered across other internal systems.