### PR TITLE
Remove 'no response' option from agent booking

### DIFF
--- a/app/forms/agent_booking_form.rb
+++ b/app/forms/agent_booking_form.rb
@@ -39,7 +39,7 @@ class AgentBookingForm # rubocop:disable ClassLength
   validates :additional_info, length: { maximum: 320 }, allow_blank: true
   validates :additional_info, presence: true, if: :accessibility_requirements
   validates :where_you_heard, presence: true
-  validates :gdpr_consent, inclusion: { in: ['yes', 'no', ''] }
+  validates :gdpr_consent, inclusion: { in: %w(yes no) }
   validates :first_choice_slot, presence: true
 
   validate :validate_confirmation_details

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -116,10 +116,6 @@
             <%= f.radio_button :gdpr_consent, 'no', class: 't-gdpr-consent-no' %>
             No
           <% end %>
-          <%= f.label :gdpr_consent, value: '', class: 'radio-inline' do %>
-            <%= f.radio_button :gdpr_consent, '', class: 't-gdpr-consent-no-response' %>
-            No response
-          <% end %>
         </div>
 
       </div>

--- a/spec/forms/agent_booking_form_spec.rb
+++ b/spec/forms/agent_booking_form_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe AgentBookingForm do
       expect(subject).to be_valid
     end
 
+    it 'requires GDPR consent to be specified' do
+      subject.gdpr_consent = ''
+      expect(subject).to be_invalid
+    end
+
     context 'when accessibility requirements were specified' do
       it 'requires additional info' do
         subject.accessibility_requirements = true


### PR DESCRIPTION
Agents must specify either yes/no now when placing a booking on behalf
of a customer.