### PR TITLE
Switch email consent field types

### DIFF
--- a/app/views/agent/appointments/edit.html.erb
+++ b/app/views/agent/appointments/edit.html.erb
@@ -171,7 +171,7 @@
 
               <%= booking_subform.check_box :email_consent_form_required, class: 't-email-consent-form-required', data: { target: 'email-consent' } %>
               <div id="email-consent">
-                <%= booking_subform.text_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
+                <%= booking_subform.email_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
               </div>
 
               <%= booking_subform.check_box :printed_consent_form_required, class: 't-printed-consent-form-required', data: { target: 'printed-consent' } %>

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -84,7 +84,7 @@
 
           <%= f.check_box :email_consent_form_required, class: 't-email-consent-form-required', data: { target: 'email-consent' } %>
           <div id="email-consent">
-            <%= f.text_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
+            <%= f.email_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
           </div>
 
           <%= f.check_box :printed_consent_form_required, class: 't-printed-consent-form-required', data: { target: 'printed-consent' } %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -249,7 +249,7 @@
 
               <%= booking_subform.check_box :email_consent_form_required, class: 't-email-consent-form-required', data: { target: 'email-consent' } %>
               <div id="email-consent">
-                <%= booking_subform.text_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
+                <%= booking_subform.email_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
               </div>
 
               <%= booking_subform.check_box :printed_consent_form_required, class: 't-printed-consent-form-required', data: { target: 'printed-consent' } %>

--- a/app/views/booking_manager/appointments/new.html.erb
+++ b/app/views/booking_manager/appointments/new.html.erb
@@ -91,7 +91,7 @@
 
             <%= f.check_box :email_consent_form_required, class: 't-email-consent-form-required', data: { target: 'email-consent' } %>
             <div id="email-consent">
-              <%= f.text_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
+              <%= f.email_field :email_consent, autocomplete: 'off', class: 't-email-consent', label: 'Consent email', placeholder: 'A consent form is sent to this email' %>
             </div>
 
             <%= f.check_box :printed_consent_form_required, class: 't-printed-consent-form-required', data: { target: 'printed-consent' } %>


### PR DESCRIPTION
This will add HTML5 validation and also popup the correct keyboard in mobile scenarios.