### PR TITLE
Workaround missing agent during validation

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -255,7 +255,7 @@ class Appointment < ActiveRecord::Base # rubocop:disable ClassLength
         return errors.add(:secondary_status, 'must be provided for the chosen status')
       end
 
-      if current_user.agent? && cancelled_by_customer? && secondary_status != AGENT_PERMITTED_SECONDARY
+      if current_user&.agent? && cancelled_by_customer? && secondary_status != AGENT_PERMITTED_SECONDARY
         errors.add(:secondary_status, "Contact centre agents should only select 'Cancelled prior to appointment'")
       end
     end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -237,6 +237,16 @@ RSpec.describe Appointment do
             expect(subject).to be_invalid
           end
         end
+
+        context 'when the current user is not present' do
+          it 'allows any secondary statuses' do
+            subject.current_user = nil
+
+            subject.status = :cancelled_by_customer
+            subject.secondary_status = '17' # Customer forgot
+            expect(subject).to be_valid
+          end
+        end
       end
 
       context 'when it is not past the cut-off date' do


### PR DESCRIPTION
The places where this is important are already covered, so softening this requirement for an agent when checking secondary statuses is going to be OK.