### PR TITLE
Allow agents to edit bookings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
   chrome: stable
 services:
 - redis-server
+- postgresql
 cache:
   bundler: true
   directories:

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -35,6 +35,10 @@ class ActivitiesController < ApplicationController
   end
 
   def booking_request
-    current_user.booking_requests.find(params[:booking_request_id])
+    if current_user.agent? || current_user.agent_manager?
+      BookingRequest.find(params[:booking_request_id])
+    else
+      current_user.booking_requests.find(params[:booking_request_id])
+    end
   end
 end

--- a/app/controllers/agent/application_controller.rb
+++ b/app/controllers/agent/application_controller.rb
@@ -2,9 +2,11 @@ module Agent
   class ApplicationController < ActionController::Base
     include GDS::SSO::ControllerMethods
     include LogrageFilterer
+    include Pollable
 
     layout 'application'
     protect_from_forgery with: :exception
+    add_flash_types :success, :warning
 
     before_action do
       authorise_user!(any_of: [User::AGENT_PERMISSION, User::AGENT_MANAGER_PERMISSION])

--- a/app/controllers/agent/application_controller.rb
+++ b/app/controllers/agent/application_controller.rb
@@ -9,10 +9,6 @@ module Agent
     protect_from_forgery with: :exception
     add_flash_types :success, :warning
 
-    before_action do
-      authorise_user!(any_of: [User::AGENT_PERMISSION, User::AGENT_MANAGER_PERMISSION])
-    end
-
     protected
 
     def location_id

--- a/app/controllers/agent/application_controller.rb
+++ b/app/controllers/agent/application_controller.rb
@@ -1,8 +1,9 @@
 module Agent
   class ApplicationController < ActionController::Base
-    include GDS::SSO::ControllerMethods
-    include LogrageFilterer
     include Pollable
+    include LogrageFilterer
+    include BookingLocationable
+    include GDS::SSO::ControllerMethods
 
     layout 'application'
     protect_from_forgery with: :exception
@@ -29,9 +30,7 @@ module Agent
     end
 
     def booking_location
-      @booking_location ||= BookingLocationDecorator.new(
-        BookingLocations.find(location_id)
-      )
+      super(location_id: location_id)
     end
   end
 end

--- a/app/controllers/agent/appointments_controller.rb
+++ b/app/controllers/agent/appointments_controller.rb
@@ -1,5 +1,9 @@
 module Agent
   class AppointmentsController < Agent::ApplicationController
+    before_action do
+      authorise_user!(User::AGENT_MANAGER_PERMISSION)
+    end
+
     before_action :load_appointment
 
     def edit

--- a/app/controllers/agent/appointments_controller.rb
+++ b/app/controllers/agent/appointments_controller.rb
@@ -1,15 +1,14 @@
 module Agent
   class AppointmentsController < Agent::ApplicationController
+    before_action :load_appointment
+
     def edit
-      @appointment = Appointment.find(params[:id])
-      @activities  = @appointment.activities
+      @activities = @appointment.activities
     end
 
     def update
-      @appointment = Appointment.find(params[:id])
-
       if @appointment.update(edit_appointment_params)
-        notify_customer(@appointment)
+        notify_customer(@appointment.entity)
 
         redirect_to edit_agent_appointment_path(@appointment),
                     success: 'The appointment was updated.'
@@ -21,6 +20,15 @@ module Agent
     end
 
     private
+
+    def load_appointment
+      @appointment = Appointment.find(params[:id])
+
+      @appointment = LocationAwareEntity.new(
+        entity: @appointment,
+        booking_location: BookingLocations.find(@appointment.location_id)
+      )
+    end
 
     def edit_appointment_params # rubocop:disable Metrics/MethodLength
       params

--- a/app/controllers/agent/appointments_controller.rb
+++ b/app/controllers/agent/appointments_controller.rb
@@ -1,0 +1,47 @@
+module Agent
+  class AppointmentsController < Agent::ApplicationController
+    def edit
+      @appointment = Appointment.find(params[:id])
+      @activities  = @appointment.activities
+    end
+
+    def update
+      @appointment = Appointment.find(params[:id])
+
+      if @appointment.update(edit_appointment_params)
+        notify_customer(@appointment)
+
+        redirect_to edit_agent_appointment_path(@appointment),
+                    success: 'The appointment was updated.'
+      else
+        @activities = @appointment.activities
+
+        render :edit
+      end
+    end
+
+    private
+
+    def edit_appointment_params # rubocop:disable Metrics/MethodLength
+      params
+        .require(:appointment)
+        .permit(
+          :name,
+          :email,
+          :phone,
+          :defined_contribution_pot_confirmed,
+          :accessibility_requirements,
+          :memorable_word,
+          :date_of_birth,
+          :additional_info
+        )
+    end
+
+    def notify_customer(appointment)
+      return unless appointment.notify?
+
+      AppointmentChangeNotificationJob.perform_later(appointment)
+      PrintedConfirmationLetterJob.perform_later(appointment)
+    end
+  end
+end

--- a/app/controllers/agent/appointments_controller.rb
+++ b/app/controllers/agent/appointments_controller.rb
@@ -48,6 +48,7 @@ module Agent
     def notify_customer(appointment)
       return unless appointment.notify?
 
+      BookingManagerAppointmentChangeNotificationJob.perform_later(appointment)
       AppointmentChangeNotificationJob.perform_later(appointment)
       PrintedConfirmationLetterJob.perform_later(appointment)
     end

--- a/app/controllers/agent/booking_requests_controller.rb
+++ b/app/controllers/agent/booking_requests_controller.rb
@@ -4,7 +4,7 @@ module Agent
 
     def index
       @search = AgentSearchForm.new(search_params)
-      @booking_requests = @search.results
+      @appointments = @search.results
     end
 
     def new

--- a/app/controllers/agent/booking_requests_controller.rb
+++ b/app/controllers/agent/booking_requests_controller.rb
@@ -2,6 +2,10 @@ module Agent
   class BookingRequestsController < Agent::ApplicationController
     include RealtimeProcessable
 
+    before_action do
+      authorise_user!(any_of: [User::AGENT_MANAGER_PERMISSION, User::AGENT_PERMISSION])
+    end
+
     def index
       @search = AgentSearchForm.new(search_params)
       @appointments = @search.results

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pollable
+
   protect_from_forgery with: :exception
 
   add_flash_types :success, :warning
@@ -9,11 +11,6 @@ class ApplicationController < ActionController::Base
   before_action do
     authorise_user!(User::BOOKING_MANAGER_PERMISSION)
   end
-
-  def poll_interval_milliseconds
-    Integer(ENV.fetch(Activity::POLLING_KEY, 5000))
-  end
-  helper_method :poll_interval_milliseconds
 
   def booking_location
     @booking_location ||= BookingLocationDecorator.new(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include Pollable
+  include BookingLocationable
 
   protect_from_forgery with: :exception
 
@@ -11,11 +12,4 @@ class ApplicationController < ActionController::Base
   before_action do
     authorise_user!(User::BOOKING_MANAGER_PERMISSION)
   end
-
-  def booking_location
-    @booking_location ||= BookingLocationDecorator.new(
-      BookingLocations.find(current_user.booking_location_id)
-    )
-  end
-  helper_method :booking_location
 end

--- a/app/controllers/changes_controller.rb
+++ b/app/controllers/changes_controller.rb
@@ -1,18 +1,23 @@
 class ChangesController < ApplicationController
   def index
-    @audits = AuditPresenter.wrap(
-      appointment.audits.reverse,
-      booking_location
-    )
+    @audits = AuditPresenter.wrap(appointment.audits.reverse, booking_location(appointment))
   end
 
   private
 
+  def booking_location(appointment)
+    super(location_id: appointment.location_id)
+  end
+
   def appointment
     @appointment ||= begin
-      current_user
-        .appointments
-        .find_by(booking_request_id: params[:appointment_id])
+      scope = if current_user.agent? || current_user.agent_manager?
+                Appointment
+              else
+                current_user.appointments
+              end
+
+      scope.find_by(booking_request_id: params[:appointment_id])
     end
   end
 end

--- a/app/forms/agent_search_form.rb
+++ b/app/forms/agent_search_form.rb
@@ -3,18 +3,16 @@ class AgentSearchForm
 
   attr_accessor :reference
   attr_accessor :name
-  attr_accessor :status
   attr_accessor :date
   attr_accessor :agent
   attr_accessor :page
 
   def results # rubocop:disable Metrics/AbcSize
-    scope = BookingRequest.includes(:slots, :agent)
-    scope = scope.where(id: reference) if reference.present?
-    scope = scope.where('booking_requests.name ILIKE ?', "%#{name}%") if name.present?
-    scope = scope.where(status: status) if status.present?
+    scope = Appointment.includes(booking_request: :agent)
+    scope = scope.where(booking_requests: { id: reference }) if reference.present?
+    scope = scope.where('name ILIKE ?', "%#{name}%") if name.present?
     scope = scope.where(created_at: date_range) if date_range
-    scope = scope.where(agent_id: agent) if agent.present?
+    scope = scope.where(booking_requests: { agent_id: agent }) if agent.present?
     scope.reorder(created_at: :desc).page(page)
   end
 

--- a/app/jobs/booking_manager_appointment_change_notification_job.rb
+++ b/app/jobs/booking_manager_appointment_change_notification_job.rb
@@ -1,0 +1,16 @@
+class BookingManagerAppointmentChangeNotificationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(appointment)
+    booking_managers = User.booking_managers(appointment.booking_location_id)
+
+    raise BookingManagersNotFoundError if booking_managers.blank?
+
+    booking_managers.each do |booking_manager|
+      Appointments.booking_manager_appointment_changed(
+        appointment,
+        booking_manager
+      ).deliver_later
+    end
+  end
+end

--- a/app/lib/booking_locationable.rb
+++ b/app/lib/booking_locationable.rb
@@ -1,0 +1,9 @@
+module BookingLocationable
+  def booking_location(location_id: current_user.booking_location_id)
+    @booking_location ||= BookingLocationDecorator.new(BookingLocations.find(location_id))
+  end
+
+  def self.included(base)
+    base.helper_method :booking_location
+  end
+end

--- a/app/lib/pollable.rb
+++ b/app/lib/pollable.rb
@@ -1,0 +1,9 @@
+module Pollable
+  def self.included(base)
+    base.helper_method :poll_interval_milliseconds
+  end
+
+  def poll_interval_milliseconds
+    Integer(ENV.fetch(Activity::POLLING_KEY, 5000))
+  end
+end

--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -1,4 +1,12 @@
 class Appointments < ApplicationMailer
+  def booking_manager_appointment_changed(appointment, booking_manager)
+    @appointment = appointment
+
+    mailgun_headers :booking_manager_appointment_changed
+
+    mail(to: booking_manager.email, subject: 'Pension Wise Appointment Changed')
+  end
+
   def cancellation(appointment)
     @appointment = decorate(appointment)
 

--- a/app/views/agent/appointments/edit.html.erb
+++ b/app/views/agent/appointments/edit.html.erb
@@ -1,0 +1,113 @@
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Planner</a></li>
+    <li class="active"><%= @appointment.name %></li>
+  </ol>
+
+  <h1>Manage appointment for <%= @appointment.name %> <small><%= @appointment.reference %></small></h1>
+</div>
+
+<%= render partial: 'activities/activity_feed', locals: {
+  activities: @activities,
+  booking_request: @appointment.booking_request
+} %>
+
+<div class="row">
+  <div class="col-md-4">
+    <h3 class="h4">Created at</h3>
+    <p class="lead">
+      <strong><%= @appointment.created_at.to_s(:govuk_date) %></strong>
+    </p>
+
+    <hr>
+    <h3 class="h4">Location</h3>
+    <p class="lead">
+      <strong>
+        <a href="https://www.pensionwise.gov.uk/locations/<%= @appointment.location_id %>" class="t-location-name">
+          <%= guard_missing_location(@appointment, :location_name) %>
+        </a>
+      </strong>
+    </p>
+
+    <% if @appointment.email? %>
+      <hr>
+      <%= button_to(
+            'Resend email confirmation',
+            booking_request_confirmation_path(@appointment.booking_request),
+            class: 'btn btn-default btn-block t-resend-confirmation',
+            data: { confirm: 'Are you sure?' }
+        )
+      %>
+    <% end %>
+  </div>
+
+  <%= form_for @appointment, url: agent_appointment_path(@appointment) do |f| %>
+    <div class="col-md-8 l-appointment-details">
+      <div class="well">
+        <% if @appointment.errors.any? %>
+          <div class="alert alert-danger t-errors" role="alert">
+            <h3 class="alert__heading h4">There's a problem</h3>
+            <ul>
+              <% @appointment.errors.full_messages.each do |msg| %>
+                <li><%= msg %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+        <div class="row">
+          <div class="col-md-6">
+            <h2 class="h3">Customer details</h2>
+            <div class="form-group">
+              <%= f.label :name %>
+              <%= f.text_field :name, class: 'form-control t-name' %>
+            </div>
+            <div class="form-group">
+              <%= f.label :email %>
+              <%= f.text_field :email, class: 'form-control t-email' %>
+            </div>
+            <div class="form-group">
+              <%= f.label :phone %>
+              <%= f.text_field :phone, class: 'form-control t-phone' %>
+            </div>
+            <div class="form-group">
+              <%= f.label :memorable_word %>
+              <%= f.text_field :memorable_word, class: 'form-control t-memorable-word' %>
+            </div>
+            <%= render partial: 'shared/date_of_birth_form_field', locals: { form: f } %>
+          </div>
+          <div class="col-md-6">
+            <h2 class="h3">Appointment details</h2>
+            <div class="form-group">
+              <%= f.label :additional_info %>
+              <%= f.text_area :additional_info, class: 'form-control t-additional-info', rows: 5, maxlength: 500 %>
+            </div>
+            <div class="form-group">
+              <p>Defined contribution pot confirmed?</p>
+              <%= f.label :defined_contribution_pot_confirmed, value: true, class: 'radio-inline' do %>
+                  <%= f.radio_button :defined_contribution_pot_confirmed, true, class: 't-defined-contribution-pot-confirmed-yes' %>
+                  Yes
+              <% end %>
+
+              <%= f.label :defined_contribution_pot_confirmed, value: false, class: 'radio-inline' do %>
+                <%= f.radio_button :defined_contribution_pot_confirmed, false, class: 't-defined-contribution-pot-confirmed-dont-know' %>
+                Don’t know
+              <% end %>
+            </div>
+            <div class="form-group">
+              <%= f.label :accessibility_requirements, class: 'checkbox-inline' do %>
+                <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements' %> Accessibility requirements?
+              <% end %>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-12">
+            <%= f.button class: 'btn btn-primary btn-block t-submit' do %>
+              Update appointment details for <%= @appointment.name %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/agent/booking_requests/index.html.erb
+++ b/app/views/agent/booking_requests/index.html.erb
@@ -55,6 +55,7 @@
             <th>Date/time</th>
             <th>Reference</th>
             <th>Agent</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -77,6 +78,12 @@
               </td>
               <td>
                 <%= appointment.booking_request.agent&.name.presence || safe_location_name(appointment.booking_location_id) %>
+              </td>
+              <td>
+                <%= link_to(edit_agent_appointment_path(appointment), title: 'Manage', class: 'btn btn-info t-edit') do %>
+                  <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                  <span class="sr-only">Manage</span>
+                <% end %>
               </td>
             </tr>
           <% end %>

--- a/app/views/agent/booking_requests/index.html.erb
+++ b/app/views/agent/booking_requests/index.html.erb
@@ -80,9 +80,11 @@
                 <%= appointment.booking_request.agent&.name.presence || safe_location_name(appointment.booking_location_id) %>
               </td>
               <td>
-                <%= link_to(edit_agent_appointment_path(appointment), title: 'Manage', class: 'btn btn-info t-edit') do %>
-                  <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                  <span class="sr-only">Manage</span>
+                <% if current_user.agent_manager? %>
+                  <%= link_to(edit_agent_appointment_path(appointment), title: 'Manage', class: 'btn btn-info t-edit') do %>
+                    <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                    <span class="sr-only">Manage</span>
+                  <% end %>
                 <% end %>
               </td>
             </tr>

--- a/app/views/agent/booking_requests/index.html.erb
+++ b/app/views/agent/booking_requests/index.html.erb
@@ -19,11 +19,7 @@
           </li>
           <li class="filters__item">
             <%= f.label :name, class: 'filters__label' %>
-            <%= f.text_field :name, class: 't-name form-control filters__form-control', placeholder: 'Name' %>
-          </li>
-          <li class="filters__item">
-            <%= f.label :status, class: 'filters__label' %>
-            <%= f.select :status, friendly_options(BookingRequest.statuses), { include_blank: 'All Statuses' }, { class: 't-status form-control filters__form-control filters__form-control--status' } %>
+            <%= f.text_field :name, class: 't-customer form-control filters__form-control', placeholder: 'Name' %>
           </li>
           <li class="filters__item">
             <%= f.label :agent, class: 'filters__label' %><%= f.select :agent, agent_options, { include_blank: 'All Agents' }, { class: 'form-control filters__form-control t-agent' } %>
@@ -44,56 +40,50 @@
 
 <div class="row">
   <div class="col-md-12">
-    <% if @booking_requests.empty? %>
-      <p class="no-content t-notice">No booking requests.</p>
+    <% if @appointments.empty? %>
+      <p class="no-content t-notice">No appointments.</p>
     <% else %>
-      <%= paginate @booking_requests %>
+      <%= paginate @appointments %>
 
       <table class="table table-bordered">
-        <caption><span class="sr-only">Booking Requests</span></caption>
+        <caption><span class="sr-only">Appointments</span></caption>
         <thead>
           <tr class="table-header">
             <th>Requested</th>
             <th>Customer name</th>
             <th>Location</th>
-            <th>Slots</th>
+            <th>Date/time</th>
             <th>Reference</th>
-            <th>Status</th>
             <th>Agent</th>
           </tr>
         </thead>
         <tbody>
-          <% @booking_requests.each do |booking_request| %>
-            <tr class="t-booking-request">
+          <% @appointments.each do |appointment| %>
+            <tr class="t-appointment">
               <td>
-                <%= booking_request.created_at.in_time_zone('London').to_s(:govuk_date) %>
+                <%= appointment.created_at.in_time_zone('London').to_s(:govuk_date) %>
               </td>
               <td>
-                <%= booking_request.name %>
+                <%= appointment.name %>
               </td>
               <td>
-                <a href="https://www.pensionwise.gov.uk/locations/<%= booking_request.location_id %>"><%= safe_location_name(booking_request.location_id) %></a>
+                <a href="https://www.pensionwise.gov.uk/locations/<%= appointment.location_id %>"><%= safe_location_name(appointment.location_id) %></a>
               </td>
               <td>
-                <%= booking_request.primary_slot.start_at.to_s(:govuk_date) %>
-                <% if booking_request.secondary_slot %><br><%= booking_request.secondary_slot.start_at.to_s(:govuk_date) %><% end %>
-                <% if booking_request.tertiary_slot %><br><%= booking_request.tertiary_slot.start_at.to_s(:govuk_date) %><% end %>
+                <%= appointment.proceeded_at.to_s(:govuk_date) %>
               </td>
               <td>
-                <%= booking_request.reference %>
+                <%= appointment.reference %>
               </td>
               <td>
-                <%= booking_request.status.humanize %>
-              </td>
-              <td>
-                <%= booking_request.agent&.name.presence || safe_location_name(booking_request.booking_location_id) %>
+                <%= appointment.booking_request.agent&.name.presence || safe_location_name(appointment.booking_location_id) %>
               </td>
             </tr>
           <% end %>
         </tbody>
       </table>
 
-      <%= paginate @booking_requests %>
+      <%= paginate @appointments %>
     <% end %>
   </div>
 </div>

--- a/app/views/appointments/booking_manager_appointment_changed.html.erb
+++ b/app/views/appointments/booking_manager_appointment_changed.html.erb
@@ -1,0 +1,19 @@
+<h2>The appointment was changed by an agent</h2>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.reference %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  The following details were changed:
+<% end %>
+
+<ul>
+  <% @appointment.audits.last.audited_changes.keys.map(&:humanize).each do |key| %>
+    <li><%= key %></li>
+  <% end %>
+</ul>

--- a/app/views/appointments/booking_manager_appointment_changed.text.erb
+++ b/app/views/appointments/booking_manager_appointment_changed.text.erb
@@ -1,0 +1,10 @@
+The appointment was changed by an agent
+
+Reference number:
+<%= @appointment.reference %>
+
+The following details were changed:
+
+<% @appointment.audits.last.audited_changes.keys.map(&:humanize).each do |key| %>
+* <%= key %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module Planner
     config.action_mailer.default_url_options = { host: ENV['APPLICATION_HOST'] }
 
     config.mount_javascript_test_routes = false
+
+    config.action_view.prefix_partial_path_with_controller_namespace = false
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
 
   namespace :agent, path: '/agents' do
     resources :booking_requests, only: :index, as: :search
+    resources :appointments, only: %i(edit update)
   end
 
   namespace :admin, path: '/admin' do

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
       email { '' }
       association :booking_request, factory: :postal_booking_request
     end
+
+    trait :with_agent do
+      association :booking_request, factory: :agent_booking_request
+    end
   end
 end

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -28,6 +28,12 @@ FactoryBot.define do
       end
     end
 
+    factory :agent_booking_request do
+      agent
+      booking_location_id { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
+      location_id { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
+    end
+
     factory :hackney_booking_request do
       booking_location_id { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
       location_id { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }

--- a/spec/features/agent_manager_modifies_an_appointment_spec.rb
+++ b/spec/features/agent_manager_modifies_an_appointment_spec.rb
@@ -1,8 +1,16 @@
 require 'rails_helper'
 
-RSpec.feature 'Agent modifies an appointment' do
-  scenario 'Causing an error' do
+RSpec.feature 'Agent manager modifies an appointment' do
+  scenario 'Attempting to access as an agent' do
     given_the_user_identifies_as_an_agent do
+      and_an_appointment_exists
+      when_they_attempt_to_edit_an_appointment
+      then_they_are_not_granted_access
+    end
+  end
+
+  scenario 'Causing an error' do
+    given_the_user_identifies_as_an_agent_manager do
       and_an_appointment_exists
       when_they_blank_the_name_field
       then_they_see_an_error_message
@@ -10,7 +18,7 @@ RSpec.feature 'Agent modifies an appointment' do
   end
 
   scenario 'Successfully modifying an appointment' do
-    given_the_user_identifies_as_an_agent do
+    given_the_user_identifies_as_an_agent_manager do
       and_an_appointment_exists
       when_they_edit_the_appointment
       then_they_see_the_location
@@ -71,5 +79,14 @@ RSpec.feature 'Agent modifies an appointment' do
 
   def and_the_booking_managers_are_notified
     assert_enqueued_jobs 1, only: BookingManagerAppointmentChangeNotificationJob
+  end
+
+  def when_they_attempt_to_edit_an_appointment
+    @page = Pages::AgentEditAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def then_they_are_not_granted_access
+    expect(page.status_code).to eq(403)
   end
 end

--- a/spec/features/agent_modifies_an_appointment_spec.rb
+++ b/spec/features/agent_modifies_an_appointment_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'Agent modifies an appointment' do
       then_they_see_the_location
       and_the_appointment_is_modified
       and_the_customer_is_notified
+      and_the_booking_managers_are_notified
     end
   end
 
@@ -66,5 +67,9 @@ RSpec.feature 'Agent modifies an appointment' do
 
   def and_the_customer_is_notified
     assert_enqueued_jobs 1, only: AppointmentChangeNotificationJob
+  end
+
+  def and_the_booking_managers_are_notified
+    assert_enqueued_jobs 1, only: BookingManagerAppointmentChangeNotificationJob
   end
 end

--- a/spec/features/agent_modifies_an_appointment_spec.rb
+++ b/spec/features/agent_modifies_an_appointment_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.feature 'Agent modifies an appointment' do
+  scenario 'Causing an error' do
+    given_the_user_identifies_as_an_agent do
+      and_an_appointment_exists
+      when_they_blank_the_name_field
+      then_they_see_an_error_message
+    end
+  end
+
+  scenario 'Successfully modifying an appointment' do
+    given_the_user_identifies_as_an_agent do
+      and_an_appointment_exists
+      when_they_edit_the_appointment
+      then_the_appointment_is_modified
+      and_the_customer_is_notified
+    end
+  end
+
+  def when_they_blank_the_name_field
+    @page = Pages::AgentEditAppointment.new
+    @page.load(id: @appointment.id)
+
+    @page.name.set('')
+    @page.submit.click
+  end
+
+  def then_they_see_an_error_message
+    expect(@page).to have_errors
+  end
+
+  def and_an_appointment_exists
+    @appointment = create(:appointment, proceeded_at: 3.weeks.from_now)
+  end
+
+  def when_they_edit_the_appointment # rubocop:disable MethodLength, AbcSize
+    @page = Pages::AgentEditAppointment.new
+    @page.load(id: @appointment.id)
+
+    @page.name.set('Ben Lovell')
+    @page.email.set('ben@example.com')
+    @page.phone.set('07715 930 459')
+    @page.day_of_birth.set('02')
+    @page.month_of_birth.set('02')
+    @page.year_of_birth.set('1960')
+    @page.accessibility_requirements.set(true)
+    @page.additional_information.set('Blah, blah, blah.')
+    @page.defined_contribution_pot_confirmed_dont_know.set(true)
+
+    @page.submit.click
+  end
+
+  def then_the_appointment_is_modified
+    expect(@page).to have_success
+
+    @appointment.reload
+
+    expect(@appointment.name).to eq('Ben Lovell')
+  end
+
+  def and_the_customer_is_notified
+    assert_enqueued_jobs 1, only: AppointmentChangeNotificationJob
+  end
+end

--- a/spec/features/agent_modifies_an_appointment_spec.rb
+++ b/spec/features/agent_modifies_an_appointment_spec.rb
@@ -13,7 +13,8 @@ RSpec.feature 'Agent modifies an appointment' do
     given_the_user_identifies_as_an_agent do
       and_an_appointment_exists
       when_they_edit_the_appointment
-      then_the_appointment_is_modified
+      then_they_see_the_location
+      and_the_appointment_is_modified
       and_the_customer_is_notified
     end
   end
@@ -51,7 +52,11 @@ RSpec.feature 'Agent modifies an appointment' do
     @page.submit.click
   end
 
-  def then_the_appointment_is_modified
+  def then_they_see_the_location
+    expect(@page.location).to have_text('Hackney')
+  end
+
+  def and_the_appointment_is_modified
     expect(@page).to have_success
 
     @appointment.reload

--- a/spec/features/agent_searches_for_booking_requests_spec.rb
+++ b/spec/features/agent_searches_for_booking_requests_spec.rb
@@ -1,51 +1,65 @@
 require 'rails_helper'
 
-RSpec.feature 'Agent searches for booking requests' do
+RSpec.feature 'Agent searches for appointments' do
   scenario 'Searching via a given booking reference' do
     given_the_user_identifies_as_an_agent_manager
-    and_booking_requests_exist
+    and_appointments_exist
     when_they_visit_the_site
     and_search_for_a_particular_booking_reference
-    then_they_see_the_booking_request
+    then_they_see_the_appointment
+    when_they_visit_the_site
+    and_search_for_a_particular_customer
+    then_they_see_the_customer_appointment
   end
 
   scenario 'Searching for booking requests' do
     given_the_user_identifies_as_an_agent_manager
-    and_booking_requests_exist
+    and_appointments_exist
     when_they_visit_the_site
-    then_they_see_the_booking_requests
+    then_they_see_the_appointments
+  end
+
+  def and_search_for_a_particular_customer
+    @page = Pages::AgentBookingSearch.new
+    @page.customer.set('Mortimer')
+    @page.submit.click
+  end
+
+  def then_they_see_the_customer_appointment
+    expect(@page).to have_appointments(count: 1)
+    expect(@page.appointments.first).to have_text('Mortimer Smith')
   end
 
   def given_the_user_identifies_as_an_agent_manager
     create(:agent_manager)
   end
 
-  def and_booking_requests_exist
+  def and_appointments_exist
     # these will be returned
-    @bookings = create_list(:hackney_booking_request, 3, agent: User.first)
+    @appointment = create(:appointment, :with_agent, guider_id: 2)
     # this will also be returned now since they're not just agent bookings
-    create(:hackney_booking_request, name: 'Mr Present')
+    create(:appointment, name: 'Mr Present')
   end
 
   def when_they_visit_the_site
     visit '/'
   end
 
-  def then_they_see_the_booking_requests
+  def then_they_see_the_appointments
     @page = Pages::AgentBookingSearch.new
     expect(@page).to be_displayed
 
-    expect(@page).to have_booking_requests(count: 4)
+    expect(@page).to have_appointments(count: 2)
     expect(@page).to have_text('Mr Present')
   end
 
   def and_search_for_a_particular_booking_reference
     @page = Pages::AgentBookingSearch.new
-    @page.reference.set(@bookings.first.id)
+    @page.reference.set(@appointment.reference)
     @page.submit.click
   end
 
-  def then_they_see_the_booking_request
-    expect(@page).to have_booking_requests(count: 1)
+  def then_they_see_the_appointment
+    expect(@page).to have_appointments(count: 1)
   end
 end

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -6,6 +6,32 @@ RSpec.describe Appointments do
   end
   let(:hackney) { BookingLocations.find('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef') }
 
+  describe 'Appointment changed' do
+    let(:appointment) { create(:appointment, proceeded_at: 3.weeks.from_now) }
+    let(:booking_manager) { create(:hackney_booking_manager) }
+
+    before { appointment.update(name: 'Bob Jones', email: 'bob@bob.com') }
+
+    subject(:mail) { described_class.booking_manager_appointment_changed(appointment, booking_manager) }
+
+    it_behaves_like 'mailgun identified email'
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Pension Wise Appointment Changed')
+      expect(mail.to).to eq([booking_manager.email])
+      expect(mail.from).to eq(['appointments@pensionwise.gov.uk'])
+    end
+
+    describe 'rendering the body' do
+      let(:body) { subject.body.encoded }
+
+      it 'includes the appointment particulars' do
+        expect(body).to include(appointment.reference)
+        expect(body).to include('Name', 'Email')
+      end
+    end
+  end
+
   describe 'Cancellation' do
     before do
       allow(appointment).to receive(:newly_cancelled?).and_return(true)

--- a/spec/mailers/previews/appointments_preview.rb
+++ b/spec/mailers/previews/appointments_preview.rb
@@ -1,4 +1,14 @@
 class AppointmentsPreview < ActionMailer::Preview
+  def booking_manager_appointment_changed
+    @booking_manager = User.first || FactoryBot.create(:hackney_booking_manager)
+    @appointment     = Appointment.first || FactoryBot.create(:appointment)
+
+    # force an audit to be present
+    @appointment.update(name: 'Bob Jones', email: 'bleh@example.com')
+
+    Appointments.booking_manager_appointment_changed(@appointment, @booking_manager)
+  end
+
   def cancellation
     Appointments.cancellation(Appointment.first || FactoryBot.create(:appointment))
   end

--- a/spec/support/pages/agent_booking_search.rb
+++ b/spec/support/pages/agent_booking_search.rb
@@ -3,8 +3,9 @@ module Pages
     set_url '/agents/booking_requests'
 
     element :reference, '.t-reference'
+    element :customer, '.t-customer'
     element :submit, '.t-submit'
 
-    elements :booking_requests, '.t-booking-request'
+    elements :appointments, '.t-appointment'
   end
 end

--- a/spec/support/pages/agent_edit_appointment.rb
+++ b/spec/support/pages/agent_edit_appointment.rb
@@ -23,6 +23,7 @@ module Pages
     elements :errors, '.field_with_errors'
     element :error_summary, '.t-errors'
     element :success, '.alert-success'
+    element :location, '.t-location-name'
 
     section :activity_feed, Sections::ActivityFeed, '.t-activity-feed'
   end

--- a/spec/support/pages/agent_edit_appointment.rb
+++ b/spec/support/pages/agent_edit_appointment.rb
@@ -1,0 +1,29 @@
+require_relative '../sections/activity'
+require_relative '../sections/activity_feed'
+
+module Pages
+  class AgentEditAppointment < SitePrism::Page
+    set_url '/agents/appointments/{id}/edit'
+
+    element :name, '.t-name'
+    element :email, '.t-email'
+    element :phone, '.t-phone'
+    element :memorable_word, '.t-memorable-word'
+    element :day_of_birth, '.t-date-of-birth-day'
+    element :month_of_birth, '.t-date-of-birth-month'
+    element :year_of_birth, '.t-date-of-birth-year'
+    element :accessibility_requirements, '.t-accessibility-requirements'
+    element :additional_information, '.t-additional-info'
+    element :defined_contribution_pot_confirmed_yes, '.t-defined-contribution-pot-confirmed-yes'
+    element :defined_contribution_pot_confirmed_dont_know, '.t-defined-contribution-pot-confirmed-dont-know'
+
+    element :submit, '.t-submit'
+    element :resend_confirmation, '.t-resend-confirmation'
+
+    elements :errors, '.field_with_errors'
+    element :error_summary, '.t-errors'
+    element :success, '.alert-success'
+
+    section :activity_feed, Sections::ActivityFeed, '.t-activity-feed'
+  end
+end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -8,6 +8,10 @@ module UserHelpers
     ENV['GDS_SSO_MOCK_INVALID'] = sso_env
   end
 
+  def given_the_user_identifies_as_an_agent_manager(&block)
+    given_the_user_identifies_as(:agent_manager, &block)
+  end
+
   def given_the_user_identifies_as_an_agent(&block)
     given_the_user_identifies_as(:agent, &block)
   end


### PR DESCRIPTION
Gives agents the ability to edit particular fields on appointments. They 
can also leave activity entries and re-send email confirmations.