### PR TITLE
Ensure matches don't cross booking locations

### DIFF
--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -20,5 +20,12 @@ FactoryBot.define do
     trait :with_agent do
       association :booking_request, factory: :agent_booking_request
     end
+
+    trait :taunton_booking_location do
+      guider_id { 2 }
+      location_id { '13e12f95-f709-4536-b6ee-8d7a735ddf9f' }
+
+      association :booking_request, factory: :taunton_child_booking_request
+    end
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -3,6 +3,46 @@ require 'rails_helper'
 RSpec.describe Appointment do
   subject { build_stubbed(:appointment) }
 
+  describe '#duplicates' do
+    it 'matches the current booking location' do
+      appointment = create(:appointment)
+
+      # doesn't match the booking location
+      create(:appointment, :taunton_booking_location)
+      expect(appointment).not_to be_duplicates
+
+      # matches the booking location
+      inside = create(:appointment, guider_id: 3)
+      expect(inside).to be_duplicates
+    end
+
+    it 'matches name' do
+      appointment = create(:appointment, :with_agent, name: 'Ben L', email: '', phone: '0121 444 555')
+      create(:appointment, name: 'Ben L', email: 'ben@ben.com', phone: '0131 333 444', guider_id: 2)
+
+      expect(appointment).to be_duplicates
+    end
+
+    it 'matches emails only when present' do
+      appointment = create(:appointment, :with_agent, name: 'Ben L', email: '', phone: '0121 444 555')
+      other = create(:appointment, :with_agent, name: 'Ben J', email: '', phone: '0131 333 444', guider_id: 2)
+
+      expect(appointment).not_to be_duplicates
+
+      appointment.update(email: 'ben@example.com')
+      other.update(email: 'ben@example.com')
+
+      expect(appointment).to be_duplicates
+    end
+
+    it 'matches phone' do
+      appointment = create(:appointment, :with_agent, name: 'Ben L', email: '', phone: '0131 333 444')
+      create(:appointment, :with_agent, name: 'Ben J', email: '', phone: '0131 333 444', guider_id: 2)
+
+      expect(appointment).to be_duplicates
+    end
+  end
+
   describe '.needing_reminder' do
     context 'with an appointment 7 days in the future' do
       it 'is included correctly based on its status' do


### PR DESCRIPTION
Also ensure matches don't occur on appointments with no email specified
eg agent bookings with customer postal addresses.