### PR TITLE
Notify the customer by email when missed

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -61,9 +61,11 @@ class AppointmentsController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength
 
-  def notify_customer(appointment)
+  def notify_customer(appointment) # rubocop:disable Metrics/MethodLength
     if appointment.newly_cancelled?
       AppointmentCancellationNotificationJob.perform_later(appointment)
+    elsif appointment.newly_missed?
+      AppointmentMissedNotificationJob.perform_later(appointment)
     elsif appointment.notify?
       AppointmentChangeNotificationJob.perform_later(appointment)
       PrintedConfirmationLetterJob.perform_later(appointment)

--- a/app/jobs/appointment_missed_notification_job.rb
+++ b/app/jobs/appointment_missed_notification_job.rb
@@ -1,0 +1,11 @@
+class AppointmentMissedNotificationJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(appointment)
+    return unless appointment.email?
+
+    Appointments.missed(appointment).deliver
+
+    AppointmentMailActivity.from(appointment)
+  end
+end

--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -7,6 +7,18 @@ class Appointments < ApplicationMailer
     mail(to: booking_manager.email, subject: appointment_changed_subject(appointment))
   end
 
+  def missed(appointment)
+    @appointment = decorate(appointment)
+
+    mailgun_headers :appointment_missed
+
+    mail(
+      to: @appointment.email,
+      subject: 'Your Pension Wise Appointment',
+      reply_to: @appointment.online_booking_reply_to
+    )
+  end
+
   def cancellation(appointment)
     @appointment = decorate(appointment)
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -117,6 +117,10 @@ class Appointment < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     status.starts_with?('cancelled')
   end
 
+  def newly_missed?
+    no_show? && previous_changes.include?(:status)
+  end
+
   def newly_cancelled?
     cancelled? && previous_changes.include?(:status)
   end

--- a/app/models/appointment_mail_activity.rb
+++ b/app/models/appointment_mail_activity.rb
@@ -2,6 +2,8 @@ class AppointmentMailActivity < Activity
   def self.from(appointment)
     message = if appointment.cancelled?
                 'cancelled'
+              elsif appointment.no_show?
+                'missed'
               elsif appointment.updated?
                 'updated'
               else

--- a/app/views/appointments/missed.html.erb
+++ b/app/views/appointments/missed.html.erb
@@ -1,0 +1,52 @@
+<%= h2 do %>
+  Missed appointment
+<% end %>
+
+<%= p do %>
+  Dear <%= @appointment.name %>,
+<% end %>
+
+<%= p do %>
+  Our records show that you missed your Pension Wise appointment which was scheduled for:
+<% end %>
+
+<%= p do %>
+  Date:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.proceeded_at.to_date.to_s(:govuk_date) %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Time:
+  <br>
+  <strong class="emphasize">
+    <%= "#{@appointment.proceeded_at.to_s(:govuk_time)} (#{@appointment.timezone})" %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Appointment location:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.location_name %><br>
+    <% @appointment.address_lines.each do |line| %>
+      <%= line %><br>
+    <% end %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Reference number:
+  <br>
+  <strong class="emphasize">
+    <%= @appointment.reference %>
+  </strong>
+<% end %>
+
+<%= p do %>
+  Email us if you want to rebook your appointment.
+<% end %>
+
+<%= render 'shared/email/money_helper' %>

--- a/app/views/appointments/missed.text.erb
+++ b/app/views/appointments/missed.text.erb
@@ -1,0 +1,20 @@
+Missed appointment
+
+Dear <%= @appointment.name %>,
+
+Our records show that you missed your Pension Wise appointment which was scheduled for:
+
+Date: <%= @appointment.proceeded_at.to_date.to_s(:govuk_date) %>
+Time: <%= "#{@appointment.proceeded_at.to_s(:govuk_time)} (#{@appointment.timezone})" %>
+
+Appointment location:
+<%= @appointment.location_name %>
+<% @appointment.address_lines.each do |line| %>
+  <%= line %>
+<% end %>
+
+Reference number: <%= @appointment.reference %>
+
+Email us if you want to rebook your appointment.
+
+<%= render 'shared/email/money_helper' %>

--- a/spec/features/customer_misses_an_appointment_spec.rb
+++ b/spec/features/customer_misses_an_appointment_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature 'Customer misses an appointment' do
+  scenario 'Agent marks the appointment as no show', js: true do
+    given_the_user_identifies_as_hackneys_booking_manager do
+      and_an_appointment_exists
+      when_they_view_the_appointment
+      and_they_mark_the_appointment_as_no_show
+      then_the_customer_is_notified
+    end
+  end
+
+  def and_an_appointment_exists
+    @appointment = create(:appointment)
+  end
+
+  def when_they_view_the_appointment
+    @page = Pages::EditAppointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def and_they_mark_the_appointment_as_no_show
+    @page.status.select('No Show')
+    @page.submit.click
+
+    expect(@page).to have_success
+  end
+
+  def then_the_customer_is_notified
+    assert_enqueued_jobs 1, only: AppointmentMissedNotificationJob
+  end
+end

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -18,6 +18,27 @@ RSpec.describe Appointments do
     end
   end
 
+  describe 'Missed appointment' do
+    subject(:mail) { described_class.missed(appointment) }
+
+    it_behaves_like 'mailgun identified email'
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Your Pension Wise Appointment')
+      expect(mail.to).to eq([appointment.email])
+      expect(mail.from).to eq(['appointments.pensionwise@moneyhelper.org.uk'])
+    end
+
+    describe 'rendering the body' do
+      let(:body) { subject.body.encoded }
+
+      it 'includes the appointment particulars' do
+        expect(body).to include(appointment.reference)
+        expect(body).to include('missed your Pension Wise appointment')
+      end
+    end
+  end
+
   describe 'Customer email consent form' do
     let(:appointment) { build_stubbed(:appointment, :third_party_booking, :third_party_email_consent_form_requested) }
 


### PR DESCRIPTION
Missed appointments trigger a new email notification for customers and add an activity to the feed.