### PR TITLE
Ensure ISO date format for picker

### DIFF
--- a/app/assets/javascripts/modules/date-time-picker.es6
+++ b/app/assets/javascripts/modules/date-time-picker.es6
@@ -5,7 +5,7 @@
     start(el) {
       this.$el = el;
       this.config = {
-        format: 'DD/MM/YYYY h:mm a',
+        format: 'YYYY-MM-DD HH:mm',
         stepping: 5,
         useCurrent: false,
         daysOfWeekDisabled: [0],


### PR DESCRIPTION
Formats picker date/time so it's compatible across en-US/en-GB
environments.