### PR TITLE
Restore the link to booking requests

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
   <% end %>
   <% if current_user.booking_manager? %>
   <li>
-    <%= link_to 'Booking Requests', root_path %>
+    <%= link_to 'Booking Requests', booking_requests_path %>
   </li>
   <li>
     <%= link_to 'Appointments', appointments_path %>


### PR DESCRIPTION
Though these are now considered legacy due to realtime upgrades, there
are still cases where booking managers need to access legacy bookings
for historical reasons.