### PR TITLE
Add a notice to bookings with DC pot uncertainty

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -1,5 +1,11 @@
 <% content_for(:page_tmtioncontle, t('servce.title', page_title: "Manage appointment for #{@appointment_form.name}")) %>
 
+<% unless @appointment_form.defined_contribution_pot_confirmed %>
+<div class="alert alert-warning" role="alert">
+  <p>The customer is not certain they have a defined contribution pot.</p>
+</div>
+<% end %>
+
 <% if @appointment_form.agent %>
 <div class="alert alert-warning" role="alert">
   <p>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -33,6 +33,12 @@
     </div>
   </div>
 
+  <% unless @appointment_form.defined_contribution_pot_confirmed %>
+  <div class="alert alert-warning" role="alert">
+    <p>The customer is not certain they have a defined contribution pot.</p>
+  </div>
+  <% end %>
+
   <% if @appointment_form.agent %>
   <div class="alert alert-warning" role="alert">
     <p>


### PR DESCRIPTION
When the customer states they are unsure whether they have a DC pot, we
display a notice to the booking manager so they are aware this
booking/appointment may well be ineligible.