### PR TITLE
Correct the date picker component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,8 @@
 
 PWPlanner.poller.init();
 PWPlanner.dateRangePicker.init();
-PWPlanner.dateTimePicker.init();
+
+$('.js-date-time-picker').each(function() {
+  var $component = $(this);
+  new PWPlanner.dateTimePicker.init($component); // jshint ignore:line
+});

--- a/app/assets/javascripts/date-time-picker.js
+++ b/app/assets/javascripts/date-time-picker.js
@@ -2,8 +2,8 @@
   'use strict';
 
   var dateTimePicker = {
-    init: function() {
-      this.$picker = $('.js-date-time-picker');
+    init: function(elem) {
+      this.$picker = elem;
       this.config = $.extend(
         true,
         {
@@ -17,10 +17,7 @@
       )
 
       this.$picker.daterangepicker(this.config);
-      this.bindEvents();
-    },
 
-    bindEvents: function() {
       if (this.config.autoUpdateInput == false) {
         this.$picker.bind('apply.daterangepicker', {
           config: this.config,

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -289,7 +289,20 @@
               ) %>
             </div>
             <div class="form-group">
-              <%= f.text_field(:proceeded_at, label: 'Date of appointment', class: 'js-date-time-picker t-date form-control', value: @appointment_form.proceeded_at.to_date.to_s(:govuk_date)) %>
+              <%= f.text_field(
+                :proceeded_at,
+                label: 'Date of appointment',
+                class: 'js-date-time-picker t-date form-control',
+                value: @appointment_form.proceeded_at.strftime('%d/%m/%Y'),
+                data: {
+                  config: {
+                    showDropdowns: true,
+                    autoUpdateInput: false,
+                    maxDate: 2.years.from_now.strftime('%d/%m/%Y'),
+                    locale: { format: 'DD/MM/YYYY' }
+                  }
+                }
+              ) %>
             </div>
             <div class="form-group">
               <%= f.label :proceeded_at, 'Time of appointment' %>

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -259,7 +259,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     # ensure Hackney is pre-selected
     expect(@page.location.value).to eq('ac7112c3-e3cf-45cd-a8ff-9ba827b8e7ef')
 
-    expect(@page.date.value).to eq('20 June 2016')
+    expect(@page.date.value).to eq('20/06/2016')
     expect(@page.time_hour.value).to eq('14')
     expect(@page.time_minute.value).to eq('00')
   end
@@ -287,7 +287,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     @page.year_of_birth.set('1945')
     @page.defined_contribution_pot_confirmed_dont_know.set true
     @page.accessibility_requirements.set(false)
-    @page.date.set('21 June 2016')
+    @page.date.set('21/06/2016')
     @page.time_hour.select('15')
     @page.time_minute.select('15')
     @page.guider.select('Bob Johnson')
@@ -319,7 +319,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     expect(@page).to be_displayed
 
     expect(@page.name.value).to eq 'Bob Jones'
-    expect(@page.date.value).to eq '21 June 2016'
+    expect(@page.date.value).to eq '21/06/2016'
     expect(@page.time_hour.value).to eq '15'
     expect(@page.time_minute.value).to eq '15'
     expect(@page.guider.find('option', text: 'Bob Johnson').selected?).to eq true


### PR DESCRIPTION
This was instantiating a single instance of the picker control and sharing configuration across any pickers present in the page. Also, in the appointment date the selected value was formatted incorrectly and not parsed by the picker, resulting in 'NaN' being displayed throughout.