### PR TITLE
Slots and appointments are 90 minutes

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -246,7 +246,7 @@ class Appointment < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
 
   def self.overlapping(guider_id:, proceeded_at:, id: nil)
     where(guider_id: guider_id)
-      .where("(proceeded_at, interval '1 hour') overlaps (?, interval '1 hour')", proceeded_at)
+      .where("(proceeded_at, interval '90 minutes') overlaps (?, interval '90 minutes')", proceeded_at)
       .where.not(status: [5, 6, 7])
       .where.not(id: id)
   end

--- a/app/models/bookable_slot.rb
+++ b/app/models/bookable_slot.rb
@@ -34,8 +34,8 @@ class BookableSlot < ActiveRecord::Base
       <<-SQL
         LEFT JOIN appointments ON
           appointments.guider_id = bookable_slots.guider_id
-          AND (appointments.proceeded_at, interval '1 hour')
-          OVERLAPS (bookable_slots.start_at, interval '1 hour')
+          AND (appointments.proceeded_at, interval '90 minutes')
+          OVERLAPS (bookable_slots.start_at, interval '90 minutes')
           AND NOT appointments.status IN (5, 6, 7)
       SQL
     ).where('appointments.proceeded_at IS NULL')
@@ -61,7 +61,7 @@ class BookableSlot < ActiveRecord::Base
   def validate_guider_overlapping # rubocop:disable Metrics/AbcSize
     return unless guider_id?
     return unless overlapping = self.class.where(
-      "(start_at, interval '1 hour') overlaps (?, interval '1 hour')", start_at
+      "(start_at, interval '90 minutes') overlaps (?, interval '90 minutes')", start_at
     ).find_by(guider_id: guider_id)
 
     if overlapping.schedule_id == schedule_id

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -29,7 +29,7 @@ class Schedule < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     bookable_slots.build(
       guider_id: guider_id,
       start_at: start_at,
-      end_at: start_at.advance(hours: 1)
+      end_at: start_at.advance(minutes: 90)
     )
   end
 
@@ -37,7 +37,7 @@ class Schedule < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
     bookable_slots.create(
       guider_id: guider_id,
       start_at: start_at,
-      end_at: start_at.advance(hours: 1)
+      end_at: start_at.advance(minutes: 90)
     )
   end
 
@@ -50,8 +50,8 @@ class Schedule < ActiveRecord::Base # rubocop:disable Metrics/ClassLength
       <<-SQL
         LEFT JOIN appointments ON
           appointments.guider_id = bookable_slots.guider_id
-          AND (appointments.proceeded_at, interval '1 hour')
-          OVERLAPS (bookable_slots.start_at, interval '1 hour')
+          AND (appointments.proceeded_at, interval '90 minutes')
+          OVERLAPS (bookable_slots.start_at, interval '90 minutes')
           AND NOT appointments.status IN (5, 6, 7)
       SQL
     ).where('appointments.proceeded_at IS NULL')

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -17,7 +17,7 @@ class Slot < ActiveRecord::Base
                        slot.match(SLOT_REGEX).captures
                      else
                        starting = Time.zone.parse(slot)
-                       ending   = starting.advance(hours: 1)
+                       ending   = starting.advance(minutes: 90)
 
                        [starting.to_date, starting.strftime('%H%M'), ending.strftime('%H%M')]
                      end

--- a/app/serializers/appointment_serializer.rb
+++ b/app/serializers/appointment_serializer.rb
@@ -16,7 +16,7 @@ class AppointmentSerializer < ActiveModel::Serializer
   end
 
   attribute :end do
-    object.proceeded_at.advance(hours: 1)
+    object.proceeded_at.advance(minutes: 90)
   end
 
   attribute :cancelled do

--- a/spec/factories/bookable_slots.rb
+++ b/spec/factories/bookable_slots.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     schedule
     guider_id { 1 }
     start_at { Time.current.change(hour: 9) }
-    end_at { start_at.to_time.advance(hour: 1) }
+    end_at { start_at.to_time.advance(minutes: 90) }
   end
 end

--- a/spec/models/bookable_slot_spec.rb
+++ b/spec/models/bookable_slot_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BookableSlot do
   describe 'validations' do
     it 'does not allow overlapping slots for a particular guider' do
       travel_to '2026-01-01 09:00' do
-        @persisted = create(:bookable_slot) # 09:00 - 10:00
+        @persisted = create(:bookable_slot) # 09:00 - 13:00
 
         # exact duplicate
         expect(build(:bookable_slot)).to be_invalid
@@ -39,7 +39,7 @@ RSpec.describe BookableSlot do
         # intersects with the end
         expect(build(:bookable_slot, start_at: time_today('09:30'))).to be_invalid
         # overlaps at the last minute
-        expect(build(:bookable_slot, start_at: time_today('10:00'))).to be_valid
+        expect(build(:bookable_slot, start_at: time_today('13:00'))).to be_valid
       end
     end
   end

--- a/spec/requests/realtime_appointments_api_spec.rb
+++ b/spec/requests/realtime_appointments_api_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'GET /locations/{location_id}/realtime_appointments' do
             'title' => 'Mortimer Smith',
             'resourceId' => 1,
             'start' => '2018-11-07T09:00:00.000Z',
-            'end' => '2018-11-07T10:00:00.000Z',
+            'end' => '2018-11-07T10:30:00.000Z',
             'cancelled' => false,
             'url' => "/appointments/#{@appointment.id}/edit",
             'location' => 'Hackney'


### PR DESCRIPTION
Ops have reported that most appointments overrun so making the durations set at 90 minutes leaves plenty of time on each side.