### PR TITLE
Include guider name in email

### DIFF
--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -15,7 +15,7 @@ module EmailHelper
 
   def mailer_booking_link(booking_request_or_appointment)
     name = booking_request_or_appointment.model_name.human.downcase
-    url  = if booking_request_or_appointment.is_a?(Appointment)
+    url  = if booking_request_or_appointment.entity.is_a?(Appointment)
              edit_appointment_url(booking_request_or_appointment)
            else
              new_booking_request_appointment_url(booking_request_or_appointment)

--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -1,6 +1,6 @@
 class Appointments < ApplicationMailer
   def booking_manager_cancellation(booking_manager, appointment)
-    @appointment = appointment
+    @appointment = decorate(appointment)
 
     mailgun_headers :sms_appointment_cancellation
 
@@ -8,10 +8,7 @@ class Appointments < ApplicationMailer
   end
 
   def customer(appointment, booking_location)
-    @appointment = LocationAwareEntity.new(
-      entity: appointment,
-      booking_location: booking_location
-    )
+    @appointment = decorate(appointment, booking_location)
 
     identification_headers_for(appointment)
 
@@ -23,10 +20,7 @@ class Appointments < ApplicationMailer
   end
 
   def reminder(appointment, booking_location)
-    @appointment = LocationAwareEntity.new(
-      entity: appointment,
-      booking_location: booking_location
-    )
+    @appointment = decorate(appointment, booking_location)
 
     mailgun_headers :appointment_reminder
 
@@ -38,6 +32,15 @@ class Appointments < ApplicationMailer
   end
 
   private
+
+  def decorate(appointment, booking_location = nil)
+    booking_location ||= BookingLocations.find(appointment.location_id)
+
+    LocationAwareEntity.new(
+      entity: appointment,
+      booking_location: booking_location
+    )
+  end
 
   def identification_headers_for(appointment)
     value = appointment.updated? ? 'appointment_modified' : 'appointment_confirmation'

--- a/app/mailers/booking_requests.rb
+++ b/app/mailers/booking_requests.rb
@@ -12,7 +12,7 @@ class BookingRequests < ApplicationMailer
   end
 
   def booking_manager(booking_request_or_appointment, booking_manager)
-    @booking_request_or_appointment = booking_request_or_appointment
+    @booking_request_or_appointment = decorate(booking_request_or_appointment)
     name = booking_request_or_appointment.model_name.human
 
     mailgun_headers('booking_manager_booking_request')
@@ -25,5 +25,16 @@ class BookingRequests < ApplicationMailer
 
     mailgun_headers('email_failure_booking_request')
     mail to: booking_manager.email, subject: 'Email Failure - Pension Wise Booking Request'
+  end
+
+  private
+
+  def decorate(booking_request_or_appointment)
+    booking_location = BookingLocations.find(booking_request_or_appointment.location_id)
+
+    LocationAwareEntity.new(
+      entity: booking_request_or_appointment,
+      booking_location: booking_location
+    )
   end
 end

--- a/app/views/appointments/booking_manager_cancellation.html.erb
+++ b/app/views/appointments/booking_manager_cancellation.html.erb
@@ -7,7 +7,11 @@
 <% end %>
 
 <%= p do %>
-  Appointment reference: <%= @appointment.reference %>.
+  Appointment reference: <%= @appointment.reference %>
+<% end %>
+
+<%= p do %>
+  Guider: <%= @appointment.guider_name %>
 <% end %>
 
 <%= p do %>

--- a/app/views/booking_requests/booking_manager.html.erb
+++ b/app/views/booking_requests/booking_manager.html.erb
@@ -3,8 +3,12 @@
 <% end %>
 
 <%= p do %>
-  Reference: <%= @booking_request_or_appointment.reference %>.
+  Reference: <%= @booking_request_or_appointment.reference %>
 <% end %>
+
+<%= p do %>
+  Guider: <%= @booking_request_or_appointment.guider_name %>
+<% end if @booking_request_or_appointment.guider_name.present? %>
 
 <%= p do %>
   <%= mailer_booking_link(@booking_request_or_appointment) %>

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Appointments do
       it 'includes the appointment particulars' do
         expect(body).to include(appointment.reference)
         expect(body).to include("/appointments/#{appointment.id}/edit")
+        expect(body).to include('Ben Lovell') # guider
       end
     end
   end

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -62,8 +62,11 @@ RSpec.describe BookingRequests do
     describe 'rendering the body' do
       let(:body) { subject.body.encoded }
 
-      it 'includes a link to the booking request page' do
+      it 'renders the particulars' do
+        expect(body).to include('View the booking request')
         expect(body).to include("http://localhost:3001/booking_requests/#{booking_request.id}/appointments/new")
+
+        expect(body).not_to include('Guider:') # guider is not yet allocated
       end
     end
 
@@ -73,7 +76,9 @@ RSpec.describe BookingRequests do
       it 'renders the appointment particulars' do
         expect(mail.subject).to eq('Pension Wise Appointment')
 
+        expect(subject.body.encoded).to include('View the appointment')
         expect(subject.body.encoded).to include("/appointments/#{booking_request.id}/edit")
+        expect(subject.body.encoded).to include('Guider: Ben Lovell') # guider
       end
     end
   end


### PR DESCRIPTION
Includes the guider name in the email so booking managers and guiders can
easily identity which booking and appointment notifications require their
attention.