### PR TITLE
Add a GDPR redactor

### DIFF
--- a/app/lib/redactor.rb
+++ b/app/lib/redactor.rb
@@ -1,0 +1,70 @@
+class Redactor
+  def initialize(reference)
+    @reference = reference
+  end
+
+  def call
+    return unless booking_request = BookingRequest.find(reference)
+
+    ActiveRecord::Base.transaction do
+      redact_booking_request(booking_request)
+      redact_appointment(booking_request.appointment)
+    end
+  end
+
+  def self.redact_for_gdpr
+    BookingRequest.for_redaction.pluck(:id).each do |reference|
+      new(reference).call
+    end
+  end
+
+  private
+
+  def redact_booking_request(booking_request)
+    booking_request.assign_attributes(booking_attributes)
+    booking_request.save(validate: false)
+    booking_request.activities.where(type: 'AuditActivity').delete_all
+  end
+
+  def redact_appointment(appointment)
+    return unless appointment
+
+    appointment.without_auditing do
+      appointment.assign_attributes(appointment_attributes)
+      appointment.save(validate: false)
+      appointment.audits.delete_all
+    end
+  end
+
+  def appointment_attributes
+    booking_attributes.except(
+      :address_line_one,
+      :address_line_two,
+      :address_line_three,
+      :town,
+      :county,
+      :postcode,
+      :gdpr_consent
+    )
+  end
+
+  def booking_attributes # rubocop:disable MethodLength
+    {
+      name: 'redacted',
+      email: 'redacted@example.com',
+      phone: '000000000',
+      memorable_word: 'redacted',
+      date_of_birth: '1950-01-01',
+      additional_info: 'redacted',
+      address_line_one: 'redacted',
+      address_line_two: 'redacted',
+      address_line_three: 'redacted',
+      town: 'redacted',
+      county: 'redacted',
+      postcode: 'redacted',
+      gdpr_consent: 'no'
+    }
+  end
+
+  attr_reader :reference
+end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -41,6 +41,12 @@ class BookingRequest < ActiveRecord::Base
 
   alias reference to_param
 
+  def self.for_redaction
+    where
+      .not(name: 'redacted')
+      .where('created_at < ?', 2.years.ago.beginning_of_day)
+  end
+
   def self.latest(email)
     where(email: email).order(:created_at).last
   end

--- a/spec/lib/redactor_spec.rb
+++ b/spec/lib/redactor_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe Redactor do
+  describe '.redact_for_gdpr' do
+    it 'redacts records yet to be redacted, greater than 2 years old' do
+      travel_to '2018-02-28 10:00' do
+        @redacted = create(:hackney_booking_request, name: 'redacted')
+        @included = create(:hackney_booking_request)
+      end
+
+      travel_to '2020-01-01 10:00' do
+        @excluded = create(:hackney_booking_request)
+      end
+
+      travel_to '2020-03-31 10:00' do
+        described_class.redact_for_gdpr
+      end
+
+      # was redacted
+      expect(@included.reload.created_at).not_to eq(@included.updated_at)
+      # was already redacted so not updated
+      expect(@redacted.reload.created_at).to eq(@redacted.updated_at)
+      # was outside the date range so not updated
+      expect(@excluded.reload.created_at).to eq(@excluded.updated_at)
+    end
+  end
+
+  describe '#call' do
+    it 'redacts all personally identifying information' do
+      appointment = create(:appointment)
+      redactor    = described_class.new(appointment.reference)
+
+      redactor.call
+
+      expect(appointment.booking_request.reload).to have_attributes(
+        name: 'Redacted',
+        email: 'redacted@example.com',
+        phone: '000000000',
+        memorable_word: 'redacted',
+        date_of_birth: '1950-01-01'.to_date,
+        additional_info: 'redacted',
+        address_line_one: 'redacted',
+        address_line_two: 'redacted',
+        address_line_three: 'redacted',
+        town: 'redacted',
+        county: 'redacted',
+        postcode: 'redacted',
+        gdpr_consent: 'no'
+      )
+
+      expect(appointment.booking_request.activities.where(type: 'AuditActivity')).to be_empty
+
+      expect(appointment.reload).to have_attributes(
+        name: 'redacted',
+        email: 'redacted@example.com',
+        phone: '000000000',
+        memorable_word: 'redacted',
+        date_of_birth: '1950-01-01'.to_date,
+        additional_info: 'redacted'
+      )
+
+      expect(appointment.audits).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Refactors the existing redactor and adds a feature to automatically
redact any bookings/appointments created more than 2 years ago and that
have yet to be redacted.