### PR TITLE
Add a further appointment status

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -12,6 +12,7 @@ class Appointment < ActiveRecord::Base # rubocop:disable ClassLength
     cancelled_by_customer
     cancelled_by_pension_wise
     cancelled_by_customer_sms
+    incomplete_other
   )
 
   before_save :calculate_statistics, if: :proceeded_at_changed?


### PR DESCRIPTION
We had a request from a pilot booking centre about appointment statuses.

They asked whether we can add the 'Incomplete - other' status. At the
moment the incomplete appointments are broadly covered by ineligible age
and ineligible pension type.

However, there are other reasons why an appointment may be incomplete.

If we say ineligible age and ineligible pension count as incomplete at
the appointment stage it's sensible adding 'Incomplete - other'.