### PR TITLE
Ignore webhooks for non-customer emails

### DIFF
--- a/app/forms/drop_form.rb
+++ b/app/forms/drop_form.rb
@@ -5,6 +5,14 @@ TokenVerificationFailure = Class.new(StandardError)
 class DropForm
   include ActiveModel::Model
 
+  INTERESTING_MESSAGE_TYPES = %w(
+    appointment_modified
+    appointment_confirmation
+    appointment_reminder
+    appointment_cancellation
+    customer_booking_request
+  ).freeze
+
   attr_accessor :event
   attr_accessor :recipient
   attr_accessor :description
@@ -21,6 +29,7 @@ class DropForm
   validates :booking_request, presence: true
   validates :environment, inclusion: { in: %w(production) }
   validates :online_booking, inclusion: { in: %w(True) }
+  validates :message_type, inclusion: { in: INTERESTING_MESSAGE_TYPES }
 
   def create_activity
     return unless valid?

--- a/spec/forms/drop_form_spec.rb
+++ b/spec/forms/drop_form_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe DropForm, '#create_activity' do
   end
 
   context 'when the signature is verified' do
+    DropForm::INTERESTING_MESSAGE_TYPES.each do |message_type|
+      it "is valid with #{message_type}" do
+        params['message_type'] = message_type
+
+        expect(subject).to be_valid
+      end
+    end
+
+    it 'only cares about customer message types' do
+      params['message_type'] = 'sms_appointment_cancellation'
+
+      expect(subject).not_to be_valid
+    end
+
     it 'requires a booking request' do
       params['recipient'] = 'meh@example.com'
 

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'POST /mail_gun/drops' do
   def when_mail_gun_posts_a_drop_notification
     post mail_gun_drops_path, params: {
       'event' => 'dropped',
+      'message_type' => 'customer_booking_request',
       'recipient' => 'morty@example.com',
       'description' => 'the reasoning',
       'environment' => 'production',


### PR DESCRIPTION
We ought to ignore webhook calls for message types not referring to customer emails. Drop notifications for booking managers can get tied to bookings in some instances, particularly when the booking email is the same as a current booking manager. Only caring about customer emails  ensures this never happens.