### PR TITLE
Skip guider overlap validation at Reading

### DIFF
--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -101,7 +101,9 @@ class AppointmentForm # rubocop:disable ClassLength
 
     proceeded_at = "#{date} #{time.to_s(:time)}"
 
-    if Appointment.overlaps?(guider_id: guider_id, proceeded_at: proceeded_at) # rubocop:disable GuardClause
+    if Appointment.overlaps?(
+      guider_id: guider_id, proceeded_at: proceeded_at, location_id: location_id
+    )
       errors.add(:guider_id, 'is already booked with an overlapping appointment')
     end
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -130,7 +130,9 @@ class Appointment < ActiveRecord::Base # rubocop:disable ClassLength
       .where(proceeded_at: date_range, schedules: { location_id: location_id })
   end
 
-  def self.overlaps?(guider_id:, proceeded_at:, id: nil)
+  def self.overlaps?(guider_id:, proceeded_at:, id: nil, location_id: nil)
+    return if location_id == 'a801a72d-91be-4a33-86a6-3d652cfc00d0' # Reading
+
     where(guider_id: guider_id)
       .where("(proceeded_at, interval '1 hour') overlaps (?, interval '1 hour')", proceeded_at)
       .where.not(status: [5, 6, 7], id: id).size.positive?
@@ -173,7 +175,9 @@ class Appointment < ActiveRecord::Base # rubocop:disable ClassLength
   def validate_guider_availability
     return unless guider_id? && proceeded_at?
 
-    if self.class.overlaps?(guider_id: guider_id, proceeded_at: proceeded_at, id: id) # rubocop:disable GuardClause
+    if self.class.overlaps?(
+      guider_id: guider_id, proceeded_at: proceeded_at, id: id, location_id: location_id
+    )
       errors.add(:guider_id, 'is already booked with an overlapping appointment')
     end
   end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -188,5 +188,13 @@ RSpec.describe Appointment do
       subject.guider_id = 2
       expect(subject).to be_valid
     end
+
+    it 'does not validate overlaps for Reading specifically' do
+      create(:appointment, proceeded_at: subject.proceeded_at.advance(minutes: 15))
+      expect(subject).to be_invalid
+
+      subject.location_id = 'a801a72d-91be-4a33-86a6-3d652cfc00d0'
+      expect(subject).to be_valid
+    end
   end
 end


### PR DESCRIPTION
A specific Reading guider has 45 minute slots so we need to skip the
usual overlapping logic in this location, temporarily.