### PR TITLE
Send notifications to CAS' alias

### DIFF
--- a/app/jobs/booking_manager_appointment_change_notification_job.rb
+++ b/app/jobs/booking_manager_appointment_change_notification_job.rb
@@ -1,8 +1,10 @@
 class BookingManagerAppointmentChangeNotificationJob < ActiveJob::Base
   queue_as :default
 
+  include BookingManagerable
+
   def perform(appointment)
-    booking_managers = User.booking_managers(appointment.booking_location_id)
+    booking_managers = booking_managers_for(appointment.booking_location_id)
 
     raise BookingManagersNotFoundError if booking_managers.blank?
 

--- a/app/jobs/booking_manager_confirmation_job.rb
+++ b/app/jobs/booking_manager_confirmation_job.rb
@@ -1,8 +1,10 @@
 class BookingManagerConfirmationJob < ActiveJob::Base
   queue_as :default
 
+  include BookingManagerable
+
   def perform(booking_request)
-    booking_managers = User.booking_managers(booking_request.booking_location_id)
+    booking_managers = booking_managers_for(booking_request.booking_location_id)
 
     raise BookingManagersNotFoundError if booking_managers.blank?
 

--- a/app/jobs/booking_manager_sms_cancellation_job.rb
+++ b/app/jobs/booking_manager_sms_cancellation_job.rb
@@ -1,8 +1,10 @@
 class BookingManagerSmsCancellationJob < ActiveJob::Base
   queue_as :default
 
+  include BookingManagerable
+
   def perform(appointment)
-    recipients = User.booking_managers(appointment.booking_request.booking_location_id)
+    recipients = booking_managers_for(appointment.booking_request.booking_location_id)
 
     recipients.each do |recipient|
       Appointments.booking_manager_cancellation(recipient, appointment).deliver_later

--- a/app/jobs/booking_managerable.rb
+++ b/app/jobs/booking_managerable.rb
@@ -1,0 +1,7 @@
+module BookingManagerable
+  def booking_managers_for(booking_location_id)
+    return [Appointment::CAS_BOOKING_MANAGER_ALIAS] if booking_location_id == Appointment::CAS_BOOKING_LOCATION_ID
+
+    User.booking_managers(booking_location_id)
+  end
+end

--- a/app/jobs/email_drop_notification_job.rb
+++ b/app/jobs/email_drop_notification_job.rb
@@ -1,8 +1,10 @@
 class EmailDropNotificationJob < ActiveJob::Base
   queue_as :default
 
+  include BookingManagerable
+
   def perform(booking_request)
-    booking_managers = User.booking_managers(booking_request.booking_location_id)
+    booking_managers = booking_managers_for(booking_request.booking_location_id)
 
     raise BookingManagersNotFoundError if booking_managers.blank?
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -4,6 +4,7 @@ class Appointment < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   audited on: :update, except: %i(fulfilment_time_seconds fulfilment_window_seconds)
   has_associated_audits
 
+  CAS_BOOKING_MANAGER_ALIAS = OpenStruct.new(email: 'cas_pwbooking@cas.org.uk').freeze
   CAS_BOOKING_LOCATION_ID   = '0c686436-de02-4d92-8dc7-26c97bb7c5bb'.freeze
   AGENT_PERMITTED_SECONDARY = '15'.freeze
   SECONDARY_STATUSES = {

--- a/spec/jobs/booking_manager_confirmation_job_spec.rb
+++ b/spec/jobs/booking_manager_confirmation_job_spec.rb
@@ -6,6 +6,19 @@ RSpec.describe BookingManagerConfirmationJob, '#perform' do
 
   subject { described_class.new.perform(booking_request) }
 
+  context 'when the booking belongs to CAS' do
+    let(:booking_request) { create(:drumchapel_booking_request) }
+
+    it 'sends a single notification to their alias' do
+      expect(BookingRequests).to receive(:booking_manager).with(
+        booking_request,
+        Appointment::CAS_BOOKING_MANAGER_ALIAS
+      ).and_return(double(deliver_later: true))
+
+      subject
+    end
+  end
+
   context 'when the booking manager(s) cannot be found' do
     it 'raises an error thus forcing retries' do
       expect { subject }.to raise_error(BookingManagersNotFoundError)


### PR DESCRIPTION
When notifications are delivered they usually go to all active booking
managers for a given booking location. CAS need them to go to one
individual alias that they have specified instead.