### PR TITLE
Increase slot colour contrast

### DIFF
--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -1,5 +1,6 @@
 $calendar-loading-view-background: transparentize($color-white, .2);
 $calendar-appointment-cancelled-background: lighten($color-medium-carmine, 20%);
+$calendar-bookable-slot-background: darken($color-green, 60%);
 
 $guider-row-height: 110px;
 
@@ -21,8 +22,13 @@ th {
   font-size: 12px;
 }
 
+.fc-bgevent {
+  background: $calendar-bookable-slot-background;
+}
+
 .fc-event {
   @include striped($color-boston-blue);
+  margin: 2px;
 }
 
 .fc-event--cancelled {

--- a/app/assets/stylesheets/helpers/_colours.scss
+++ b/app/assets/stylesheets/helpers/_colours.scss
@@ -4,6 +4,7 @@ $color-black: #000;
 $color-dove-gray: #707070;
 $color-medium-carmine: #ad3b3b;
 $color-boston-blue: #3a87ad;
+$color-green: #c6f5c6;
 
 $appointment-status-well-background-color: $color-silver;
 $read-only-background: $color-white;


### PR DESCRIPTION
Makes green underlying slots more visible under appointments by
improving the contrasting colours and widening the margins a little.