### PR TITLE
Send final reminder at 72 hour interval

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -99,11 +99,11 @@ class Appointment < ActiveRecord::Base # rubocop:disable ClassLength
   end
 
   def self.needing_sms_reminder
-    pending.not_booked_today.with_mobile.where(proceeded_at: [day_range(2), day_range(7)])
+    pending.not_booked_today.with_mobile.where(proceeded_at: [day_range(3), day_range(7)])
   end
 
   def self.needing_reminder
-    not_booked_today.with_email.without_mobile.pending.where(proceeded_at: [day_range(2), day_range(7)])
+    not_booked_today.with_email.without_mobile.pending.where(proceeded_at: [day_range(3), day_range(7)])
   end
 
   def self.for_sms_cancellation(number)

--- a/spec/features/scheduled_appointment_reminders_spec.rb
+++ b/spec/features/scheduled_appointment_reminders_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Scheduled appointment reminders' do
-  scenario 'more than 48 hours before the appointment, it does not send a reminder' do
+  scenario 'more than 72 hours before the appointment, it does not send a reminder' do
     perform_enqueued_jobs do
       travel_to Time.zone.parse('2016-06-17 11:55') do
         given_an_unreminded_appointment_exists
@@ -12,9 +12,9 @@ RSpec.feature 'Scheduled appointment reminders' do
     end
   end
 
-  scenario 'within 48 hours of the appointment, it does send a reminder' do
+  scenario 'within 72 hours of the appointment, it does send a reminder' do
     perform_enqueued_jobs do
-      travel_to Time.zone.parse('2016-06-18 12:05') do
+      travel_to Time.zone.parse('2016-06-17 12:05') do
         given_an_unreminded_appointment_exists(phone: '02082524782')
         when_the_reminder_job_runs
         then_an_email_reminder_is_delivered

--- a/spec/features/sms_appointment_reminder_spec.rb
+++ b/spec/features/sms_appointment_reminder_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'SMS appointment reminders' do
     @mobile = create(
       :appointment,
       phone: '07715930455',
-      proceeded_at: 2.days.from_now,
+      proceeded_at: 3.days.from_now,
       created_at: 1.day.ago,
       guider_id: 3
     )


### PR DESCRIPTION
We previously sent reminders at 48 hours before the appointment was due
to take place. This has been extended to 72 hours in the hope that
cancellations grant enough time for their underlying slots to be
rebooked by others in the current booking window.