### PR TITLE
Ensure email link is generated correctly

### DIFF
--- a/app/jobs/booking_manager_confirmation_job.rb
+++ b/app/jobs/booking_manager_confirmation_job.rb
@@ -7,7 +7,10 @@ class BookingManagerConfirmationJob < ActiveJob::Base
     raise BookingManagersNotFoundError unless booking_managers.present?
 
     booking_managers.each do |booking_manager|
-      BookingRequests.booking_manager(booking_request, booking_manager).deliver_later
+      BookingRequests.booking_manager(
+        booking_request.appointment || booking_request,
+        booking_manager
+      ).deliver_later
     end
   end
 end

--- a/spec/jobs/booking_manager_confirmation_job_spec.rb
+++ b/spec/jobs/booking_manager_confirmation_job_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe BookingManagerConfirmationJob, '#perform' do
   let(:booking_request) { create(:hackney_booking_request) }
+  let(:appointment) { create(:appointment) }
 
   subject { described_class.new.perform(booking_request) }
 
@@ -24,6 +25,18 @@ RSpec.describe BookingManagerConfirmationJob, '#perform' do
 
     it 'raises an error' do
       expect { subject }.to raise_error(BookingManagersNotFoundError)
+    end
+  end
+
+  context 'when the booking has an appointment associated' do
+    let(:booking_manager) { create(:hackney_booking_manager) }
+
+    it 'passes the appointment on to the mailer' do
+      expect(BookingRequests).to receive(:booking_manager)
+        .with(appointment, booking_manager)
+        .and_return(double.as_null_object)
+
+      described_class.new.perform(appointment.booking_request)
     end
   end
 end

--- a/spec/requests/create_an_appointment_request_spec.rb
+++ b/spec/requests/create_an_appointment_request_spec.rb
@@ -126,6 +126,6 @@ RSpec.describe 'POST /api/v1/booking_requests' do
   end
 
   def and_the_booking_manager_receives_an_email_notification
-    expect(ActionMailer::Base.deliveries.map(&:subject)).to include('Pension Wise Booking Request')
+    expect(ActionMailer::Base.deliveries.map(&:subject)).to include('Pension Wise Appointment')
   end
 end


### PR DESCRIPTION
There was an issue where notifications for appointments were incorrectly
generating appointment links direct to the planner.