### PR TITLE
Send cancellation notifications correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_script:
 - "(cd .downloads; [ -d prince-9.0r5-linux-amd64-static ] || curl -s https://www.princexml.com/download/prince-9.0r5-linux-amd64-static.tar.gz | tar xzf -)"
 - echo $PWD | ./.downloads/prince-9.0r5-linux-amd64-static/install.sh
 - npm install
-- npx @puppeteer/browsers install chromedriver@118.0.5993.70 --path $PWD/bin
-- export PATH=$PWD/bin/chromedriver/linux-118.0.5993.70/chromedriver-linux64:$PATH
+- npx @puppeteer/browsers install chromedriver@119.0.6045.105 --path $PWD/bin
+- export PATH=$PWD/bin/chromedriver/linux-119.0.6045.105/chromedriver-linux64:$PATH
 - bundle exec rake db:create db:migrate RAILS_ENV=test
 branches:
   except:

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -62,11 +62,11 @@ class AppointmentsController < ApplicationController
   # rubocop:enable Metrics/MethodLength
 
   def notify_customer(appointment)
-    if appointment.notify?
+    if appointment.newly_cancelled?
+      AppointmentCancellationNotificationJob.perform_later(appointment)
+    elsif appointment.notify?
       AppointmentChangeNotificationJob.perform_later(appointment)
       PrintedConfirmationLetterJob.perform_later(appointment)
-    elsif appointment.newly_cancelled?
-      AppointmentCancellationNotificationJob.perform_later(appointment)
     end
 
     BslCustomerExitPollJob.set(wait: 24.hours).perform_later(appointment) if appointment.bsl_newly_completed?


### PR DESCRIPTION
This ensures when a cancellation is made, only that notification is sent.