### PR TITLE
Display all appointments on realtime calendar

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -116,18 +116,8 @@ class Appointment < ActiveRecord::Base # rubocop:disable ClassLength
     days.days.from_now.beginning_of_day..days.days.from_now.end_of_day
   end
 
-  def self.realtime_appointments(location_id, date_range) # rubocop:disable MethodLength
-    joins('inner join schedules on schedules.location_id = appointments.location_id')
-      .joins(
-        <<-SQL
-          inner join bookable_slots on bookable_slots.schedule_id = schedules.id
-          and bookable_slots.guider_id = appointments.guider_id
-          and bookable_slots.date = appointments.proceeded_at::date
-          and bookable_slots.start = to_char(appointments.proceeded_at, 'HH24MI')
-          and not bookable_slots.guider_id is null
-        SQL
-      )
-      .where(proceeded_at: date_range, schedules: { location_id: location_id })
+  def self.realtime_appointments(location_id, date_range)
+    where(proceeded_at: date_range, location_id: location_id)
   end
 
   def self.overlaps?(guider_id:, proceeded_at:, id: nil, location_id: nil)

--- a/spec/requests/realtime_appointments_api_spec.rb
+++ b/spec/requests/realtime_appointments_api_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe 'GET /locations/{location_id}/realtime_appointments' do
 
   def given_a_schedule_with_realtime_slots_exists
     @slot = create(:bookable_slot, :realtime, date: '2018-11-07')
-    # ensure duplicate slots don't cause duplicated appointment instances
-    create(:bookable_slot, :realtime, date: '2018-11-07', guider_id: 2)
   end
 
   def and_an_overlapping_realtime_appointment_exists


### PR DESCRIPTION
Since the realtime calendar is per-day, it's highly unlikely that mixed
realtime/non-realtime appointments exist within a single view. Trying to
determine which appointments are realtime by overlaying them on realtime
slots is not entirely fool-proof and was causing inaccurate results.

This change simplifies the view and displays all appointments,
regardless.