### PR TITLE
Remove 'no response' options for consent

### DIFF
--- a/app/views/appointments/_gdpr_consent_modal.html.erb
+++ b/app/views/appointments/_gdpr_consent_modal.html.erb
@@ -20,7 +20,7 @@
           <% end %>
 
           <%= f.label :gdpr_consent, value: '', class: 'radio-inline' do %>
-              <%= f.radio_button :gdpr_consent, '', class: 't-consent-no-response' %>
+              <%= f.radio_button :gdpr_consent, '', class: 't-consent-no-response', disabled: true %>
               No response
           <% end %>
         </div>

--- a/app/views/booking_manager/appointments/new.html.erb
+++ b/app/views/booking_manager/appointments/new.html.erb
@@ -153,10 +153,6 @@
             <%= f.radio_button :gdpr_consent, 'no', class: 't-gdpr-consent-no' %>
             No
           <% end %>
-          <%= f.label :gdpr_consent, value: '', class: 'radio-inline' do %>
-            <%= f.radio_button :gdpr_consent, '', class: 't-gdpr-consent-no-response' %>
-            No response
-          <% end %>
         </div>
 
       </div>


### PR DESCRIPTION
Leaves it disabled for the modal as they'll need to see prior responses that were set.