### PR TITLE
Default `processed` criteria to false

### DIFF
--- a/app/forms/appointments_search_form.rb
+++ b/app/forms/appointments_search_form.rb
@@ -25,8 +25,6 @@ class AppointmentsSearchForm
   private
 
   def processed_scope(scope)
-    return scope if processed.blank?
-
     if ActiveRecord::Type::Boolean.new.cast(processed)
       scope.where.not(processed_at: nil)
     else

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -29,7 +29,7 @@
             <%= f.label :guider, class: 'filters__label' %><%= f.select :guider, guider_options(booking_location), { include_blank: 'All Guiders' }, { class: 'form-control filters__form-control t-guider' } %>
           </li>
           <li class="filters__item">
-            <%= f.label :processed, class: 'filters__label' %><%= f.select :processed, [['Yes', 'true'], ['No', 'false']], { include_blank: 'All' }, { class: 'form-control filters__form-control t-processed' } %>
+            <%= f.label :processed, class: 'filters__label' %><%= f.select :processed, [['No', 'false'], ['Yes', 'true']], {}, { class: 'form-control filters__form-control t-processed' } %>
           </li>
           <li class="filters__item">
            <%= f.button class: 't-submit btn btn-default filters__button' do %>


### PR DESCRIPTION
This has been requested by booking managers to assist in finding newly
placed and unprocessed bookings/appointments.