### PR TITLE
Validate additional info requirement

### DIFF
--- a/app/forms/agent_booking_form.rb
+++ b/app/forms/agent_booking_form.rb
@@ -36,6 +36,7 @@ class AgentBookingForm # rubocop:disable ClassLength
   validates :phone, presence: true, format: /\A([\d+\-\s\+()]+)\z/
   validates :memorable_word, presence: true
   validates :additional_info, length: { maximum: 320 }, allow_blank: true
+  validates :additional_info, presence: true, if: :accessibility_requirements
   validates :where_you_heard, presence: true
   validates :defined_contribution_pot_confirmed, presence: true
   validates :gdpr_consent, inclusion: { in: ['yes', 'no', ''] }

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -66,7 +66,7 @@
         </div>
         <div class="form-group">
           <%= f.label :accessibility_requirements, class: 'checkbox-inline checkbox-inline--accessibility' do %>
-            <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements' %> Do you need any help or an adjustment to access our service?
+            <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements' %> Do you need an adjustment to access our service?
         <% end %>
         </div>
         <hr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,3 +53,7 @@ en:
               blank: must be given
             slots:
               blank: must be selected
+        agent_booking_form:
+          attributes:
+            additional_info:
+              blank: describe the accessibility adjustment the customer requires

--- a/spec/forms/agent_booking_form_spec.rb
+++ b/spec/forms/agent_booking_form_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe AgentBookingForm do
       expect(subject).to be_valid
     end
 
+    context 'when accessibility requirements were specified' do
+      it 'requires additional info' do
+        subject.accessibility_requirements = true
+        expect(subject).to be_invalid
+
+        subject.additional_info = 'Needs wheelchair access'
+        expect(subject).to be_valid
+      end
+    end
+
     context 'dob validation bug' do
       it 'requires a date of birth' do
         subject.date_of_birth = ''


### PR DESCRIPTION
When accessibility requirements are specified we need to ensure the
customer/agent supplies descriptive text for their needs to be
fulfilled.