### PR TITLE
Improve pension provider labelling

### DIFF
--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -169,13 +169,15 @@
           %>
         </div>
         <div class="form-group">
-          <%= f.label :pension_provider, 'Referring pension provider' %>
+          <%= f.label :pension_provider do %>
+            Pension provider <span class="alert-danger">(required for final nudge trial only)</span>
+          <% end %>
           <%= f.select :pension_provider,
             options_for_select(PensionProvider.all.invert.to_a, @booking.pension_provider),
             { include_blank: true},
             class: 't-pension-provider form-control'
           %>
-          <div class="help-block">Required for final-nudge pilot appointments. Otherwise select <i>Not Applicable</i></div>
+          <span class="help-block">Otherwise select <i>Not Applicable</i></span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Agents are still incorrectly completing this field so improving the
label should help make things clearer.