### PR TITLE
Include access information in confirmation emails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/guidance-guarantee-programme/booking_locations.git
-  revision: 871e913fca46e4dc9215377fd8da7074b7e6f792
+  revision: 1486c95a18fece326f39f01c3fe60e36816f9d8c
   specs:
-    booking_locations (0.25.0)
+    booking_locations (0.26.0)
       activesupport (>= 4, <= 6)
       globalid
 
@@ -161,7 +161,7 @@ GEM
     hashie (3.6.0)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (1.6.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -200,7 +200,7 @@ GEM
     mimemagic (0.3.3)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.14.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     msgpack (1.2.10)
@@ -416,7 +416,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.9)
     tins (1.20.3)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)

--- a/app/models/location_aware_entity.rb
+++ b/app/models/location_aware_entity.rb
@@ -7,6 +7,7 @@ class LocationAwareEntity < SimpleDelegator
   end
 
   delegate :online_booking_reply_to, to: :booking_location
+  delegate :accessibility_information, to: :actual_location
 
   def online_booking_twilio_number
     actual_location&.online_booking_twilio_number.to_s.sub(/^\+44/, '0')

--- a/app/views/shared/email/_appointment_details.html.erb
+++ b/app/views/shared/email/_appointment_details.html.erb
@@ -33,6 +33,16 @@
   </strong>
 <% end %>
 
+<% if @appointment.accessibility_information.present? %>
+  <%= p do %>
+  Access:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.accessibility_information %>
+  </strong>
+  <% end %>
+<% end %>
+
 <%= p do %>
   Guidance specialist:
   <br>

--- a/app/views/shared/email/_appointment_details.text.erb
+++ b/app/views/shared/email/_appointment_details.text.erb
@@ -13,6 +13,11 @@ Appointment location:
 <%= line %>
 <% end %>
 
+<% if @appointment.accessibility_information.present? %>
+Access:
+<%= @appointment.accessibility_information %>
+
+<% end %>
 Guidance specialist:
 <%= @appointment.guider_name.split.first %>
 

--- a/spec/models/location_aware_entity_spec.rb
+++ b/spec/models/location_aware_entity_spec.rb
@@ -37,10 +37,17 @@ RSpec.describe LocationAwareEntity do
 
   context 'when decorating an Appointment' do
     let(:booking_location) { instance_double(BookingLocations::Location) }
+    let(:actual_location) { instance_double(BookingLocations::Location, accessibility_information: 'Broken lift') }
     let(:appointment) { instance_double(Appointment, location_id: 'deadbeef', guider_id: 1) }
 
     subject do
       described_class.new(booking_location: booking_location, entity: appointment)
+    end
+
+    it 'returns access information' do
+      allow(booking_location).to receive(:location_for).and_return(actual_location)
+
+      expect(subject.accessibility_information).to eq('Broken lift')
     end
 
     describe '#guider_name' do


### PR DESCRIPTION
Includes access information - when specified - in the customer emails.