### PR TITLE
Do not return full availability for locations

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -55,7 +55,7 @@ class Schedule < ActiveRecord::Base # rubocop:disable ClassLength
     starting: grace_period.start,
     ending:   grace_period.end
   )
-    return DefaultBookableSlots.new(location_id: location_id).call if default?
+    return [] if default?
 
     bookable_slots.windowed(starting..ending)
   end

--- a/spec/features/agent_places_a_booking_spec.rb
+++ b/spec/features/agent_places_a_booking_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Agent places a booking request' do
   scenario 'Successfully placing a booking request' do
     travel_to '2017-11-14 13:00' do
       given_the_user_identifies_as_an_agent
+      and_bookable_slots_exist
       when_they_attempt_to_place_a_customer_booking_at_hackney
       and_they_choose_several_slots
       and_they_provide_the_customer_details
@@ -38,6 +39,14 @@ RSpec.feature 'Agent places a booking request' do
   def when_they_attempt_to_place_a_customer_booking_at_hackney
     @page = Pages::AgentBooking.new
     @page.load(location_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
+  end
+
+  def and_bookable_slots_exist
+    create(:schedule) do |schedule|
+      create(:bookable_slot, :am, date: '2017-11-17', schedule: schedule)
+      create(:bookable_slot, :pm, date: '2017-11-17', schedule: schedule)
+      create(:bookable_slot, :am, date: '2017-12-01', schedule: schedule)
+    end
   end
 
   def and_they_choose_several_slots

--- a/spec/requests/bookable_slots_api_spec.rb
+++ b/spec/requests/bookable_slots_api_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe 'GET /api/v1/locations/{location_id}/bookable_slots' do
     end
   end
 
-  scenario 'Returns default availability for locations without schedules' do
+  scenario 'Returns empty availability for locations without schedules' do
     when_a_request_for_a_location_without_a_schedule_is_made
     then_the_service_responds_ok
-    and_slots_are_serialized_as_json
+    and_an_empty_array_is_serialized_as_json
   end
 
   def given_a_location_with_a_schedule_exists # rubocop:disable AbcSize
@@ -92,6 +92,10 @@ RSpec.describe 'GET /api/v1/locations/{location_id}/bookable_slots' do
     @json = JSON.parse(response.body).tap do |json|
       expect(json.first.keys).to match_array(%w(date start end))
     end
+  end
+
+  def and_an_empty_array_is_serialized_as_json
+    expect(JSON.parse(response.body)).to eq([])
   end
 
   def create_appointment_with_booking_slot(schedule:, date:, guider_id:, status: :pending)


### PR DESCRIPTION
When new locations are added they will return full AM/PM availability
until a schedule is created. This change ensures new locations now
return no availability until a schedule is created.