### PR TITLE
Notify booking managers of realtime bookings

### DIFF
--- a/app/lib/realtime_processable.rb
+++ b/app/lib/realtime_processable.rb
@@ -5,6 +5,7 @@ module RealtimeProcessable
     appointment = fulfil_appointment(booking_request)
     appointment = Appointment.create!(appointment.appointment_params)
 
+    BookingManagerConfirmationJob.perform_later(booking_request)
     AppointmentChangeNotificationJob.perform_later(appointment)
     PrintedConfirmationLetterJob.perform_later(appointment)
     SlackPingerJob.perform_later(appointment)

--- a/app/views/booking_requests/booking_manager.html.erb
+++ b/app/views/booking_requests/booking_manager.html.erb
@@ -1,5 +1,5 @@
 <%= p do %>
-  A new booking request has come in.
+  A new booking has come in.
 <% end %>
 
 <%= p do %>

--- a/spec/features/agent_places_a_realtime_booking_spec.rb
+++ b/spec/features/agent_places_a_realtime_booking_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Agent places a realtime booking' do
       and_the_appointment_is_automatically_fulfilled
       and_the_agent_sees_the_confirmation
       and_the_customer_is_notified
+      and_the_booking_manager_is_notified
     end
   end
 
@@ -104,5 +105,9 @@ RSpec.feature 'Agent places a realtime booking' do
 
   def and_the_customer_is_notified
     assert_enqueued_jobs(2, only: [PrintedConfirmationLetterJob, AppointmentChangeNotificationJob])
+  end
+
+  def and_the_booking_manager_is_notified
+    assert_enqueued_jobs(1, only: BookingManagerConfirmationJob)
   end
 end

--- a/spec/requests/create_an_appointment_request_spec.rb
+++ b/spec/requests/create_an_appointment_request_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
         and_the_booking_request_is_created
         and_the_appointment_is_created
         and_the_customer_receives_a_confirmation_email
+        and_the_booking_manager_receives_an_email_notification
       end
     end
   end
@@ -121,6 +122,10 @@ RSpec.describe 'POST /api/v1/booking_requests' do
   end
 
   def and_the_customer_receives_a_confirmation_email
-    expect(ActionMailer::Base.deliveries.first.subject).to eq('Your Pension Wise Appointment')
+    expect(ActionMailer::Base.deliveries.map(&:subject)).to include('Your Pension Wise Appointment')
+  end
+
+  def and_the_booking_manager_receives_an_email_notification
+    expect(ActionMailer::Base.deliveries.map(&:subject)).to include('Pension Wise Booking Request')
   end
 end


### PR DESCRIPTION
Booking managers were getting email notifications when normal bookings
where placed as usual, however, they were not receiving notifications
when realtime bookings were placed. This change corrects that behaviour.