### PR TITLE
Guard against the absence of an email

### DIFF
--- a/app/jobs/bsl_customer_exit_poll_job.rb
+++ b/app/jobs/bsl_customer_exit_poll_job.rb
@@ -2,6 +2,8 @@ class BslCustomerExitPollJob < ActiveJob::Base
   queue_as :default
 
   def perform(appointment)
+    return unless appointment.email?
+
     booking_location = BookingLocations.find(appointment.location_id)
 
     Appointments.bsl_customer_exit_poll(appointment, booking_location).deliver_now

--- a/spec/jobs/bsl_customer_exit_poll_job_spec.rb
+++ b/spec/jobs/bsl_customer_exit_poll_job_spec.rb
@@ -11,4 +11,12 @@ RSpec.describe BslCustomerExitPollJob, '#perform' do
 
     expect { subject }.to change { BslCustomerExitPollActivity.count }.by(1)
   end
+
+  context 'when the appointment does not have an associated email' do
+    it 'does nothing' do
+      appointment.email = ''
+
+      expect { subject }.not_to(change { BslCustomerExitPollActivity.count })
+    end
+  end
 end


### PR DESCRIPTION
This job is scheduled but ought to do nothing if the underlying appointment does not have an email associated.