### PR TITLE
Use selenium-webdriver over webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,6 @@ source 'https://rubygems.org' do # rubocop:disable Metrics/BlockLength
     gem 'phantomjs'
     gem 'poltergeist'
     gem 'selenium-webdriver'
-    gem 'webdrivers'
     gem 'webmock'
   end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,6 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
-    childprocess (3.0.0)
     cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.2.2)
@@ -388,6 +387,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rexml (3.2.6)
     rgeo (2.1.1)
     rgeo-geojson (2.1.1)
       rgeo (>= 1.0.0)
@@ -416,7 +416,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sassc (2.0.1)
       ffi (~> 1.9)
@@ -428,9 +428,10 @@ GEM
       sprockets-rails
       tilt
     select2-rails (4.0.13)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.9.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -472,14 +473,11 @@ GEM
       rack (>= 2.0.6)
     warden-oauth2 (0.0.1)
       warden
-    webdrivers (4.4.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.6.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    websocket (1.2.9)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -558,7 +556,6 @@ DEPENDENCIES
   sprockets-es6!
   uglifier (>= 1.3.0)!
   uk_postcode!
-  webdrivers!
   webmock!
   working_hours!
 

--- a/spec/support/chrome.rb
+++ b/spec/support/chrome.rb
@@ -8,7 +8,4 @@ Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
-Webdrivers::Chromedriver.required_version = '114.0.5735.90'
-Webdrivers.install_dir = '/opt/homebrew/bin' unless ENV['CI'] == 'true'
-
 Capybara.javascript_driver = :chrome


### PR DESCRIPTION
This is the now recommended approach for managing driver versions. See https://github.com/titusfortner/webdrivers/issues/247