### PR TITLE
Allow agents to cancel appointments

### DIFF
--- a/app/controllers/cancels_controller.rb
+++ b/app/controllers/cancels_controller.rb
@@ -1,0 +1,27 @@
+class CancelsController < ApplicationController
+  skip_before_action :authorise!
+
+  before_action do
+    authorise_user!(any_of: [User::AGENT_MANAGER_PERMISSION, User::AGENT_PERMISSION])
+  end
+
+  def create
+    if appointment.cancel_by_agent!(current_user)
+      send_notifications(appointment)
+      redirect_back success: 'The appointment was cancelled.', fallback_location: agent_search_index_path
+    else
+      redirect_back warning: 'The appointment could not be cancelled.', fallback_location: agent_search_index_path
+    end
+  end
+
+  private
+
+  def send_notifications(appointment)
+    AppointmentCancellationNotificationJob.perform_later(appointment)
+    BookingManagerAppointmentChangeNotificationJob.perform_later(appointment)
+  end
+
+  def appointment
+    @appointment ||= Appointment.find(params[:appointment_id])
+  end
+end

--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -4,7 +4,7 @@ class Appointments < ApplicationMailer
 
     mailgun_headers :booking_manager_appointment_changed
 
-    mail(to: booking_manager.email, subject: 'Pension Wise Appointment Changed')
+    mail(to: booking_manager.email, subject: appointment_changed_subject(appointment))
   end
 
   def cancellation(appointment)
@@ -52,6 +52,18 @@ class Appointments < ApplicationMailer
   end
 
   private
+
+  def appointment_changed_subject(appointment)
+    subject = 'Pension Wise Appointment'
+
+    suffix = if appointment.cancelled?
+               'Cancelled'
+             else
+               'Changed'
+             end
+
+    "#{subject} #{suffix}"
+  end
 
   def decorate(appointment, booking_location = nil)
     booking_location ||= BookingLocations.find(appointment.location_id)

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -132,6 +132,13 @@ class Appointment < ActiveRecord::Base # rubocop:disable ClassLength
     end
   end
 
+  def cancel_by_agent!(agent)
+    self.current_user = agent
+    self.status = :cancelled_by_customer
+    self.secondary_status = AGENT_PERMITTED_SECONDARY # cancelled prior to appointment
+    save
+  end
+
   def updated?
     audits.present?
   end

--- a/app/views/agent/appointments/edit.html.erb
+++ b/app/views/agent/appointments/edit.html.erb
@@ -46,6 +46,16 @@
         )
       %>
     <% end %>
+    <% unless @appointment.cancelled? %>
+      <hr>
+      <%= button_to(
+            'Cancel the appointment',
+            appointment_cancel_path(@appointment),
+            class: 'btn btn-default btn-block t-cancel',
+            data: { confirm: 'Are you sure?' }
+        )
+      %>
+    <% end %>
   </div>
 
   <%= form_for @appointment, url: agent_appointment_path(@appointment) do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :users, only: :update
 
   resources :appointments, only: %i(index edit update) do
+    resource :cancel, only: :create
     resource :process, only: :create
     resources :changes, only: :index
 

--- a/spec/features/agent_cancels_an_appointment_spec.rb
+++ b/spec/features/agent_cancels_an_appointment_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.feature 'Agent cancels an appointment' do
+  scenario 'Agent successfully cancels an appointment', js: true do
+    given_the_user_identifies_as_an_agent_manager do
+      and_an_appointment_exists
+      when_the_agent_views_the_appointment
+      and_they_cancel_the_appointment
+      and_they_see_a_confirmation
+      then_the_appointment_is_cancelled
+      and_the_necessary_parties_are_notified
+    end
+  end
+
+  def and_an_appointment_exists
+    @appointment = create(:appointment)
+  end
+
+  def when_the_agent_views_the_appointment
+    @page = Pages::AgentEditAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def and_they_cancel_the_appointment
+    @page.accept_confirm do
+      @page.cancel.click
+    end
+  end
+
+  def then_the_appointment_is_cancelled
+    @appointment.reload
+
+    expect(@appointment).to be_cancelled_by_customer
+    expect(@appointment.secondary_status).to eq(Appointment::AGENT_PERMITTED_SECONDARY)
+  end
+
+  def and_they_see_a_confirmation
+    expect(@page.success).to have_text('cancelled')
+  end
+
+  def and_the_necessary_parties_are_notified
+    assert_enqueued_jobs(
+      2,
+      only: [AppointmentCancellationNotificationJob, BookingManagerAppointmentChangeNotificationJob]
+    )
+  end
+end

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -16,8 +16,26 @@ RSpec.describe Appointments do
 
     it_behaves_like 'mailgun identified email'
 
+    context 'when it is a regular update' do
+      it 'subject includes `changed`' do
+        expect(mail.subject).to eq('Pension Wise Appointment Changed')
+      end
+    end
+
+    context 'when it is a cancellation' do
+      it 'subject includes `cancelled`' do
+        appointment.current_user = build(:agent)
+        # cancelled prior to appointment
+        appointment.update_attributes(
+          status: :cancelled_by_customer,
+          secondary_status: Appointment::AGENT_PERMITTED_SECONDARY
+        )
+
+        expect(mail.subject).to eq('Pension Wise Appointment Cancelled')
+      end
+    end
+
     it 'renders the headers' do
-      expect(mail.subject).to eq('Pension Wise Appointment Changed')
       expect(mail.to).to eq([booking_manager.email])
       expect(mail.from).to eq(['appointments.pensionwise@moneyhelper.org.uk'])
     end

--- a/spec/support/pages/agent_edit_appointment.rb
+++ b/spec/support/pages/agent_edit_appointment.rb
@@ -19,6 +19,7 @@ module Pages
 
     element :submit, '.t-submit'
     element :resend_confirmation, '.t-resend-confirmation'
+    element :cancel, '.t-cancel'
 
     elements :errors, '.field_with_errors'
     element :error_summary, '.t-errors'


### PR DESCRIPTION
Will set the appointment to the correct status and secondary status and
notify both the customer and associated booking managers.