### PR TITLE
Do not allocate non-realtime bookings

### DIFF
--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -83,6 +83,8 @@ class BookingRequest < ActiveRecord::Base
   def validate_slots
     errors.add(:slots, 'you must provide at least one slot') if slots.empty?
 
+    return unless realtime?
+
     errors.add(:slots, 'could not be allocated') unless @allocated = Schedule.allocates?(self)
   end
 end


### PR DESCRIPTION
Ensures this validation only runs for realtime bookings during the
crossover period. This can be simplified when all locations are
enrolled.