### PR TITLE
Revert available BSL slots after 7 days

### DIFF
--- a/app/lib/bsl_slot_reverter.rb
+++ b/app/lib/bsl_slot_reverter.rb
@@ -1,0 +1,5 @@
+class BslSlotReverter
+  def call
+    BookableSlot.bsl_slots_to_revert.update_all(bsl: false) # rubocop:disable Rails/SkipsModelValidations
+  end
+end

--- a/lib/tasks/slots.rake
+++ b/lib/tasks/slots.rake
@@ -3,4 +3,9 @@ namespace :slots do
   task remove_exclusions: :environment do
     BookableSlot.where(date: EXCLUSIONS).destroy_all
   end
+
+  desc 'Reverts BSL availability to normal after 7 days (unbooked)'
+  task revert_bsl: :environment do
+    BslSlotReverter.new.call
+  end
 end

--- a/spec/lib/bsl_slot_reverter_spec.rb
+++ b/spec/lib/bsl_slot_reverter_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe BslSlotReverter, '#call' do
+  it 'switches available BSL slots back to normal after 7 days' do
+    travel_to '2025-06-18 13:00' do
+      recent    = create(:bookable_slot, bsl: true, start_at: 1.day.from_now)
+      available = create(:bookable_slot, bsl: true, start_at: 7.working.days.from_now, guider_id: 2)
+      booked    = create(:bookable_slot, bsl: true, start_at: 7.working.days.from_now)
+      create(:appointment, :bsl, proceeded_at: booked.start_at, guider_id: booked.guider_id)
+
+      BslSlotReverter.new.call
+
+      expect(booked.reload).to be_bsl
+      expect(recent.reload).to be_bsl
+      expect(available.reload).to_not be_bsl
+    end
+  end
+end


### PR DESCRIPTION
This will run on a nightly schedule and reverts BSL slots back to the
normal pool of availability after they've remained unavailable for 7
days.