### PR TITLE
Serialize mailer job arguments as strings

### DIFF
--- a/app/jobs/booking_managerable.rb
+++ b/app/jobs/booking_managerable.rb
@@ -2,6 +2,6 @@ module BookingManagerable
   def booking_managers_for(booking_location_id)
     return [Appointment::CAS_BOOKING_MANAGER_ALIAS] if booking_location_id == Appointment::CAS_BOOKING_LOCATION_ID
 
-    User.booking_managers(booking_location_id)
+    User.booking_managers(booking_location_id).pluck(:email)
   end
 end

--- a/app/jobs/email_drop_notification_job.rb
+++ b/app/jobs/email_drop_notification_job.rb
@@ -8,7 +8,7 @@ class EmailDropNotificationJob < ActiveJob::Base
 
     raise BookingManagersNotFoundError if booking_managers.blank?
 
-    return if booking_managers.pluck(:email).include?(booking_request.email)
+    return if booking_managers.include?(booking_request.email)
 
     booking_managers.each do |booking_manager|
       BookingRequests.email_failure(booking_request, booking_manager).deliver_later

--- a/app/mailers/appointments.rb
+++ b/app/mailers/appointments.rb
@@ -4,7 +4,7 @@ class Appointments < ApplicationMailer
 
     mailgun_headers :booking_manager_appointment_changed
 
-    mail(to: booking_manager.email, subject: appointment_changed_subject(appointment))
+    mail(to: booking_manager, subject: appointment_changed_subject(appointment))
   end
 
   def missed(appointment)
@@ -36,7 +36,7 @@ class Appointments < ApplicationMailer
 
     mailgun_headers :sms_appointment_cancellation
 
-    mail(to: booking_manager.email, subject: 'Pension Wise Appointment SMS Cancellation')
+    mail(to: booking_manager, subject: 'Pension Wise Appointment SMS Cancellation')
   end
 
   def customer(appointment, booking_location)

--- a/app/mailers/booking_requests.rb
+++ b/app/mailers/booking_requests.rb
@@ -16,7 +16,7 @@ class BookingRequests < ApplicationMailer
     name = booking_request_or_appointment.model_name.human
 
     mailgun_headers('booking_manager_booking_request')
-    mail to: booking_manager.email,
+    mail to: booking_manager,
          subject: "Pension Wise #{name.titleize}" + adjustment_banner(@booking_request_or_appointment)
   end
 
@@ -25,7 +25,7 @@ class BookingRequests < ApplicationMailer
     @booking_manager = booking_manager
 
     mailgun_headers('email_failure_booking_request')
-    mail to: booking_manager.email, subject: 'Email Failure - Pension Wise Booking Request'
+    mail to: booking_manager, subject: 'Email Failure - Pension Wise Booking Request'
   end
 
   private

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -4,7 +4,7 @@ class Appointment < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
   audited on: :update, except: %i(fulfilment_time_seconds fulfilment_window_seconds)
   has_associated_audits
 
-  CAS_BOOKING_MANAGER_ALIAS = OpenStruct.new(email: 'cas_pwbooking@cas.org.uk').freeze
+  CAS_BOOKING_MANAGER_ALIAS = 'cas_pwbooking@cas.org.uk'.freeze
   CAS_BOOKING_LOCATION_ID   = '0c686436-de02-4d92-8dc7-26c97bb7c5bb'.freeze
   AGENT_PERMITTED_SECONDARY = '15'.freeze
   SECONDARY_STATUSES = {

--- a/spec/features/booking_manager_places_a_realtime_booking_spec.rb
+++ b/spec/features/booking_manager_places_a_realtime_booking_spec.rb
@@ -111,6 +111,9 @@ RSpec.feature 'Booking manager places a realtime booking', js: true do
     @page = Pages::AdHocBookingPreview.new
     expect(@page).to be_displayed
     @page.confirmation.click
+
+    @page = Pages::AppointmentConfirmation.new
+    expect(@page).to be_displayed
   end
 
   def then_the_booking_is_placed_with_cardiff

--- a/spec/jobs/booking_manager_confirmation_job_spec.rb
+++ b/spec/jobs/booking_manager_confirmation_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe BookingManagerConfirmationJob, '#perform' do
 
     it 'passes the appointment on to the mailer' do
       expect(BookingRequests).to receive(:booking_manager)
-        .with(appointment, booking_manager)
+        .with(appointment, booking_manager.email)
         .and_return(double.as_null_object)
 
       described_class.new.perform(appointment.booking_request)

--- a/spec/mailers/appointments_spec.rb
+++ b/spec/mailers/appointments_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Appointments do
 
     before { appointment.update(name: 'Bob Jones', email: 'bob@bob.com') }
 
-    subject(:mail) { described_class.booking_manager_appointment_changed(appointment, booking_manager) }
+    subject(:mail) { described_class.booking_manager_appointment_changed(appointment, booking_manager.email) }
 
     it_behaves_like 'mailgun identified email'
 
@@ -113,7 +113,7 @@ RSpec.describe Appointments do
   describe 'SMS cancellation' do
     let(:booking_manager) { create(:hackney_booking_manager) }
 
-    subject(:mail) { described_class.booking_manager_cancellation(booking_manager, appointment) }
+    subject(:mail) { described_class.booking_manager_cancellation(booking_manager.email, appointment) }
 
     it_behaves_like 'mailgun identified email'
 

--- a/spec/mailers/booking_requests_spec.rb
+++ b/spec/mailers/booking_requests_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe BookingRequests do
   describe 'Booking Manager Notification' do
     let(:booking_manager) { build_stubbed(:hackney_booking_manager) }
 
-    subject(:mail) { BookingRequests.booking_manager(booking_request, booking_manager) }
+    subject(:mail) { BookingRequests.booking_manager(booking_request, booking_manager.email) }
 
     it_behaves_like 'mailgun identified email'
 
@@ -102,7 +102,7 @@ RSpec.describe BookingRequests do
     let(:booking_request) { build_stubbed(:hackney_booking_request) }
     let(:booking_manager) { build_stubbed(:hackney_booking_manager) }
 
-    subject(:mail) { BookingRequests.email_failure(booking_request, booking_manager) }
+    subject(:mail) { BookingRequests.email_failure(booking_request, booking_manager.email) }
 
     it_behaves_like 'mailgun identified email'
 


### PR DESCRIPTION
This was causing some complications with activejob's serialization due
to the recent CAS booking alias alterations.