### PR TITLE
Ensure only booking managers are notified

### DIFF
--- a/app/jobs/booking_manager_confirmation_job.rb
+++ b/app/jobs/booking_manager_confirmation_job.rb
@@ -2,9 +2,7 @@ class BookingManagerConfirmationJob < ActiveJob::Base
   queue_as :default
 
   def perform(booking_request)
-    booking_managers = User.active.where(
-      organisation_content_id: booking_request.booking_location_id
-    ).select(&:booking_manager?)
+    booking_managers = User.booking_managers(booking_request.booking_location_id)
 
     raise BookingManagersNotFoundError if booking_managers.blank?
 

--- a/app/jobs/booking_manager_sms_cancellation_job.rb
+++ b/app/jobs/booking_manager_sms_cancellation_job.rb
@@ -2,18 +2,10 @@ class BookingManagerSmsCancellationJob < ActiveJob::Base
   queue_as :default
 
   def perform(appointment)
-    recipients = booking_managers(appointment)
+    recipients = User.booking_managers(appointment.booking_request.booking_location_id)
 
     recipients.each do |recipient|
       Appointments.booking_manager_cancellation(recipient, appointment).deliver_later
     end
-  end
-
-  private
-
-  def booking_managers(appointment)
-    User.active.where(
-      organisation_content_id: appointment.booking_request.booking_location_id
-    )
   end
 end

--- a/app/jobs/email_drop_notification_job.rb
+++ b/app/jobs/email_drop_notification_job.rb
@@ -2,7 +2,7 @@ class EmailDropNotificationJob < ActiveJob::Base
   queue_as :default
 
   def perform(booking_request)
-    booking_managers = User.active.where(organisation_content_id: booking_request.booking_location_id)
+    booking_managers = User.booking_managers(booking_request.booking_location_id)
 
     raise BookingManagersNotFoundError unless booking_managers.present?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,10 @@ class User < ActiveRecord::Base
 
   scope :active, -> { where(disabled: false) }
 
+  scope :booking_managers, lambda { |booking_location_id|
+    active.where(organisation_content_id: booking_location_id).select(&:booking_manager?)
+  }
+
   def unfulfilled_booking_requests
     booking_requests
       .includes(:appointment)


### PR DESCRIPTION
These places were missed last time around. This ensures only booking
managers will receive these particular notifications.