### PR TITLE
Only send to actual booking managers

### DIFF
--- a/app/jobs/booking_manager_confirmation_job.rb
+++ b/app/jobs/booking_manager_confirmation_job.rb
@@ -2,9 +2,11 @@ class BookingManagerConfirmationJob < ActiveJob::Base
   queue_as :default
 
   def perform(booking_request)
-    booking_managers = User.active.where(organisation_content_id: booking_request.booking_location_id)
+    booking_managers = User.active.where(
+      organisation_content_id: booking_request.booking_location_id
+    ).select(&:booking_manager?)
 
-    raise BookingManagersNotFoundError unless booking_managers.present?
+    raise BookingManagersNotFoundError if booking_managers.blank?
 
     booking_managers.each do |booking_manager|
       BookingRequests.booking_manager(

--- a/spec/jobs/booking_manager_confirmation_job_spec.rb
+++ b/spec/jobs/booking_manager_confirmation_job_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe BookingManagerConfirmationJob, '#perform' do
     end
   end
 
+  context 'with organisation members that are not booking managers' do
+    before { create(:user, organisation_content_id: 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
+
+    it 'raises an error' do
+      expect { subject }.to raise_error(BookingManagersNotFoundError)
+    end
+  end
+
   context 'when the booking has an appointment associated' do
     let(:booking_manager) { create(:hackney_booking_manager) }
 


### PR DESCRIPTION
This was highlighted by an edge case whereby a re-synchronised and
previously inactive user was notified for a new booking although they
were no longer assigned the correct permissions for this organisation
and application.