### PR TITLE
Exclude CAS locations for org admins

### DIFF
--- a/app/controllers/admin/searches_controller.rb
+++ b/app/controllers/admin/searches_controller.rb
@@ -1,9 +1,14 @@
 module Admin
   class SearchesController < ApplicationController
-    before_action { authorise_user!(User::ADMINISTRATOR_PERMISSION) }
+    NON_CITA_EW_BOOKING_LOCATION_IDS = %w(
+      0c686436-de02-4d92-8dc7-26c97bb7c5bb
+      d0cd2b5a-27dc-4d1d-8d3b-d7b93b5afd4a
+    ).freeze
+
+    before_action { authorise_user!(any_of: [User::ADMINISTRATOR_PERMISSION, User::ORG_ADMIN_PERMISSION]) }
 
     def show
-      if @appointment = Appointment.find_by(booking_request_id: params[:id])
+      if @appointment = find_appointment
         assign!(@appointment)
 
         redirect_to edit_appointment_path(@appointment)
@@ -13,6 +18,18 @@ module Admin
     end
 
     private
+
+    def find_appointment
+      appointment_scope = Appointment
+
+      if current_user.org_admin?
+        appointment_scope = appointment_scope
+                            .joins(:booking_request)
+                            .where.not(booking_requests: { booking_location_id: NON_CITA_EW_BOOKING_LOCATION_IDS })
+      end
+
+      appointment_scope.find_by(booking_request_id: params[:id])
+    end
 
     def assign!(appointment)
       current_user.update!(

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action do
-    authorise_user!(User::ADMINISTRATOR_PERMISSION)
+    authorise_user!(any_of: [User::ADMINISTRATOR_PERMISSION, User::ORG_ADMIN_PERMISSION])
   end
 
   def update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,8 +19,9 @@ module ApplicationHelper
     super(objects, options)
   end
 
-  def booking_location_options
+  def booking_location_options(current_user)
     location_ids = BookingRequest.distinct.pluck(:booking_location_id)
+    location_ids = filter_org_admin_location_ids(location_ids) if current_user.org_admin?
 
     location_ids.map do |id|
       location = BookingLocations.find(id)
@@ -38,5 +39,10 @@ module ApplicationHelper
 
   def postcode_api_key
     ENV.fetch('POSTCODE_API_KEY') { 'iddqd' } # default to test API key
+  end
+
+  def filter_org_admin_location_ids(ids)
+    # exclude CAS - Drumchapel, Parkhead
+    ids - %w(0c686436-de02-4d92-8dc7-26c97bb7c5bb d0cd2b5a-27dc-4d1d-8d3b-d7b93b5afd4a)
   end
 end

--- a/app/lib/booking_locationable.rb
+++ b/app/lib/booking_locationable.rb
@@ -1,9 +1,21 @@
 module BookingLocationable
+  BookingLocationNotFound = Class.new(StandardError)
+
   def booking_location(location_id: current_user.booking_location_id)
-    @booking_location ||= BookingLocationDecorator.new(BookingLocations.find(location_id))
+    @booking_location ||= begin
+                            booking_location = BookingLocations.find(location_id)
+
+                            raise BookingLocationNotFound unless booking_location
+
+                            BookingLocationDecorator.new(booking_location)
+                          end
   end
 
   def self.included(base)
     base.helper_method :booking_location
+
+    base.rescue_from BookingLocationable::BookingLocationNotFound do
+      render 'shared/booking_location_not_found'
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
   PENSION_WISE_API_PERMISSION = 'pension_wise_api_user'
   BOOKING_MANAGER_PERMISSION  = 'booking_manager'
   ADMINISTRATOR_PERMISSION    = 'administrator'
+  ORG_ADMIN_PERMISSION        = 'org_admin'
   AGENT_PERMISSION            = 'agent'
   AGENT_MANAGER_PERMISSION    = 'agent_manager'
 
@@ -49,5 +50,9 @@ class User < ActiveRecord::Base
 
   def agent_manager?
     has_permission?(AGENT_MANAGER_PERMISSION)
+  end
+
+  def org_admin?
+    has_permission?(ORG_ADMIN_PERMISSION)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
   </li>
   <% end %>
 
-  <% if current_user.administrator? %>
+  <% if current_user.administrator? || current_user.org_admin? %>
     <li class="dropdown quick-search t-quick-search" data-module="quick-search">
       <a href="#" class="dropdown-toggle js-quick-search-button" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
         <span class="sr-only">Find an appointment by reference</span>
@@ -61,9 +61,7 @@
         </form>
       </div>
     </li>
-  <% end %>
 
-  <% if current_user.administrator? || current_user.org_admin? %>
     <%= form_for current_user, html: { class: 'navbar-form navbar-right js-location-form' } do |f| %>
       <div class="form-group">
         <%= f.select :organisation_content_id,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,11 +61,13 @@
         </form>
       </div>
     </li>
+  <% end %>
 
+  <% if current_user.administrator? || current_user.org_admin? %>
     <%= form_for current_user, html: { class: 'navbar-form navbar-right js-location-form' } do |f| %>
       <div class="form-group">
         <%= f.select :organisation_content_id,
-              options_for_select(booking_location_options, current_user.organisation_content_id),
+              options_for_select(booking_location_options(current_user), current_user.organisation_content_id),
               {},
               { class: 't-location js-location form-control input-sm' }
         %>

--- a/app/views/shared/booking_location_not_found.html.erb
+++ b/app/views/shared/booking_location_not_found.html.erb
@@ -1,0 +1,15 @@
+<% content_for(:page_title, t('service.title', page_title: 'Choose a booking location')) %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Planner</a></li>
+    <li class="active">Choose a booking location</li>
+  </ol>
+
+  <h1>Choose a booking location</h1>
+</div>
+
+<div class="lead notice t-booking-location-banner">
+  <p>
+    Please select a booking location from the navigation menu above.
+  </p>
+</div>

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -27,5 +27,12 @@ FactoryBot.define do
 
       association :booking_request, factory: :taunton_child_booking_request
     end
+
+    trait :drumchapel_booking_location do
+      guider_id { 2 }
+      location_id { '0c686436-de02-4d92-8dc7-26c97bb7c5bb' }
+
+      association :booking_request, factory: :drumchapel_booking_request
+    end
   end
 end

--- a/spec/factories/booking_requests.rb
+++ b/spec/factories/booking_requests.rb
@@ -54,6 +54,11 @@ FactoryBot.define do
       location_id { '7f916cf6-d2bd-4bcc-90dc-594207c8b1f4' }
     end
 
+    factory :drumchapel_booking_request do
+      booking_location_id { '0c686436-de02-4d92-8dc7-26c97bb7c5bb' }
+      location_id { '0c686436-de02-4d92-8dc7-26c97bb7c5bb' }
+    end
+
     factory :postal_booking_request do
       booking_location_id { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
       location_id { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -30,6 +30,11 @@ FactoryBot.define do
       organisation_content_id { 'ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef' }
     end
 
+    factory :org_admin do
+      permissions { [User::ORG_ADMIN_PERMISSION, User::BOOKING_MANAGER_PERMISSION] }
+      organisation_content_id { SecureRandom.uuid } # random so it's not assigned
+    end
+
     factory :hackney_administrator, parent: :hackney_booking_manager do
       permissions do
         [

--- a/spec/features/administrator_searches_for_an_appointment_spec.rb
+++ b/spec/features/administrator_searches_for_an_appointment_spec.rb
@@ -14,8 +14,28 @@ RSpec.feature 'Administrator searches for an appointment', js: true do
     end
   end
 
+  scenario 'Viewing an appointment as CITA E&W org admin', js: true do
+    given_the_user_identifies_as_an_organisation_admin do
+      when_they_search_for_a_cas_based_appointment
+      then_they_see_the_appointment_cannot_be_found
+    end
+  end
+
+  def then_they_see_the_appointment_cannot_be_found
+    expect(page).to have_text(/The appointment '\d+' could not be found/)
+  end
+
   def when_they_search_for_an_appointment
     @appointment = create(:appointment)
+
+    visit '/'
+    find(:css, '.t-quick-search').click
+    fill_in 'quick-search-input', with: @appointment.reference
+    find(:css, '.t-quick-search-button').click
+  end
+
+  def when_they_search_for_a_cas_based_appointment
+    @appointment = create(:appointment, :drumchapel_booking_location)
 
     visit '/'
     find(:css, '.t-quick-search').click

--- a/spec/features/booking_manager_views_booking_requests_spec.rb
+++ b/spec/features/booking_manager_views_booking_requests_spec.rb
@@ -18,6 +18,14 @@ RSpec.feature 'Viewing Booking Requests' do
     end
   end
 
+  scenario 'Organisation admins can change their location' do
+    given_the_user_identifies_as_an_organisation_admin do
+      when_they_visit_the_site
+      then_they_are_told_to_select_their_location
+      then_they_see_the_administrative_location_choices
+    end
+  end
+
   scenario 'Bookings Manager views their Booking Requests' do
     given_the_user_identifies_as_hackneys_booking_manager do
       and_there_are_booking_requests_for_their_location
@@ -43,6 +51,13 @@ RSpec.feature 'Viewing Booking Requests' do
       when_they_filter_by_location
       then_they_are_shown_the_booking_request_matching_the_location
     end
+  end
+
+  def then_they_are_told_to_select_their_location
+    @page = Pages::BookingRequests.new
+
+    expect(@page).to be_displayed
+    expect(@page).to have_booking_location_banner
   end
 
   def and_they_have_a_booking_with_multiple_slots

--- a/spec/support/pages/booking_requests.rb
+++ b/spec/support/pages/booking_requests.rb
@@ -26,5 +26,7 @@ module Pages
       element :title, '.growl-title'
       element :message, '.growl-message'
     end
+
+    element :booking_location_banner, '.t-booking-location-banner'
   end
 end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -24,6 +24,15 @@ module UserHelpers
     given_the_user_identifies_as(:hackney_booking_manager, &block)
   end
 
+  def given_the_user_identifies_as_an_organisation_admin
+    @user = create(:org_admin)
+    GDS::SSO.test_user = @user
+
+    yield
+  ensure
+    GDS::SSO.test_user = nil
+  end
+
   def given_the_user_identifies_as(factory_name)
     @user = create(factory_name)
     GDS::SSO.test_user = @user


### PR DESCRIPTION
Introduces a new role that can be applied to CITA E&W which will exclude CAS locations from the location dropdown thus not allowing them to switch to those locations.