### PR TITLE
Allow admins to clear future slots

### DIFF
--- a/app/controllers/realtime_bookable_slots_controller.rb
+++ b/app/controllers/realtime_bookable_slots_controller.rb
@@ -38,6 +38,16 @@ class RealtimeBookableSlotsController < ApplicationController
     end
   end
 
+  def future
+    @schedule
+      .bookable_slots
+      .realtime
+      .where('start_at >= ?', Time.current.beginning_of_day)
+      .destroy_all
+
+    redirect_back fallback_location: schedules_path, success: 'The schedule was successfully cleared'
+  end
+
   private
 
   def load_window

--- a/app/views/schedules/_location.html.erb
+++ b/app/views/schedules/_location.html.erb
@@ -4,5 +4,17 @@
   </td>
   <td>
     <%= realtime_availability_button(location) %>
+    <% if current_user.administrator? %>
+      <%= link_to(
+            future_realtime_bookable_slots_path(location_id: location.id),
+            title: 'Delete future slots',
+            class: 'btn btn-danger t-clear-future-slots',
+            method: :delete,
+            data: { confirm: 'Are you sure you want to delete all future slots - this action is irrecoverable?' }
+      ) do %>
+        <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
+        <span class="sr-only">Delete future slots</span>
+      <% end %>
+    <% end %>
   </td>
 </tr>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -14,8 +14,8 @@
 
     <table class="centered-table table table-bordered table-striped">
       <colgroup>
-        <col width="85%" />
-        <col width="15%" />
+        <col width="80%" />
+        <col width="20%" />
       </colgroup>
       <thead>
         <tr class="table-header">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,9 @@ Rails.application.routes.draw do
   resources :locations, only: :index
 
   scope '/locations/:location_id' do
-    resources :realtime_bookable_slots, only: %w(index create destroy)
+    resources :realtime_bookable_slots, only: %w(index create destroy) do
+      delete 'future', on: :collection
+    end
     resources :realtime_bookable_slot_copies, only: %w(new create) do
       post 'preview', on: :collection
     end

--- a/spec/features/administrator_clears_a_schedule_spec.rb
+++ b/spec/features/administrator_clears_a_schedule_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'Administrator clears a schedule' do
+  scenario 'Successfully clearing a schedule of future slots', js: true do
+    given_the_user_identifies_as_hackneys_administrator do
+      travel_to '2020-01-31 13:00' do
+        and_a_schedule_exists
+        when_they_view_their_schedules
+        and_choose_to_clear_a_schedule
+        then_the_future_slots_are_cleared
+      end
+    end
+  end
+
+  def and_a_schedule_exists
+    @schedule = create(:schedule)
+    # this will not be deleted
+    @remained = create(:bookable_slot, start_at: '2020-01-30 13:00', schedule: @schedule)
+    # this will be deleted
+    @deleted = create(:bookable_slot, start_at: '2020-02-03 13:00', schedule: @schedule)
+  end
+
+  def when_they_view_their_schedules
+    @page = Pages::Schedules.new
+    @page.load
+  end
+
+  def and_choose_to_clear_a_schedule
+    expect(@page).to have_schedules
+
+    @page.accept_confirm do
+      # Hackney
+      @page.schedules.first.clear_future_slots.click
+    end
+  end
+
+  def then_the_future_slots_are_cleared
+    expect(@page).to have_success
+
+    expect(@schedule.bookable_slots.pluck(:start_at).map(&:to_date)).to eq(['2020-01-30'.to_date])
+  end
+end

--- a/spec/features/booking_manager_manages_realtime_availability_spec.rb
+++ b/spec/features/booking_manager_manages_realtime_availability_spec.rb
@@ -27,6 +27,8 @@ RSpec.feature 'Booking manager manages realtime availability' do
 
   def and_choose_to_edit_the_realtime_availability
     expect(@page).to have_schedules
+    # hidden from non-administrator roles
+    expect(@page.schedules.first).to have_no_clear_future_slots
     # Hackney
     @page.schedules.first.realtime_availability.click
   end

--- a/spec/support/pages/schedules.rb
+++ b/spec/support/pages/schedules.rb
@@ -2,6 +2,8 @@ module Pages
   class Schedules < SitePrism::Page
     set_url '/schedules'
 
+    element :success, '.alert-success'
+
     sections :pagination, '.pagination' do
       element :first_page, 'li.first a'
       element :previous_page, 'li.prev a'
@@ -13,6 +15,7 @@ module Pages
     sections :schedules, '.t-schedule' do
       element :location, '.t-location'
       element :realtime_availability, '.t-realtime-availability'
+      element :clear_future_slots, '.t-clear-future-slots'
     end
   end
 end


### PR DESCRIPTION
Administrators can clear future slots from a schedule. This is handy
when a location with scheduled slots goes inactive. In these cases the
guiders will be reallocated to other locations but when they exist in
overlapping slots elsewhere this is not possible.