### PR TITLE
Include date/location in SMS cancellation

### DIFF
--- a/app/jobs/sms_cancellation_success_job.rb
+++ b/app/jobs/sms_cancellation_success_job.rb
@@ -4,10 +4,25 @@ class SmsCancellationSuccessJob < SmsJobBase
   def perform(appointment)
     return unless api_key
 
+    appointment = LocationAwareEntity.new(
+      entity: appointment,
+      booking_location: BookingLocations.find(appointment.location_id)
+    )
+
+    send_sms(appointment)
+  end
+
+  private
+
+  def send_sms(appointment)
     sms_client.send_sms(
       phone_number: appointment.phone,
       template_id: TEMPLATE_ID,
-      reference: appointment.reference
+      reference: appointment.reference,
+      personalisation: {
+        date: appointment.proceeded_at.to_s(:govuk_date_short),
+        location: appointment.location_name
+      }
     )
   end
 end

--- a/spec/jobs/sms_cancellation_success_job_spec.rb
+++ b/spec/jobs/sms_cancellation_success_job_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe SmsCancellationSuccessJob, '#perform' do
     expect(client).to receive(:send_sms).with(
       phone_number: '07715 930 444',
       template_id: SmsCancellationSuccessJob::TEMPLATE_ID,
-      reference: appointment.reference
+      reference: appointment.reference,
+      personalisation: {
+        date: '2:00pm, 20 Jun 2016',
+        location: 'Hackney'
+      }
     )
 
     described_class.new.perform(appointment)


### PR DESCRIPTION
Includes these appointment attributes to be displayed in the SMS
cancellation success template.