### PR TITLE
Add `last_slot_on` to reporting summaries

### DIFF
--- a/app/lib/scheduled_reporting_summary.rb
+++ b/app/lib/scheduled_reporting_summary.rb
@@ -7,7 +7,8 @@ class ScheduledReportingSummary
         location_id: location.id,
         name: location.title,
         four_week_availability: schedule.available_before?,
-        first_available_slot_on: schedule.first_available_slot_on
+        first_available_slot_on: schedule.first_available_slot_on,
+        last_slot_on: schedule.last_slot_on
       )
     end
   end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -80,6 +80,10 @@ class Schedule < ActiveRecord::Base
     without_appointments.first&.start_at
   end
 
+  def last_slot_on
+    bookable_slots_in_window.last&.start_at
+  end
+
   def self.allocates?(booking_request)
     schedule = current(booking_request.location_id)
 

--- a/db/migrate/20240930143121_add_last_slot_on_to_reporting_summaries.rb
+++ b/db/migrate/20240930143121_add_last_slot_on_to_reporting_summaries.rb
@@ -1,0 +1,5 @@
+class AddLastSlotOnToReportingSummaries < ActiveRecord::Migration[6.1]
+  def change
+    add_column :reporting_summaries, :last_slot_on, :date, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_12_200044) do
+ActiveRecord::Schema.define(version: 2024_09_30_143121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define(version: 2024_04_12_200044) do
     t.date "first_available_slot_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "last_slot_on"
   end
 
   create_table "schedules", force: :cascade do |t|

--- a/spec/features/scheduled_reporting_summary_spec.rb
+++ b/spec/features/scheduled_reporting_summary_spec.rb
@@ -35,6 +35,9 @@ RSpec.feature 'Scheduled reporting summary' do
     # Limited availability
     create(:schedule, location_id: '377e27e1-8f38-437a-baa9-4e90ebd980e8') do |schedule|
       create(:bookable_slot, schedule: schedule, start_at: '2018-04-27 10:00')
+      # this is booked
+      create(:bookable_slot, schedule: schedule, start_at: '2018-04-28 10:00')
+      create(:appointment, location_id: schedule.location_id, proceeded_at: '2018-04-28 10:00')
     end
 
     # Only available after the 4 week window
@@ -54,6 +57,7 @@ RSpec.feature 'Scheduled reporting summary' do
       name: 'Abergavenny',
       four_week_availability: false,
       first_available_slot_on: nil,
+      last_slot_on: nil,
       created_at: Time.zone.now
     )
 
@@ -61,6 +65,7 @@ RSpec.feature 'Scheduled reporting summary' do
       name: 'Hackney',
       four_week_availability: true,
       first_available_slot_on: '2018-04-27'.to_date,
+      last_slot_on: '2018-04-28'.to_date,
       created_at: Time.zone.now
     )
 
@@ -68,6 +73,7 @@ RSpec.feature 'Scheduled reporting summary' do
       name: 'Reading',
       four_week_availability: false,
       first_available_slot_on: '2018-05-25'.to_date,
+      last_slot_on: '2018-05-25'.to_date,
       created_at: Time.zone.now
     )
   end


### PR DESCRIPTION
Adds this extra snapshotted value to the reporting summary when the batch job runs per schedule/location.