### PR TITLE
Resolve issues with too many open sockets in test

### DIFF
--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -2,5 +2,6 @@ require 'webmock/rspec'
 
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: 'chromedriver.storage.googleapis.com'
+  allow: 'chromedriver.storage.googleapis.com',
+  net_http_connect_on_start: true
 )


### PR DESCRIPTION
Ensures the net HTTP client doesn't attempt to use a new socket for every single request during spec runs.