### PR TITLE
Cancel appointment regardless of validation

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -66,7 +66,7 @@ class Appointment < ActiveRecord::Base # rubocop:disable ClassLength
   def cancel!
     without_auditing do
       transaction do
-        update!(status: :cancelled_by_customer_sms)
+        update_attribute(:status, :cancelled_by_customer_sms) # rubocop:disable SkipsModelValidations
 
         SmsCancellationActivity.from(self)
       end


### PR DESCRIPTION
We had appointments with overlapping guiders causing the cancellation to
fail as validation would fail with `update!`. We can blindly update the
`status` attribute here regardless of other validations so that's what
we should do.