### PR TITLE
Hide the recording consent attribute

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -125,7 +125,6 @@ class AppointmentsController < ApplicationController
         :proceeded_at,
         :status,
         :secondary_status,
-        :recording_consent,
         :third_party,
         booking_request_attributes: %i(
           id

--- a/app/forms/agent_booking_form.rb
+++ b/app/forms/agent_booking_form.rb
@@ -21,7 +21,6 @@ class AgentBookingForm # rubocop:disable Metrics/ClassLength
     booking_location_id
     additional_info
     gdpr_consent
-    recording_consent
     nudged
     bsl
     third_party
@@ -75,7 +74,6 @@ class AgentBookingForm # rubocop:disable Metrics/ClassLength
     bsl
     nudged
     accessibility_requirements
-    recording_consent
     third_party
     email_consent_form_required
     printed_consent_form_required
@@ -210,7 +208,6 @@ class AgentBookingForm # rubocop:disable Metrics/ClassLength
       booking_location_id: booking_location_id,
       additional_info: additional_info,
       gdpr_consent: gdpr_consent,
-      recording_consent: recording_consent,
       nudged: nudged,
       bsl: bsl,
       third_party: third_party,

--- a/app/forms/appointment_form.rb
+++ b/app/forms/appointment_form.rb
@@ -14,7 +14,6 @@ class AppointmentForm # rubocop:disable Metrics/ClassLength
     address?
     consent
     email?
-    recording_consent
     nudged
   ).freeze
 
@@ -86,10 +85,6 @@ class AppointmentForm # rubocop:disable Metrics/ClassLength
 
   def accessibility_requirements
     @accessibility_requirements ||= location_aware_booking_request.accessibility_requirements
-  end
-
-  def recording_consent
-    @recording_consent ||= location_aware_booking_request.recording_consent
   end
 
   def nudged

--- a/app/forms/booking_manager_appointment_form.rb
+++ b/app/forms/booking_manager_appointment_form.rb
@@ -25,7 +25,6 @@ class BookingManagerAppointmentForm # rubocop:disable Metrics/ClassLength
     guider_id
     ad_hoc_start_at
     scheduled
-    recording_consent
     bsl
     third_party
     data_subject_name
@@ -76,7 +75,6 @@ class BookingManagerAppointmentForm # rubocop:disable Metrics/ClassLength
   BOOLEAN_ATTRS = %i(
     scheduled
     accessibility_requirements
-    recording_consent
     third_party
     email_consent_form_required
     printed_consent_form_required
@@ -230,7 +228,6 @@ class BookingManagerAppointmentForm # rubocop:disable Metrics/ClassLength
       additional_info: additional_info,
       gdpr_consent: gdpr_consent,
       guider_id: scheduled ? '' : guider_id,
-      recording_consent: recording_consent,
       bsl: bsl,
       third_party: third_party,
       data_subject_name: data_subject_name,

--- a/app/mappers/appointment_mapper.rb
+++ b/app/mappers/appointment_mapper.rb
@@ -13,7 +13,6 @@ class AppointmentMapper
       proceeded_at: Time.zone.parse("#{appointment_form.date} #{appointment_form.time.strftime('%H:%M')}"),
       booking_request_id: appointment_form.reference,
       additional_info: appointment_form.additional_info,
-      recording_consent: appointment_form.recording_consent,
       nudged: appointment_form.nudged,
       third_party: appointment_form.third_party
     }

--- a/app/views/agent/booking_requests/new.html.erb
+++ b/app/views/agent/booking_requests/new.html.erb
@@ -52,7 +52,6 @@
         <%= f.text_field :email, class: 'form-control t-email', help: 'OK <em>(name)</em>, I am going to repeat this to you phonetically as we will send your appointment confirmation by email and I want to ensure you receive this'.html_safe %>
         <%= f.text_field :memorable_word, class: 'form-control t-memorable-word', help: 'We use this each time the customer is called. Avoid using the same word from a different account or service' %>
         <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?', help: location.accessibility_information %>
-        <%= f.check_box :recording_consent, class: 't-recording-consent', label: 'Appointment recording consent?' %>
         <%= f.check_box :bsl, class: 't-bsl-video', label: 'BSL appointment?' %>
         <%= f.check_box :nudged, class: 't-nudged', label: 'Stronger Nudge signposting?' %>
         <%= f.check_box :third_party, class: 't-third-party', label: 'Third party appointment?', data: { target: 'consent' } %>

--- a/app/views/agent/booking_requests/preview.html.erb
+++ b/app/views/agent/booking_requests/preview.html.erb
@@ -27,7 +27,6 @@
   <%= f.hidden_field :county %>
   <%= f.hidden_field :postcode %>
   <%= f.hidden_field :additional_info %>
-  <%= f.hidden_field :recording_consent %>
   <%= f.hidden_field :nudged %>
   <%= f.hidden_field :bsl %>
   <%= f.hidden_field :third_party %>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -194,7 +194,6 @@
 
             <hr>
             <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?', help: @appointment_form.accessibility_information %>
-            <%= f.check_box :recording_consent, class: 't-recording-consent', label: 'Appointment recording consent?' %>
 
             <%= f.fields_for :booking_request, fieldset: false  do |booking_subform| %>
             <%= booking_subform.check_box :bsl, class: 't-bsl-video', label: 'BSL appointment?' %>

--- a/app/views/booking_manager/appointments/new.html.erb
+++ b/app/views/booking_manager/appointments/new.html.erb
@@ -60,7 +60,6 @@
           <%= f.text_field :memorable_word, class: 'form-control t-memorable-word', help: 'We use this each time the customer is called. Avoid using the same word from a different account or service' %>
 
           <%= f.check_box :accessibility_requirements, class: 't-accessibility-requirements', label: 'Do you require an adjustment to access our service?', help: location.accessibility_information %>
-          <%= f.check_box :recording_consent, class: 't-recording-consent', label: 'Appointment recording consent?' %>
           <%= f.check_box :bsl, class: 't-bsl-video', label: 'BSL appointment?' %>
 
           <%= f.check_box :third_party, class: 't-third-party', label: 'Third party appointment?', data: { target: 'consent' } %>

--- a/app/views/booking_manager/appointments/preview.html.erb
+++ b/app/views/booking_manager/appointments/preview.html.erb
@@ -31,7 +31,6 @@
   <%= f.hidden_field :scheduled %>
   <%= f.hidden_field :ad_hoc_start_at %>
   <%= f.hidden_field :guider_id %>
-  <%= f.hidden_field :recording_consent %>
   <%= f.hidden_field :bsl %>
   <%= f.hidden_field :third_party %>
   <%= f.hidden_field :data_subject_name %>

--- a/spec/features/agent_places_a_realtime_booking_spec.rb
+++ b/spec/features/agent_places_a_realtime_booking_spec.rb
@@ -71,7 +71,6 @@ RSpec.feature 'Agent places a realtime booking' do
     @page.county.set('Berkshire')
     @page.postcode.set('RG1 1AA')
     @page.additional_info.set('Other notes')
-    @page.recording_consent.set(true)
     @page.nudged.set(true)
     @page.bsl.set(true)
 
@@ -124,7 +123,6 @@ RSpec.feature 'Agent places a realtime booking' do
       additional_info: 'Other notes',
       gdpr_consent: 'yes',
       pension_provider: '',
-      recording_consent: true,
       bsl: true,
       nudged: true,
       third_party: true,

--- a/spec/features/booking_manager_edits_an_appointment_spec.rb
+++ b/spec/features/booking_manager_edits_an_appointment_spec.rb
@@ -319,7 +319,6 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     @page.time_hour.select('15')
     @page.time_minute.select('15')
     @page.guider.select('Bob Johnson')
-    @page.recording_consent.set(true)
     @page.bsl.set(true)
     @page.third_party.set(true)
 
@@ -343,7 +342,7 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     @page.submit.click
   end
 
-  def then_the_appointment_is_updated # rubocop:disable Metrics/MethodLength
+  def then_the_appointment_is_updated
     @page = Pages::EditAppointment.new
     expect(@page).to be_displayed
 
@@ -352,7 +351,6 @@ RSpec.feature 'Booking Manager edits an Appointment' do
     expect(@page.time_hour.value).to eq '15'
     expect(@page.time_minute.value).to eq '15'
     expect(@page.guider.find('option', text: 'Bob Johnson').selected?).to eq true
-    expect(@page.recording_consent).to be_checked
     expect(@page.email_consent_form_required).to be_checked
     expect(@page.printed_consent_form_required).to be_checked
     expect(@page.bsl).to be_checked

--- a/spec/features/booking_manager_places_a_realtime_booking_spec.rb
+++ b/spec/features/booking_manager_places_a_realtime_booking_spec.rb
@@ -91,7 +91,6 @@ RSpec.feature 'Booking manager places a realtime booking', js: true do
     @page.county.set('Berkshire')
     @page.postcode.set('RG1 1AA')
     @page.additional_info.set('Other notes')
-    @page.recording_consent.set(true)
     @page.bsl.set(true)
     @page.third_party.set(true)
 
@@ -144,7 +143,6 @@ RSpec.feature 'Booking manager places a realtime booking', js: true do
       age_range: '55-plus',
       additional_info: 'Other notes',
       gdpr_consent: 'yes',
-      recording_consent: true,
       third_party: true,
       bsl: true
     )

--- a/spec/forms/agent_booking_form_spec.rb
+++ b/spec/forms/agent_booking_form_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe AgentBookingForm do
       gdpr_consent: 'yes',
       accessibility_requirements: false,
       additional_info: '',
-      recording_consent: true,
       nudged: true,
       bsl: true,
       third_party: false,

--- a/spec/forms/booking_manager_appointment_form_spec.rb
+++ b/spec/forms/booking_manager_appointment_form_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe BookingManagerAppointmentForm do
       accessibility_requirements: false,
       additional_info: '',
       scheduled: 'true',
-      recording_consent: true,
       third_party: false,
       bsl: false,
       data_subject_consent_obtained: false,

--- a/spec/mappers/appointment_mapper_spec.rb
+++ b/spec/mappers/appointment_mapper_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe AppointmentMapper, '.map' do
       defined_contribution_pot_confirmed: appointment_form.defined_contribution_pot_confirmed,
       accessibility_requirements: appointment_form.accessibility_requirements,
       additional_info: appointment_form.additional_info,
-      recording_consent: false,
       nudged: false,
       third_party: false
     )

--- a/spec/support/pages/ad_hoc_booking.rb
+++ b/spec/support/pages/ad_hoc_booking.rb
@@ -32,7 +32,6 @@ module Pages
     element :postcode, '.t-postcode'
     element :country, '.t-country'
     element :additional_info, '.t-additional-info'
-    element :recording_consent, '.t-recording-consent'
     element :bsl, '.t-bsl-video'
 
     element :third_party, '.t-third-party'

--- a/spec/support/pages/agent_booking.rb
+++ b/spec/support/pages/agent_booking.rb
@@ -25,7 +25,6 @@ module Pages
     element :postcode, '.t-postcode'
     element :country, '.t-country'
     element :additional_info, '.t-additional-info'
-    element :recording_consent, '.t-recording-consent'
     element :nudged, '.t-nudged'
     element :bsl, '.t-bsl-video'
     element :third_party, '.t-third-party'

--- a/spec/support/pages/edit_appointment.rb
+++ b/spec/support/pages/edit_appointment.rb
@@ -19,7 +19,6 @@ module Pages
     element :defined_contribution_pot_confirmed_dont_know, '.t-defined-contribution-pot-confirmed-dont-know'
     element :gdpr_consent, '.t-gdpr-consent'
     element :consent, '.t-consent-button'
-    element :recording_consent, '.t-recording-consent'
     element :bsl, '.t-bsl-video'
     element :third_party, '.t-third-party'
     element :data_subject_name, '.t-data-subject-name'


### PR DESCRIPTION
The data will remain but the ability to set this flag has been removed as it was being misused.