### PR TITLE
Include richer information in confirmations

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -12,4 +12,15 @@ module EmailHelper
       ].join(';')
     )
   end
+
+  def mailer_booking_link(booking_request_or_appointment)
+    name = booking_request_or_appointment.model_name.human.downcase
+    url  = if booking_request_or_appointment.is_a?(Appointment)
+             edit_appointment_url(booking_request_or_appointment)
+           else
+             new_booking_request_appointment_url(booking_request_or_appointment)
+           end
+
+    link_to "View the #{name}", url
+  end
 end

--- a/app/jobs/booking_manager_confirmation_job.rb
+++ b/app/jobs/booking_manager_confirmation_job.rb
@@ -7,7 +7,7 @@ class BookingManagerConfirmationJob < ActiveJob::Base
     raise BookingManagersNotFoundError unless booking_managers.present?
 
     booking_managers.each do |booking_manager|
-      BookingRequests.booking_manager(booking_manager).deliver_later
+      BookingRequests.booking_manager(booking_request, booking_manager).deliver_later
     end
   end
 end

--- a/app/mailers/booking_requests.rb
+++ b/app/mailers/booking_requests.rb
@@ -11,9 +11,12 @@ class BookingRequests < ApplicationMailer
     )
   end
 
-  def booking_manager(booking_manager)
+  def booking_manager(booking_request_or_appointment, booking_manager)
+    @booking_request_or_appointment = booking_request_or_appointment
+    name = booking_request_or_appointment.model_name.human
+
     mailgun_headers('booking_manager_booking_request')
-    mail to: booking_manager.email, subject: 'Pension Wise Booking Request'
+    mail to: booking_manager.email, subject: "Pension Wise #{name.titleize}"
   end
 
   def email_failure(booking_request, booking_manager)

--- a/app/views/booking_requests/booking_manager.html.erb
+++ b/app/views/booking_requests/booking_manager.html.erb
@@ -1,7 +1,11 @@
 <%= p do %>
-  A new booking has come in.
+  A new <%= @booking_request_or_appointment.model_name.human.downcase %> has come in.
 <% end %>
 
 <%= p do %>
-  <%= link_to 'Go to the planner', root_url %>
+  Reference: <%= @booking_request_or_appointment.reference %>.
+<% end %>
+
+<%= p do %>
+  <%= mailer_booking_link(@booking_request_or_appointment) %>
 <% end %>

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe BookingRequests do
-  describe 'Customer notification' do
-    let(:location_id) { '183080c6-642b-4b8f-96fd-891f5cd9f9c7' }
-    let(:booking_location_id) { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
-    let(:booking_location) { BookingLocations.find(booking_location_id) }
-    let(:actual_location) { booking_location.location_for(location_id) }
-    let(:booking_request) do
-      create(:booking_request, location_id: location_id, booking_location_id: booking_location_id)
-    end
+  let(:location_id) { '183080c6-642b-4b8f-96fd-891f5cd9f9c7' }
+  let(:booking_location_id) { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
+  let(:booking_location) { BookingLocations.find(booking_location_id) }
+  let(:actual_location) { booking_location.location_for(location_id) }
+  let(:booking_request) do
+    create(:booking_request, location_id: location_id, booking_location_id: booking_location_id)
+  end
 
+  describe 'Customer notification' do
     subject(:mail) { BookingRequests.customer(booking_request, booking_location) }
 
     it_behaves_like 'mailgun identified email'
@@ -48,7 +48,7 @@ RSpec.describe BookingRequests do
   describe 'Booking Manager Notification' do
     let(:booking_manager) { build_stubbed(:hackney_booking_manager) }
 
-    subject(:mail) { BookingRequests.booking_manager(booking_manager) }
+    subject(:mail) { BookingRequests.booking_manager(booking_request, booking_manager) }
 
     it_behaves_like 'mailgun identified email'
 
@@ -62,8 +62,18 @@ RSpec.describe BookingRequests do
     describe 'rendering the body' do
       let(:body) { subject.body.encoded }
 
-      it 'includes a link to the service start page' do
-        expect(body).to include('http://localhost:3001')
+      it 'includes a link to the booking request page' do
+        expect(body).to include("http://localhost:3001/booking_requests/#{booking_request.id}/appointments/new")
+      end
+    end
+
+    context 'for an appointment' do
+      let(:booking_request) { create(:appointment) }
+
+      it 'renders the appointment particulars' do
+        expect(mail.subject).to eq('Pension Wise Appointment')
+
+        expect(subject.body.encoded).to include("/appointments/#{booking_request.id}/edit")
       end
     end
   end


### PR DESCRIPTION
Booking managers need assistance when a new booking request or
appointment is made. The updated email body is specific to the type of
booking or appointment, includes the reference and a direct link to view
or fulfil.