### PR TITLE
Send change notifications correctly

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -163,9 +163,9 @@ class Appointment < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   end
 
   def notify?
-    return if (previous_changes.none? && booking_request.previous_changes.none?) || proceeded_at.past?
-    return true if previous_changes.exclude?(:status)
-    return true if booking_request.previous_changes.exclude?(:updated_at)
+    return false if proceeded_at.past?
+    return true  if previous_changes.any? && previous_changes.exclude?(:status)
+    return true  if booking_request.previous_changes.any? && booking_request.previous_changes.exclude?(:updated_at)
 
     previous_changes[:status] && pending?
   end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -202,6 +202,9 @@ RSpec.describe Appointment do
 
             original.update(status: :pending)
             expect(original).to be_notify
+
+            original.update(status: :no_show)
+            expect(original).to_not be_notify
           end
         end
 


### PR DESCRIPTION
Prior to this logic change, we were sending change notifications for most status changes incorrectly. This ensures that only meaningful changes trigger email notifications to customers.