### PR TITLE
Create default, blank schedules for locations

### DIFF
--- a/app/helpers/schedule_helper.rb
+++ b/app/helpers/schedule_helper.rb
@@ -42,8 +42,6 @@ module ScheduleHelper
   end
 
   def availability_button(location_id)
-    return unless Schedule.exists?(location_id: location_id)
-
     link_to(
       bookable_slots_path(location_id: location_id),
       title: 'Modify availability',
@@ -56,7 +54,6 @@ module ScheduleHelper
 
   def realtime_availability_button(location)
     return unless location.realtime?
-    return unless Schedule.exists?(location_id: location.id)
 
     safe_join([bookable_slots_button(location), bookable_slot_list_button(location)], "\n")
   end

--- a/db/migrate/20190328103352_change_schedule_defaults.rb
+++ b/db/migrate/20190328103352_change_schedule_defaults.rb
@@ -1,0 +1,7 @@
+class ChangeScheduleDefaults < ActiveRecord::Migration[5.2]
+  def change
+    Schedule::SLOT_ATTRIBUTES.each do |attr|
+      change_column_default(:schedules, attr, from: true, to: false)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_06_150047) do
+ActiveRecord::Schema.define(version: 2019_03_28_103352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,16 +128,16 @@ ActiveRecord::Schema.define(version: 2019_03_06_150047) do
 
   create_table "schedules", force: :cascade do |t|
     t.string "location_id", null: false
-    t.boolean "monday_am", default: true, null: false
-    t.boolean "monday_pm", default: true, null: false
-    t.boolean "tuesday_am", default: true, null: false
-    t.boolean "tuesday_pm", default: true, null: false
-    t.boolean "wednesday_am", default: true, null: false
-    t.boolean "wednesday_pm", default: true, null: false
-    t.boolean "thursday_am", default: true, null: false
-    t.boolean "thursday_pm", default: true, null: false
-    t.boolean "friday_am", default: true, null: false
-    t.boolean "friday_pm", default: true, null: false
+    t.boolean "monday_am", default: false, null: false
+    t.boolean "monday_pm", default: false, null: false
+    t.boolean "tuesday_am", default: false, null: false
+    t.boolean "tuesday_pm", default: false, null: false
+    t.boolean "wednesday_am", default: false, null: false
+    t.boolean "wednesday_pm", default: false, null: false
+    t.boolean "thursday_am", default: false, null: false
+    t.boolean "thursday_pm", default: false, null: false
+    t.boolean "friday_am", default: false, null: false
+    t.boolean "friday_pm", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["location_id"], name: "index_schedules_on_location_id"

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -3,12 +3,6 @@ FactoryBot.define do
     # Hackney
     location_id { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
 
-    trait :blank do
-      Schedule::SLOT_ATTRIBUTES.each do |attribute|
-        add_attribute(attribute) { false }
-      end
-    end
-
     trait :dalston do
       location_id { '183080c6-642b-4b8f-96fd-891f5cd9f9c7' }
     end

--- a/spec/features/booking_manager_fulfils_booking_request_spec.rb
+++ b/spec/features/booking_manager_fulfils_booking_request_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature 'Fulfiling Booking Requests' do
   end
 
   def and_an_unfulfilled_booking_request_exists
-    @schedule = create(:schedule, :blank)
+    @schedule = create(:schedule)
     @slot     = create(:bookable_slot, :realtime, date: '2018-12-06', schedule: @schedule)
     @booking  = build(:hackney_booking_request, number_of_slots: 0)
     @booking.slots.build(date: '2018-12-06', from: '0900', to: '1300', priority: 1)

--- a/spec/features/booking_manager_manages_availability_spec.rb
+++ b/spec/features/booking_manager_manages_availability_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Booking manager manages availability' do
   end
 
   def and_a_schedule_with_weekends_exists
-    @schedule = create(:schedule, :blank, :dalston)
+    @schedule = create(:schedule, :dalston)
   end
 
   def when_they_view_the_weekend_schedule
@@ -42,7 +42,7 @@ RSpec.feature 'Booking manager manages availability' do
   end
 
   def and_a_schedule_exists
-    @schedule = create(:schedule, :blank, monday_am: true, &:generate_bookable_slots!)
+    @schedule = create(:schedule, monday_am: true, &:generate_bookable_slots!)
   end
 
   def when_they_view_their_schedules

--- a/spec/features/booking_manager_manages_realtime_availability_spec.rb
+++ b/spec/features/booking_manager_manages_realtime_availability_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Booking manager manages realtime availability' do
   end
 
   def and_a_schedule_exists
-    @schedule = create(:schedule, :blank)
+    @schedule = create(:schedule)
   end
 
   def when_they_view_their_schedules

--- a/spec/features/booking_manager_manages_schedules_spec.rb
+++ b/spec/features/booking_manager_manages_schedules_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Booking manager manages schedules' do
       when_they_view_their_schedules
       then_they_see_default_schedules_across_their_locations
       when_they_manage_the_location_schedule
-      and_they_mark_some_days_unavailable
+      and_they_mark_some_days_available
       when_they_save_the_schedule
       then_slot_generation_is_scheduled
       and_they_see_the_schedule_summarised_accurately
@@ -37,7 +37,7 @@ RSpec.feature 'Booking manager manages schedules' do
     @page.schedules.second.manage.click
   end
 
-  def and_they_mark_some_days_unavailable
+  def and_they_mark_some_days_available
     @page = Pages::Schedule.new
     @page.load(location_id: '183080c6-642b-4b8f-96fd-891f5cd9f9c7')
     expect(@page).to be_loaded
@@ -59,11 +59,11 @@ RSpec.feature 'Booking manager manages schedules' do
     @page = Pages::Schedules.new
 
     @page.schedules.second.summary.tap do |summary|
-      expect(summary.monday_am).to be_closed
-      expect(summary.wednesday_pm).to be_closed
-      expect(summary.friday_am).to be_closed
-      # just a single example of an open slot
-      expect(summary.monday_pm).to be_open
+      expect(summary.monday_am).to be_open
+      expect(summary.wednesday_pm).to be_open
+      expect(summary.friday_am).to be_open
+      # just a single example of a closed slot
+      expect(summary.monday_pm).to be_closed
     end
   end
 end

--- a/spec/features/scheduled_reporting_summary_spec.rb
+++ b/spec/features/scheduled_reporting_summary_spec.rb
@@ -30,15 +30,15 @@ RSpec.feature 'Scheduled reporting summary' do
 
   def and_the_booking_locations_have_schedules_of_varying_availability
     # Unavailable
-    create(:schedule, :blank, location_id: '108cac82-16ec-41f0-8177-e55019e8c110')
+    create(:schedule, location_id: '108cac82-16ec-41f0-8177-e55019e8c110')
 
     # Limited availability
-    create(:schedule, :blank, location_id: '377e27e1-8f38-437a-baa9-4e90ebd980e8') do |schedule|
+    create(:schedule, location_id: '377e27e1-8f38-437a-baa9-4e90ebd980e8') do |schedule|
       create(:bookable_slot, :am, schedule: schedule, date: 1.week.from_now)
     end
 
     # Only available after the 4 week window
-    create(:schedule, :blank, location_id: '47b30a8f-d5f9-448e-a7ac-d5397a853e6a') do |schedule|
+    create(:schedule, location_id: '47b30a8f-d5f9-448e-a7ac-d5397a853e6a') do |schedule|
       create(:bookable_slot, :am, schedule: schedule, date: 5.weeks.from_now)
     end
   end

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe BookableSlot do
 
     context 'when mixed slots exists' do
       it 'does not permit non-realtime slots after the first realtime slot' do
-        @schedule = create(:schedule, :blank)
+        @schedule = create(:schedule)
 
         @schedule.create_realtime_bookable_slot!(
           start_at: 2.days.from_now,

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Schedule do
 
   describe '#unavailable?' do
     context 'with a default schedule' do
-      it 'is false' do
-        expect(described_class.new).to_not be_unavailable
+      it 'is true' do
+        expect(described_class.new).to be_unavailable
       end
     end
 
     context 'with an empty schedule' do
       it 'is true' do
-        @schedule = create(:schedule, :blank)
+        @schedule = create(:schedule)
 
         expect(@schedule).to be_unavailable
       end
@@ -31,7 +31,7 @@ RSpec.describe Schedule do
         create(:bookable_slot, :am, schedule: schedule)
       end
 
-      @current_schedule = create(:schedule, :blank, monday_am: true, friday_pm: true)
+      @current_schedule = create(:schedule, monday_am: true, friday_pm: true)
     end
 
     after { travel_back }
@@ -67,7 +67,7 @@ RSpec.describe Schedule do
 
     context 'when no schedules exist' do
       it 'returns a default schedule' do
-        expect(described_class.current(hackney.id)).to_not be_persisted
+        expect(described_class.current(hackney.id)).to be_unavailable
       end
     end
   end

--- a/spec/requests/create_an_appointment_request_spec.rb
+++ b/spec/requests/create_an_appointment_request_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
   end
 
   def and_an_empty_schedule_exists
-    @schedule = create(:schedule, :blank)
+    @schedule = create(:schedule)
   end
 
   def then_the_service_responds_with_a_422
@@ -48,7 +48,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
   end
 
   def and_a_schedule_with_realtime_slots_exists
-    @schedule = create(:schedule, :blank)
+    @schedule = create(:schedule)
     @slot     = create(:bookable_slot, :realtime, date: '2018-11-08', schedule: @schedule)
   end
 

--- a/spec/requests/internal_bookable_slots_api_spec.rb
+++ b/spec/requests/internal_bookable_slots_api_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'GET /locations/:location_id/bookable_slots.json' do
   end
 
   def given_a_location_with_a_schedule_exists
-    @schedule = create(:schedule, :blank, monday_am: true, &:generate_bookable_slots!)
+    @schedule = create(:schedule, monday_am: true, &:generate_bookable_slots!)
   end
 
   def when_a_request_for_bookable_slots_is_made


### PR DESCRIPTION
When a new location appears that would otherwise require a new schedule
to be created, we should automatically create a default, blank schedule
on the booking manager's behalf.