### PR TITLE
Appointments can be filtered by DC pot options

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -51,7 +51,8 @@ class AppointmentsController < ApplicationController
         :status,
         :location,
         :guider,
-        :processed
+        :processed,
+        :dc_pot_confirmed
       ).merge(
         current_user: current_user,
         page: params[:page]

--- a/app/forms/appointments_search_form.rb
+++ b/app/forms/appointments_search_form.rb
@@ -9,11 +9,13 @@ class AppointmentsSearchForm
   attr_accessor :current_user
   attr_accessor :appointment_date
   attr_accessor :processed
+  attr_accessor :dc_pot_confirmed
 
   def results # rubocop:disable Metrics/AbcSize
     scope = current_user.appointments.includes(booking_request: :slots)
     scope = search_term_scope(scope)
     scope = processed_scope(scope)
+    scope = dc_pot_scope(scope)
     scope = scope.where(proceeded_at: date_range) if date_range
     scope = scope.where(status: status) if status.present?
     scope = scope.where(location_id: location) if location.present?
@@ -23,6 +25,12 @@ class AppointmentsSearchForm
   end
 
   private
+
+  def dc_pot_scope(scope)
+    return scope if dc_pot_confirmed.blank?
+
+    scope.where(booking_requests: { defined_contribution_pot_confirmed: dc_pot_confirmed })
+  end
 
   def processed_scope(scope)
     if ActiveRecord::Type::Boolean.new.cast(processed)

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -32,6 +32,9 @@
             <%= f.label :processed, class: 'filters__label' %><%= f.select :processed, [['No', 'false'], ['Yes', 'true']], {}, { class: 'form-control filters__form-control t-processed' } %>
           </li>
           <li class="filters__item">
+            <%= f.label :dc_pot_confirmed, 'DC Pot Confirmed', class: 'filters__label' %><%= f.select :dc_pot_confirmed, [['Yes', 'true'], ['Don’t know', 'false']], { include_blank: 'All Options' }, { class: 'form-control filters__form-control t-dc-pot-confirmed' } %>
+          </li>
+          <li class="filters__item">
            <%= f.button class: 't-submit btn btn-default filters__button' do %>
              <span aria-hidden="true" class="glyphicon glyphicon-search"></span> Search
            <% end %>


### PR DESCRIPTION
Allows the booking managers to filter and search appointments by the
customer's stated confirmation of their DC pension pot.