### PR TITLE
Display accessibility information

### DIFF
--- a/app/views/agent/appointments/edit.html.erb
+++ b/app/views/agent/appointments/edit.html.erb
@@ -108,7 +108,7 @@
             </div>
             <hr>
 
-            <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Accessibility requirements?' %>
+            <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Accessibility requirements?', help: @appointment.accessibility_information %>
             <%= f.check_box :third_party, class: 't-third-party', label: 'Third party appointment?', data: { target: 'consent' } %>
 
             <%= f.fields_for :booking_request, fieldset: false  do |booking_subform| %>

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -51,7 +51,7 @@
         <%= f.text_field :phone, class: 'form-control t-phone', help: 'We will use this to send an SMS appointment reminder by 8am - 72 hours before the appointment. Customers can cancel appointments via SMS' %>
         <%= f.text_field :email, class: 'form-control t-email', help: 'OK <em>(name)</em>, I am going to repeat this to you phonetically as we will send your appointment confirmation by email and I want to ensure you receive this'.html_safe %>
         <%= f.text_field :memorable_word, class: 'form-control t-memorable-word', help: 'We use this each time the customer is called.' %>
-        <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?' %>
+        <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?', help: location.accessibility_information %>
         <%= f.check_box :recording_consent, class: 't-recording-consent', label: 'Appointment recording consent?' %>
         <%= f.check_box :nudged, class: 't-nudged', label: 'Stronger Nudge signposting?' %>
         <%= f.check_box :third_party, class: 't-third-party', label: 'Third party appointment?', data: { target: 'consent' } %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -185,7 +185,7 @@
             </div>
 
             <hr>
-            <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?' %>
+            <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?', help: @appointment_form.accessibility_information %>
             <%= f.check_box :recording_consent, class: 't-recording-consent', label: 'Appointment recording consent?' %>
 
             <%= f.check_box :third_party, class: 't-third-party', label: 'Third party appointment?', data: { target: 'consent' } %>

--- a/app/views/booking_manager/appointments/new.html.erb
+++ b/app/views/booking_manager/appointments/new.html.erb
@@ -59,7 +59,7 @@
           <%= f.text_field :email, class: 'form-control t-email', help: 'OK <em>(name)</em>, I am going to repeat this to you phonetically as we will send your appointment confirmation by email and I want to ensure you receive this.'.html_safe %>
           <%= f.text_field :memorable_word, class: 'form-control t-memorable-word', help: 'We use this each time the customer is called.' %>
 
-          <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?' %>
+          <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?', help: location.accessibility_information %>
           <%= f.check_box :recording_consent, class: 't-recording-consent', label: 'Appointment recording consent?' %>
 
           <%= f.check_box :third_party, class: 't-third-party', label: 'Third party appointment?', data: { target: 'consent' } %>

--- a/spec/features/agent_places_a_realtime_booking_spec.rb
+++ b/spec/features/agent_places_a_realtime_booking_spec.rb
@@ -56,6 +56,8 @@ RSpec.feature 'Agent places a realtime booking' do
   end
 
   def and_they_provide_the_customer_details
+    expect(@page).to have_text('Access via the lift is currently unavailable')
+
     @page.name.set('Summer Sanchez')
     @page.phone.set('07715 930 444')
     @page.memorable_word.set('spaceships')

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -245,6 +245,8 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     @page = Pages::EditAppointment.new
     expect(@page).to be_displayed
 
+    expect(@page).to have_text('Access via the lift is currently unavailable')
+
     expect(@page.name.value).to eq(@appointment.name)
     expect(@page.email.value).to eq(@appointment.email)
     expect(@page.phone.value).to eq(@appointment.phone)

--- a/spec/features/booking_manager_places_a_realtime_booking_spec.rb
+++ b/spec/features/booking_manager_places_a_realtime_booking_spec.rb
@@ -75,6 +75,8 @@ RSpec.feature 'Booking manager places a realtime booking', js: true do
   end
 
   def and_they_provide_the_customer_details
+    expect(@page).to have_text('Access via the lift is currently unavailable')
+
     @page.name.set('Summer Sanchez')
     @page.phone.set('07715 930 444')
     @page.memorable_word.set('spaceships')


### PR DESCRIPTION
Whenever we display the 'accessibility requirements/adjustments' we will also display a hint containing the information stored against the location. This is to help inform the customer during the booking process.