### PR TITLE
Allocate slots when they are missing

### DIFF
--- a/app/forms/edit_appointment_form.rb
+++ b/app/forms/edit_appointment_form.rb
@@ -7,10 +7,44 @@ class EditAppointmentForm < SimpleDelegator
     super
   end
 
+  def update(attributes)
+    assign_attributes(attributes)
+
+    return if invalid?
+
+    transaction do
+      allocate if allocation_changed?
+      super
+    end
+  end
+
   def slots
     Schedule
       .current(location_id)
       .without_appointments
       .realtime
+  end
+
+  private
+
+  def allocation_changed?
+    proceeded_at_changed? || guider_id_changed? || location_id_changed?
+  end
+
+  def allocate
+    return unless schedule = Schedule.current(location_id)
+
+    slot = schedule.create_realtime_bookable_slot(
+      start_at: proceeded_at,
+      guider_id: guider_id
+    )
+
+    log_errors(slot) if slot.invalid?
+  end
+
+  def log_errors(slot)
+    logger.warn('Could not allocate missing slot')
+    logger.warn("proceeded_at: #{proceeded_at}, guider_id: #{guider_id}, location_id: #{location_id}")
+    logger.warn(slot.errors.full_messages.to_sentence)
   end
 end

--- a/spec/forms/edit_appointment_form_spec.rb
+++ b/spec/forms/edit_appointment_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe EditAppointmentForm do
   let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
-  let(:underlying_appointment) { build_stubbed(:appointment) }
+  let(:underlying_appointment) { create(:appointment) }
   let(:appointment) do
     LocationAwareEntity.new(
       entity: underlying_appointment,
@@ -20,5 +20,23 @@ RSpec.describe EditAppointmentForm do
 
   it 'delegates the agent to the underlying booking request' do
     expect(subject.agent).to eq(appointment.booking_request.agent)
+  end
+
+  context 'when no underlying slot exists after reallocation' do
+    it 'creates the missing realtime slot' do
+      # creates the missing slot
+      expect { subject.update(proceeded_at: '2019-05-22 13:00 UTC') }.to change { BookableSlot.count }.by(1)
+
+      # doesn't create another, overlapping slot
+      expect { subject.update(proceeded_at: '2019-05-22 12:45 UTC') }.not_to(change { BookableSlot.count })
+
+      # creates another slot for the guider change
+      expect { subject.update(guider_id: 2) }.to change { BookableSlot.count }.by(1)
+
+      # creates another slot for the location and date change
+      expect do
+        subject.update(location_id: '183080c6-642b-4b8f-96fd-891f5cd9f9c7', proceeded_at: '2019-05-22 14:15 UTC')
+      end.to change { BookableSlot.count }.by(1)
+    end
   end
 end


### PR DESCRIPTION
When a booking manager alters the date/time and/or the guider of an
already booked appointment we will now create an underlying slot where
no existing overlapping slot is present.