### PR TITLE
Highlight when a customer needs adjustment

### DIFF
--- a/app/mailers/booking_requests.rb
+++ b/app/mailers/booking_requests.rb
@@ -16,7 +16,8 @@ class BookingRequests < ApplicationMailer
     name = booking_request_or_appointment.model_name.human
 
     mailgun_headers('booking_manager_booking_request')
-    mail to: booking_manager.email, subject: "Pension Wise #{name.titleize}"
+    mail to: booking_manager.email,
+         subject: "Pension Wise #{name.titleize}" + accessibility_banner(@booking_request_or_appointment)
   end
 
   def email_failure(booking_request, booking_manager)
@@ -28,6 +29,10 @@ class BookingRequests < ApplicationMailer
   end
 
   private
+
+  def accessibility_banner(entity)
+    entity.accessibility_requirements? ? ' (Accessibility Adjustment)' : ''
+  end
 
   def decorate(booking_request_or_appointment)
     booking_location = BookingLocations.find(booking_request_or_appointment.location_id)

--- a/app/views/booking_requests/booking_manager.html.erb
+++ b/app/views/booking_requests/booking_manager.html.erb
@@ -2,6 +2,12 @@
   A new <%= @booking_request_or_appointment.model_name.human.downcase %> has come in.
 <% end %>
 
+<% if @booking_request_or_appointment.accessibility_requirements? %>
+  <%= p do %>
+    <strong>The customer has indicated they require help or an accessibility adjustment to access their appointment</strong>
+  <% end %>
+<% end %>
+
 <%= p do %>
   Reference: <%= @booking_request_or_appointment.reference %>
 <% end %>

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe BookingRequests do
   let(:booking_location) { BookingLocations.find(booking_location_id) }
   let(:actual_location) { booking_location.location_for(location_id) }
   let(:booking_request) do
-    create(:booking_request, location_id: location_id, booking_location_id: booking_location_id)
+    create(
+      :booking_request,
+      location_id: location_id,
+      booking_location_id: booking_location_id,
+      accessibility_requirements: false
+    )
   end
 
   describe 'Customer notification' do
@@ -79,6 +84,16 @@ RSpec.describe BookingRequests do
         expect(subject.body.encoded).to include('View the appointment')
         expect(subject.body.encoded).to include("/appointments/#{booking_request.id}/edit")
         expect(subject.body.encoded).to include('Guider: Ben Lovell') # guider
+      end
+    end
+
+    context 'for an appointment requiring accessibility adjustment' do
+      let(:booking_request) { create(:appointment, accessibility_requirements: true) }
+
+      it 'renders the accessibility adjustment particulars' do
+        expect(mail.subject).to eq('Pension Wise Appointment (Accessibility Adjustment)')
+
+        expect(subject.body.encoded).to include('The customer has indicated they require help')
       end
     end
   end


### PR DESCRIPTION
When a customer specifies they need an accessibility adjustment or help
with their appointment we must inform the associated booking manager(s)
in the regular appointment notification email. This includes a subject
banner and email body content.