### PR TITLE
Remove final nudge options

### DIFF
--- a/app/controllers/api/v1/booking_requests_controller.rb
+++ b/app/controllers/api/v1/booking_requests_controller.rb
@@ -73,7 +73,6 @@ module Api
           :placed_by_agent,
           :where_you_heard,
           :gdpr_consent,
-          :pension_provider,
           slots: %i(date from to priority)
         ).tap { |p| p[:slots_attributes] = p.delete(:slots) }
       end

--- a/app/forms/agent_booking_form.rb
+++ b/app/forms/agent_booking_form.rb
@@ -21,7 +21,6 @@ class AgentBookingForm # rubocop:disable ClassLength
     booking_location_id
     additional_info
     gdpr_consent
-    pension_provider
   ).freeze
 
   attr_accessor(*ATTRIBUTES)
@@ -40,7 +39,7 @@ class AgentBookingForm # rubocop:disable ClassLength
   validates :where_you_heard, presence: true
   validates :gdpr_consent, inclusion: { in: ['yes', 'no', ''] }
   validates :first_choice_slot, presence: true
-  validates :pension_provider, presence: true
+
   validate :validate_confirmation_details
   validate :validate_eligibility
 
@@ -138,8 +137,7 @@ class AgentBookingForm # rubocop:disable ClassLength
       location_id: location_id,
       booking_location_id: booking_location_id,
       additional_info: additional_info,
-      gdpr_consent: gdpr_consent,
-      pension_provider: pension_provider.to_s
+      gdpr_consent: gdpr_consent
     }
   end
 

--- a/app/jobs/slack_pinger_job.rb
+++ b/app/jobs/slack_pinger_job.rb
@@ -10,7 +10,7 @@ class SlackPingerJob < ActiveJob::Base
     actual_location  = booking_location.name_for(booking_request_or_appointment.location_id)
 
     hook = WebHook.new(hook_uri)
-    hook.call(payload(actual_location, booking_request_or_appointment))
+    hook.call(payload(actual_location))
   end
 
   private
@@ -19,13 +19,11 @@ class SlackPingerJob < ActiveJob::Base
     ENV['BOOKING_REQUESTS_SLACK_PINGER_URI']
   end
 
-  def payload(actual_location, booking_request_or_appointment)
-    pension_provider = PensionProvider[booking_request_or_appointment]
-
+  def payload(actual_location)
     {
       username: 'frank',
       channel: '#online-bookings',
-      text: ":zap: #{actual_location} #{pension_provider} :zap:",
+      text: ":zap: #{actual_location} :zap:",
       icon_emoji: ':frank:'
     }
   end

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -156,17 +156,6 @@
             class: 't-where-you-heard form-control'
           %>
         </div>
-        <div class="form-group">
-          <%= f.label :pension_provider do %>
-            Pension provider <span class="alert-danger">(required for final nudge trial only)</span>
-          <% end %>
-          <%= f.select :pension_provider,
-            options_for_select(PensionProvider.all.invert.to_a, @booking.pension_provider),
-            { include_blank: true},
-            class: 't-pension-provider form-control'
-          %>
-          <span class="help-block">Otherwise select <i>Not Applicable</i></span>
-        </div>
       </div>
     </div>
   </div>

--- a/app/views/agent/booking_requests/preview.html.erb
+++ b/app/views/agent/booking_requests/preview.html.erb
@@ -27,7 +27,6 @@
   <%= f.hidden_field :county %>
   <%= f.hidden_field :postcode %>
   <%= f.hidden_field :additional_info %>
-  <%= f.hidden_field :pension_provider %>
 
   <% @booking = AgentBookingDecorator.new(@booking) %>
 
@@ -104,17 +103,6 @@
             <tr>
               <td class="active" width="35%"><b>Additional info</b></td>
               <td><%= @booking.additional_info %></td>
-            </tr>
-          </tbody>
-        </table>
-        <% end %>
-
-        <% if @booking.pension_provider.present? %>
-        <table class="table lead">
-          <tbody>
-            <tr>
-              <td class="active" width="35%"><b>Pension provider</b></td>
-              <td><%= @booking.pension_provider %></td>
             </tr>
           </tbody>
         </table>

--- a/spec/features/agent_places_a_realtime_booking_spec.rb
+++ b/spec/features/agent_places_a_realtime_booking_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature 'Agent places a realtime booking' do
     travel_to '2018-11-03 13:00' do
       given_the_user_identifies_as_an_agent
       and_available_realtime_slots_exist_within_the_booking_window
-      and_pension_providers_are_configured
       when_they_attempt_to_place_a_booking_at_hackney
       and_they_choose_a_realtime_slot
       and_they_provide_the_customer_details
@@ -27,10 +26,6 @@ RSpec.feature 'Agent places a realtime booking' do
     create(:bookable_slot, start_at: '2018-11-07 09:00', end_at: '2018-11-07 10:00')
     # a duplicate that gets deduplicated
     create(:bookable_slot, start_at: '2018-11-07 09:00', end_at: '2018-11-07 10:00', guider_id: 2)
-  end
-
-  def and_pension_providers_are_configured
-    allow(PensionProvider).to receive(:all).and_return('aviva' => 'Aviva')
   end
 
   def when_they_attempt_to_place_a_booking_at_hackney
@@ -57,7 +52,6 @@ RSpec.feature 'Agent places a realtime booking' do
     @page.county.set('Berkshire')
     @page.postcode.set('RG1 1AA')
     @page.additional_info.set('Other notes')
-    @page.pension_provider.select('Aviva')
   end
 
   def and_they_confirm_the_booking
@@ -66,7 +60,6 @@ RSpec.feature 'Agent places a realtime booking' do
     @page = Pages::AgentBookingPreview.new
     expect(@page).to be_displayed
     expect(@page.first_choice_slot).to have_text('7 November 2018 - 09:00')
-    expect(@page).to have_text('Aviva')
 
     @page.confirmation.click
   end
@@ -89,7 +82,7 @@ RSpec.feature 'Agent places a realtime booking' do
       age_range: '55-plus',
       additional_info: 'Other notes',
       gdpr_consent: 'yes',
-      pension_provider: 'aviva'
+      pension_provider: ''
     )
   end
 

--- a/spec/forms/agent_booking_form_spec.rb
+++ b/spec/forms/agent_booking_form_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe AgentBookingForm do
       where_you_heard: 1,
       gdpr_consent: 'yes',
       accessibility_requirements: false,
-      additional_info: '',
-      pension_provider: 'n/a'
+      additional_info: ''
     )
   end
 

--- a/spec/requests/create_an_appointment_request_spec.rb
+++ b/spec/requests/create_an_appointment_request_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe 'POST /api/v1/booking_requests' do
         'placed_by_agent' => true,
         'where_you_heard' => 1,
         'gdpr_consent' => 'yes',
-        'pension_provider' => 'aviva',
         'slots' => [
           {
             'date' => '2018-11-08',
@@ -119,7 +118,7 @@ RSpec.describe 'POST /api/v1/booking_requests' do
       defined_contribution_pot_confirmed: true,
       accessibility_requirements: false,
       additional_info: 'Additional Info',
-      pension_provider: 'aviva'
+      pension_provider: ''
     )
   end
 

--- a/spec/support/pages/agent_booking.rb
+++ b/spec/support/pages/agent_booking.rb
@@ -15,7 +15,6 @@ module Pages
     element :gdpr_consent_no, '.t-gdpr-consent-no'
     element :gdpr_consent_no_response, '.t-gdpr-consent-no-response'
     element :where_you_heard, '.t-where-you-heard'
-    element :pension_provider, '.t-pension-provider'
 
     element :email, '.t-email'
     element :address_line_one, '.t-address-line-one'


### PR DESCRIPTION
The underlying data remains but the API does not log the provider
neither does the agent booking form permit these values.