### PR TITLE
Don't permit a continual cycle of drop notifications

### DIFF
--- a/app/controllers/mail_gun/drops_controller.rb
+++ b/app/controllers/mail_gun/drops_controller.rb
@@ -3,6 +3,9 @@ module MailGun
     skip_before_action :verify_authenticity_token
 
     def create
+      form = DropForm.new(drop_params)
+      form.create_activity
+
       head :ok
     end
 

--- a/app/jobs/email_drop_notification_job.rb
+++ b/app/jobs/email_drop_notification_job.rb
@@ -6,6 +6,8 @@ class EmailDropNotificationJob < ActiveJob::Base
 
     raise BookingManagersNotFoundError unless booking_managers.present?
 
+    return if booking_managers.pluck(:email).include?(booking_request.email)
+
     booking_managers.each do |booking_manager|
       BookingRequests.email_failure(booking_request, booking_manager).deliver_later
     end

--- a/spec/jobs/email_drop_notification_job_spec.rb
+++ b/spec/jobs/email_drop_notification_job_spec.rb
@@ -12,10 +12,18 @@ RSpec.describe EmailDropNotificationJob, '#perform' do
   end
 
   context 'when booking manager(s) are found' do
-    before { create(:hackney_booking_manager) }
+    let!(:booking_manager) { create(:hackney_booking_manager, email: 'doh@example.com') }
 
     it 'fans out a notification job for each booking manager' do
       assert_enqueued_jobs(1) { subject }
+    end
+
+    context 'when the booking manager and customer email is the same' do
+      let(:booking_request) { create(:hackney_booking_request, email: 'doh@example.com') }
+
+      it 'does not fan out, thus avoiding an infinite loop of bounces' do
+        assert_no_enqueued_jobs { subject }
+      end
     end
   end
 

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'POST /mail_gun/drops' do
   scenario 'inbound hooks create activity entries' do
-    skip 'for now'
-
     perform_enqueued_jobs do
       with_a_configured_token('deadbeef') do
         given_a_hackney_booking_request


### PR DESCRIPTION
When a booking manager creates an appointment and the confirmation email to
themselves (in the role of customer) fails, they will be sent the booking
manager's regular email failure notification email. If this subsequently
fails, this enters an infinite loop of bounce/retry until the application
queue - in this instance, redis - falls over with out-of-memory exceptions.

This change ensures that whenever the booking's customer email matches any
of the found booking manager emails the drop processing is aborted and a
successful status is reported to mailgun, ensuring they do not continually
retry.