### PR TITLE
Allow reply-to to be overridden

### DIFF
--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -47,7 +47,7 @@ class Appointments < ApplicationMailer
     mail(
       to: appointment.email,
       subject: 'Your Pension Wise Appointment',
-      reply_to: booking_location.online_booking_reply_to
+      reply_to: @appointment.online_booking_reply_to
     )
   end
 
@@ -59,7 +59,7 @@ class Appointments < ApplicationMailer
     mail(
       to: appointment.email,
       subject: 'Your Pension Wise BSL Video Appointment',
-      reply_to: booking_location.online_booking_reply_to
+      reply_to: @appointment.online_booking_reply_to
     )
   end
 
@@ -71,7 +71,7 @@ class Appointments < ApplicationMailer
     mail(
       to: appointment.email,
       subject: 'Your Pension Wise Appointment Reminder',
-      reply_to: booking_location.online_booking_reply_to
+      reply_to: @appointment.online_booking_reply_to
     )
   end
 

--- a/app/models/location_aware_entity.rb
+++ b/app/models/location_aware_entity.rb
@@ -6,8 +6,11 @@ class LocationAwareEntity < SimpleDelegator
     super(entity)
   end
 
-  delegate :online_booking_reply_to, to: :booking_location
   delegate :accessibility_information, to: :actual_location
+
+  def online_booking_reply_to
+    actual_location.online_booking_reply_to.presence || booking_location.online_booking_reply_to
+  end
 
   def online_booking_twilio_number
     actual_location&.online_booking_twilio_number.to_s.sub(/^\+44/, '0')

--- a/spec/models/location_aware_entity_spec.rb
+++ b/spec/models/location_aware_entity_spec.rb
@@ -3,13 +3,35 @@ require 'rails_helper'
 RSpec.describe LocationAwareEntity do
   context 'when decorating a BookingRequest' do
     let(:booking_location) do
-      instance_double(BookingLocations::Location, name: 'Hackney', hidden?: false)
+      instance_double(
+        BookingLocations::Location, name: 'Hackney', hidden?: false, online_booking_reply_to: 'parent@example.com'
+      )
     end
 
     let(:booking_request) { instance_double(BookingRequest, location_id: 'deadbeef') }
 
     subject do
       described_class.new(booking_location: booking_location, entity: booking_request)
+    end
+
+    describe '#online_booking_reply_to' do
+      context 'when the actual location has specified a reply-to' do
+        it 'returns the actual location reply-to' do
+          allow(booking_location).to receive(:location_for).and_return(
+            double(online_booking_reply_to: 'abc@example.com')
+          )
+
+          expect(subject.online_booking_reply_to).to eq('abc@example.com')
+        end
+      end
+
+      context 'when the actual location does not specify a reply-to' do
+        it 'returns the booking location reply-to' do
+          allow(booking_location).to receive(:location_for).and_return(double(online_booking_reply_to: ''))
+
+          expect(subject.online_booking_reply_to).to eq('parent@example.com')
+        end
+      end
     end
 
     describe '#entity' do


### PR DESCRIPTION
When the child location has its own reply-to, this should be used in precedence over the parent booking location.