### PR TITLE
Third party appointments

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -116,7 +116,8 @@ class AppointmentsController < ApplicationController
         :proceeded_at,
         :status,
         :secondary_status,
-        :recording_consent
+        :recording_consent,
+        :third_party
       ).merge(current_user: current_user)
   end
 

--- a/app/forms/agent_booking_form.rb
+++ b/app/forms/agent_booking_form.rb
@@ -23,6 +23,7 @@ class AgentBookingForm # rubocop:disable ClassLength
     gdpr_consent
     recording_consent
     nudged
+    third_party
   ).freeze
 
   attr_accessor(*ATTRIBUTES)
@@ -64,6 +65,10 @@ class AgentBookingForm # rubocop:disable ClassLength
 
   def nudged
     ActiveRecord::Type::Boolean.new.cast(@nudged)
+  end
+
+  def third_party
+    ActiveRecord::Type::Boolean.new.cast(@third_party)
   end
 
   def create_booking!
@@ -144,7 +149,8 @@ class AgentBookingForm # rubocop:disable ClassLength
       additional_info: additional_info,
       gdpr_consent: gdpr_consent,
       recording_consent: recording_consent,
-      nudged: nudged
+      nudged: nudged,
+      third_party: third_party
     }
   end
 

--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -104,6 +104,10 @@ class AppointmentForm # rubocop:disable ClassLength
     @nudged ||= location_aware_booking_request.nudged
   end
 
+  def third_party
+    @third_party ||= location_aware_booking_request.third_party
+  end
+
   private
 
   def validate_guider_availability

--- a/app/forms/booking_manager_appointment_form.rb
+++ b/app/forms/booking_manager_appointment_form.rb
@@ -26,6 +26,7 @@ class BookingManagerAppointmentForm # rubocop:disable ClassLength
     ad_hoc_start_at
     scheduled
     recording_consent
+    third_party
   ).freeze
 
   attr_accessor(*ATTRIBUTES)
@@ -66,6 +67,10 @@ class BookingManagerAppointmentForm # rubocop:disable ClassLength
 
   def recording_consent
     ActiveRecord::Type::Boolean.new.cast(@recording_consent)
+  end
+
+  def third_party
+    ActiveRecord::Type::Boolean.new.cast(@third_party)
   end
 
   def create_appointment!
@@ -163,7 +168,8 @@ class BookingManagerAppointmentForm # rubocop:disable ClassLength
       additional_info: additional_info,
       gdpr_consent: gdpr_consent,
       guider_id: scheduled ? '' : guider_id,
-      recording_consent: recording_consent
+      recording_consent: recording_consent,
+      third_party: third_party
     }
   end
 

--- a/app/mappers/appointment_mapper.rb
+++ b/app/mappers/appointment_mapper.rb
@@ -14,7 +14,8 @@ class AppointmentMapper
       booking_request_id: appointment_form.reference,
       additional_info: appointment_form.additional_info,
       recording_consent: appointment_form.recording_consent,
-      nudged: appointment_form.nudged
+      nudged: appointment_form.nudged,
+      third_party: appointment_form.third_party
     }
   end
 end

--- a/app/models/agent_booking_decorator.rb
+++ b/app/models/agent_booking_decorator.rb
@@ -23,6 +23,10 @@ class AgentBookingDecorator < SimpleDelegator
     super ? 'Yes' : 'No'
   end
 
+  def third_party
+    super ? 'Yes' : 'No'
+  end
+
   def pension_provider
     PensionProvider[super]
   end

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -80,6 +80,11 @@
             <%= f.check_box :nudged, class: 't-nudged' %> Stronger Nudge signposting?
           <% end %>
         </div>
+        <div class="form-group">
+          <%= f.label :third_party, class: 'checkbox-inline' do %>
+            <%= f.check_box :third_party, class: 't-third-party' %> Third party appointment?
+          <% end %>
+        </div>
         <hr>
 
         <h2 class="h3">Eligibility</h2>

--- a/app/views/agent/booking_requests/preview.html.erb
+++ b/app/views/agent/booking_requests/preview.html.erb
@@ -29,6 +29,7 @@
   <%= f.hidden_field :additional_info %>
   <%= f.hidden_field :recording_consent %>
   <%= f.hidden_field :nudged %>
+  <%= f.hidden_field :third_party %>
 
   <% @booking = AgentBookingDecorator.new(@booking) %>
 
@@ -77,6 +78,10 @@
             <tr>
               <td class="active"><b>You need help or an adjustment to access our service</b></td>
               <td><%= @booking.accessibility_requirements %></td>
+            </tr>
+            <tr>
+              <td class="active"><b>Third party appointment?</b></td>
+              <td><%= @booking.third_party %></td>
             </tr>
           </tbody>
         </table>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -202,6 +202,11 @@
                 <%= f.check_box :recording_consent, class: 't-recording-consent' %> Appointment recording consent?
               <% end %>
             </div>
+            <div class="form-group">
+              <%= f.label :third_party, class: 'checkbox-inline' do %>
+                <%= f.check_box :third_party, class: 't-third-party' %> Third party appointment?
+              <% end %>
+            </div>
           </div>
           <div class="col-md-6">
             <h2 class="h3">Appointment details</h2>

--- a/app/views/booking_manager/appointments/new.html.erb
+++ b/app/views/booking_manager/appointments/new.html.erb
@@ -100,6 +100,11 @@
             <%= f.check_box :recording_consent, class: 't-recording-consent' %> Appointment recording consent?
           <% end %>
         </div>
+        <div class="form-group">
+          <%= f.label :third_party, class: 'checkbox-inline' do %>
+            <%= f.check_box :third_party, class: 't-third-party' %> Third party appointment?
+          <% end %>
+        </div>
         <hr>
 
         <h2 class="h3">Eligibility</h2>

--- a/app/views/booking_manager/appointments/preview.html.erb
+++ b/app/views/booking_manager/appointments/preview.html.erb
@@ -32,6 +32,7 @@
   <%= f.hidden_field :ad_hoc_start_at %>
   <%= f.hidden_field :guider_id %>
   <%= f.hidden_field :recording_consent %>
+  <%= f.hidden_field :third_party %>
 
   <% @appointment = AgentBookingDecorator.new(@appointment) %>
 
@@ -88,6 +89,10 @@
             <tr>
               <td class="active"><b>You need help or an adjustment to access our service</b></td>
               <td><%= @appointment.accessibility_requirements %></td>
+            </tr>
+            <tr>
+              <td class="active"><b>Third party appointment</b></td>
+              <td><%= @appointment.third_party %></td>
             </tr>
           </tbody>
         </table>

--- a/db/migrate/20230327143228_add_third_party_to_booking_requests.rb
+++ b/db/migrate/20230327143228_add_third_party_to_booking_requests.rb
@@ -1,0 +1,5 @@
+class AddThirdPartyToBookingRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :booking_requests, :third_party, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230327145802_add_third_party_to_appointments.rb
+++ b/db/migrate/20230327145802_add_third_party_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddThirdPartyToAppointments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :appointments, :third_party, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_27_143228) do
+ActiveRecord::Schema.define(version: 2023_03_27_145802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2023_03_27_143228) do
     t.string "secondary_status", default: "", null: false
     t.boolean "recording_consent", default: false, null: false
     t.boolean "nudged", default: false, null: false
+    t.boolean "third_party", default: false, null: false
     t.index ["booking_request_id"], name: "index_appointments_on_booking_request_id"
     t.index ["guider_id", "proceeded_at"], name: "index_appointments_on_guider_id_and_proceeded_at"
     t.index ["location_id"], name: "index_appointments_on_location_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_03_074952) do
+ActiveRecord::Schema.define(version: 2023_03_27_143228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2022_10_03_074952) do
     t.string "pension_provider", default: "", null: false
     t.boolean "recording_consent", default: false, null: false
     t.boolean "nudged", default: false, null: false
+    t.boolean "third_party", default: false, null: false
   end
 
   create_table "guider_lookups", force: :cascade do |t|

--- a/spec/features/agent_places_a_realtime_booking_spec.rb
+++ b/spec/features/agent_places_a_realtime_booking_spec.rb
@@ -71,6 +71,7 @@ RSpec.feature 'Agent places a realtime booking' do
     @page.additional_info.set('Other notes')
     @page.recording_consent.set(true)
     @page.nudged.set(true)
+    @page.third_party.set(true)
   end
 
   def and_they_confirm_the_booking
@@ -103,7 +104,8 @@ RSpec.feature 'Agent places a realtime booking' do
       gdpr_consent: 'yes',
       pension_provider: '',
       recording_consent: true,
-      nudged: true
+      nudged: true,
+      third_party: true
     )
   end
 

--- a/spec/features/booking_manager_places_a_realtime_booking_spec.rb
+++ b/spec/features/booking_manager_places_a_realtime_booking_spec.rb
@@ -90,6 +90,7 @@ RSpec.feature 'Booking manager places a realtime booking', javascript: true do
     @page.postcode.set('RG1 1AA')
     @page.additional_info.set('Other notes')
     @page.recording_consent.set(true)
+    @page.third_party.set(true)
   end
 
   def and_they_confirm_the_booking
@@ -132,7 +133,8 @@ RSpec.feature 'Booking manager places a realtime booking', javascript: true do
       age_range: '55-plus',
       additional_info: 'Other notes',
       gdpr_consent: 'yes',
-      recording_consent: true
+      recording_consent: true,
+      third_party: true
     )
   end
 

--- a/spec/forms/agent_booking_form_spec.rb
+++ b/spec/forms/agent_booking_form_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe AgentBookingForm do
       accessibility_requirements: false,
       additional_info: '',
       recording_consent: true,
-      nudged: true
+      nudged: true,
+      third_party: true
     )
   end
 

--- a/spec/forms/booking_manager_appointment_form_spec.rb
+++ b/spec/forms/booking_manager_appointment_form_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe BookingManagerAppointmentForm do
       accessibility_requirements: false,
       additional_info: '',
       scheduled: 'true',
-      recording_consent: true
+      recording_consent: true,
+      third_party: true
     )
   end
 

--- a/spec/mappers/appointment_mapper_spec.rb
+++ b/spec/mappers/appointment_mapper_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe AppointmentMapper, '.map' do
       accessibility_requirements: appointment_form.accessibility_requirements,
       additional_info: appointment_form.additional_info,
       recording_consent: false,
-      nudged: false
+      nudged: false,
+      third_party: false
     )
   end
 end

--- a/spec/support/pages/ad_hoc_booking.rb
+++ b/spec/support/pages/ad_hoc_booking.rb
@@ -33,6 +33,7 @@ module Pages
     element :country, '.t-country'
     element :additional_info, '.t-additional-info'
     element :recording_consent, '.t-recording-consent'
+    element :third_party, '.t-third-party'
 
     element :preview, '.t-preview'
   end

--- a/spec/support/pages/agent_booking.rb
+++ b/spec/support/pages/agent_booking.rb
@@ -27,6 +27,7 @@ module Pages
     element :additional_info, '.t-additional-info'
     element :recording_consent, '.t-recording-consent'
     element :nudged, '.t-nudged'
+    element :third_party, '.t-third-party'
 
     element :preview, '.t-preview'
   end


### PR DESCRIPTION
This is a simple addition to flag appointments as being held on behalf of a third-party. This will be expanded in future for parity with the telephone channel but for now this means we can at least capture MI data around third-party appointments.