### PR TITLE
Overlapping appointments are not available

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -67,7 +67,8 @@ class Schedule < ActiveRecord::Base
       <<-SQL
         LEFT JOIN appointments ON
           appointments.guider_id = bookable_slots.guider_id
-          AND appointments.proceeded_at = TO_TIMESTAMP(CONCAT(bookable_slots.date, ' ', bookable_slots.start), 'YYYY-MM-DD HH24MI')
+          AND (appointments.proceeded_at, interval '1 hour')
+          OVERLAPS (TO_TIMESTAMP(CONCAT(bookable_slots.date, ' ', bookable_slots.start), 'YYYY-MM-DD HH24MI'), interval '1 hour')
           AND NOT appointments.status IN (5, 6, 7)
       SQL
     ).where('appointments.proceeded_at IS NULL')

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe 'GET /api/v1/locations/{location_id}/bookable_slots' do
         guider_id: 4,
         status: :cancelled_by_customer
       )
+      # excluded since an appointment overlaps the start/end
+      @overlapping = create(
+        :bookable_slot,
+        :realtime,
+        schedule: schedule,
+        date: '2017-06-06',
+        start: '1330',
+        end: '1430'
+      )
+      create(:appointment, proceeded_at: @overlapping.start_at.advance(minutes: 30))
     end
   end
 


### PR DESCRIPTION
Prior to this change, a slot was still available when an appointment
overlaps but does not match the start precisely. This was causing
multiple, attempted bookings and contention for slots.